### PR TITLE
Vector DB stats dashboard, collapsible experiment rows, and orphan sweep reconciliation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,14 @@ VOYAGE_TPM_LIMIT=10000
 # Format: mongodb+srv://username:password@cluster.mongodb.net/dbname?retryWrites=true&w=majority
 MONGODB_URI=your_mongodb_atlas_uri_here
 
+# Optional — auto-detect cluster storage quota for the dashboard (Atlas Admin API).
+# Without these, set MONGODB_STORAGE_LIMIT_MB manually or quota UI stays hidden.
+# ATLAS_PUBLIC_KEY=
+# ATLAS_PRIVATE_KEY=
+# ATLAS_GROUP_ID=                         # 24-char project ID from Atlas URL
+# ATLAS_CLUSTER_NAME=                     # omit to parse from MONGODB_URI host
+# MONGODB_STORAGE_LIMIT_MB=512            # manual override (MB); skips API lookup
+
 # FastAPI Server URL (for CLI to connect to)
 SERVER_URL=http://localhost:8001
 

--- a/docs/_internal/PROGRESS.md
+++ b/docs/_internal/PROGRESS.md
@@ -1,7 +1,7 @@
 # rag-params-finder — Build Progress
 
-**Last Updated**: 2026-05-19 (Slice 9 — Experiment deletion with confirmation)
-**Current**: Slices 1–9 ✅ COMPLETE | Next: Slice 10 📋 PLANNED (failed-run recovery) · Slice 11 📋 PLANNED (Search Explorer enhancements) · Slice 16 📋 PLANNED (honor `parallelism`)
+**Last Updated**: 2026-05-19 (Vector DB stats + collapsible experiment rows — in progress on `feat/vector-db-stats-and-collapsible-cards`)
+**Current**: Slices 1–9 ✅ COMPLETE | 🔨 IN PROGRESS: Vector DB stats panel + collapsible list rows | Next: Slice 10 📋 PLANNED (failed-run recovery) · Slice 11 📋 PLANNED (Search Explorer enhancements) · Slice 16 📋 PLANNED (honor `parallelism`)
 
 ---
 
@@ -18,6 +18,7 @@
 | 7 — Free/local embedding + reranking | ✅ COMPLETE | ~15 min | sentence-transformers, no API key needed |
 | 8 — Dashboard UX improvements | ✅ COMPLETE | ~2 h | Loading feedback panels, polling indicators, pagination, unified chrome |
 | 9 — Experiment deletion | ✅ COMPLETE | ~1 h | CLI delete command + dashboard confirmation modal, cascade cleanup |
+| — — Vector DB stats + collapsible rows | 🔨 IN PROGRESS | ~1 h | `GET /experiments/{id}/db-stats`; detail stats panel; list row collapse (localStorage) |
 | 10 — Run recovery | 📋 PLANNED | ~1–2 h | Retry FAILED `(± INTERRUPTED)` runs in-place; see [`SLICE-10-RUN-RECOVERY.md`](../slices/SLICE-10-RUN-RECOVERY.md) |
 | 11 — Search Explorer enhancements | 📋 PLANNED | ~1 h | Better visualization, export results, query filtering improvements |
 | 16 — Parallel sweep execution | 📋 PLANNED | ~2–4 h | Bounded concurrent `_run_single`; see [`SLICE-16-PARALLEL-SWEEP-RUNS.md`](../slices/SLICE-16-PARALLEL-SWEEP-RUNS.md) |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,21 +1,79 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import ExperimentsScreen from './components/ExperimentsScreen';
 import ExperimentDetailScreen from './components/ExperimentDetailScreen';
 import SearchExplorerScreen from './components/SearchExplorerScreen';
+import type { Experiment, ExperimentDbStatsSummary, VectorDbStatsGroup } from './types';
+import { findDbStatsInGroups } from './utils/experimentDbStats';
+
+export type ListCache = {
+  experiments: Experiment[];
+  vectorDbGroups: VectorDbStatsGroup[];
+  ready: boolean;
+};
+
+type DetailNav = {
+  initialExperiment?: Experiment;
+  initialDbStats?: ExperimentDbStatsSummary;
+};
 
 type Screen =
   | { kind: 'list' }
-  | { kind: 'detail'; experimentId: string }
+  | {
+      kind: 'detail';
+      experimentId: string;
+      initialExperiment?: Experiment;
+      initialDbStats?: ExperimentDbStatsSummary;
+    }
   | { kind: 'explore'; experimentId: string };
 
 export default function App() {
   const [screen, setScreen] = useState<Screen>({ kind: 'list' });
+  const [listCache, setListCache] = useState<ListCache>({
+    experiments: [],
+    vectorDbGroups: [],
+    ready: false,
+  });
+  const [detailNav, setDetailNav] = useState<DetailNav>({});
+
+  const handleListCacheUpdate = useCallback(
+    (update: { experiments: Experiment[]; vectorDbGroups: VectorDbStatsGroup[] }) => {
+      setListCache((prev) => ({
+        ...prev,
+        experiments: update.experiments,
+        vectorDbGroups: update.vectorDbGroups,
+        ready: true,
+      }));
+    },
+    [],
+  );
+
+  const openDetail = useCallback(
+    (experiment: Experiment) => {
+      const initialDbStats = findDbStatsInGroups(listCache.vectorDbGroups, experiment.experiment_id);
+      const nav: DetailNav = { initialExperiment: experiment, initialDbStats };
+      setDetailNav(nav);
+      setScreen({
+        kind: 'detail',
+        experimentId: experiment.experiment_id,
+        initialExperiment: experiment,
+        initialDbStats,
+      });
+    },
+    [listCache.vectorDbGroups],
+  );
 
   if (screen.kind === 'explore') {
     return (
       <SearchExplorerScreen
         experimentId={screen.experimentId}
-        onBack={() => setScreen({ kind: 'detail', experimentId: screen.experimentId })}
+        onBack={() =>
+          setScreen({
+            kind: 'detail',
+            experimentId: screen.experimentId,
+            initialExperiment: detailNav.initialExperiment,
+            initialDbStats: detailNav.initialDbStats,
+          })
+        }
       />
     );
   }
@@ -24,6 +82,8 @@ export default function App() {
     return (
       <ExperimentDetailScreen
         experimentId={screen.experimentId}
+        initialExperiment={screen.initialExperiment ?? detailNav.initialExperiment}
+        initialDbStats={screen.initialDbStats ?? detailNav.initialDbStats}
         onBack={() => setScreen({ kind: 'list' })}
         onExplore={() => setScreen({ kind: 'explore', experimentId: screen.experimentId })}
       />
@@ -32,7 +92,11 @@ export default function App() {
 
   return (
     <ExperimentsScreen
-      onSelect={(id) => setScreen({ kind: 'detail', experimentId: id })}
+      cacheReady={listCache.ready}
+      cachedExperiments={listCache.ready ? listCache.experiments : undefined}
+      cachedVectorDbGroups={listCache.ready ? listCache.vectorDbGroups : undefined}
+      onCacheUpdate={handleListCacheUpdate}
+      onSelect={openDetail}
     />
   );
 }

--- a/frontend/src/components/CollapsibleCard.tsx
+++ b/frontend/src/components/CollapsibleCard.tsx
@@ -1,0 +1,73 @@
+import { useCallback, useState, type ReactNode } from 'react';
+
+type CollapsibleCardProps = {
+  title: string;
+  icon?: ReactNode;
+  headerExtra?: ReactNode;
+  storageKey?: string;
+  defaultOpen?: boolean;
+  compact?: boolean;
+  className?: string;
+  children: ReactNode;
+};
+
+function readStoredOpen(storageKey: string | undefined, defaultOpen: boolean): boolean {
+  if (!storageKey) return defaultOpen;
+  const stored = localStorage.getItem(storageKey);
+  if (stored === null) return defaultOpen;
+  return stored === 'true';
+}
+
+export default function CollapsibleCard({
+  title,
+  icon,
+  headerExtra,
+  storageKey,
+  defaultOpen = true,
+  compact = false,
+  className = '',
+  children,
+}: CollapsibleCardProps) {
+  const [open, setOpen] = useState(() => readStoredOpen(storageKey, defaultOpen));
+
+  const toggle = useCallback(() => {
+    setOpen((prev) => {
+      const next = !prev;
+      if (storageKey) localStorage.setItem(storageKey, String(next));
+      return next;
+    });
+  }, [storageKey]);
+
+  return (
+    <div className={className}>
+      <button
+        type="button"
+        onClick={toggle}
+        className="flex w-full items-center gap-2 text-left"
+        aria-expanded={open}
+      >
+        <svg
+          className={`h-4 w-4 shrink-0 text-slate-500 transition-transform ${open ? 'rotate-90' : ''}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+        </svg>
+        {icon}
+        <h2
+          className={
+            compact
+              ? 'flex-1 text-sm font-bold uppercase tracking-wider text-slate-700'
+              : 'flex-1 text-lg font-bold text-slate-800'
+          }
+        >
+          {title}
+        </h2>
+        {headerExtra}
+      </button>
+      {open ? <div className="mt-4">{children}</div> : null}
+    </div>
+  );
+}

--- a/frontend/src/components/ExperimentDetailScreen.tsx
+++ b/frontend/src/components/ExperimentDetailScreen.tsx
@@ -35,7 +35,7 @@ import { RunStatus, Phase, EnvParams, SweepSummary, ExperimentStatus, Experiment
 import { createStallWatcher, type FetchProgressUpdate } from '../services/fetchWithProgress';
 import { devDebugThrottled, devWarn } from '../utils/devLog';
 import { toExperimentDbStatsSummary } from '../utils/experimentDbStats';
-import { isRunningExperimentStatus, isTerminalExperimentStatus } from '../utils/experimentStatus';
+import { isRunningExperimentStatus, isTerminalExperimentStatus, summarizeExperimentRuns } from '../utils/experimentStatus';
 
 let detailFeedSeq = 0;
 
@@ -295,20 +295,43 @@ function StatCard({
   value,
   icon,
   trend,
-  color = 'blue'
+  color = 'blue',
+  compact = false,
 }: {
   label: string;
   value: string | number;
   icon: React.ReactNode;
   trend?: string;
-  color?: 'blue' | 'green' | 'purple' | 'amber';
+  color?: 'blue' | 'green' | 'purple' | 'amber' | 'red' | 'slate';
+  compact?: boolean;
 }) {
   const colors = {
     blue: 'bg-blue-50 text-blue-600 border-blue-200',
     green: 'bg-green-50 text-green-600 border-green-200',
     purple: 'bg-purple-50 text-purple-600 border-purple-200',
     amber: 'bg-amber-50 text-amber-600 border-amber-200',
+    red: 'bg-red-50 text-red-600 border-red-200',
+    slate: 'bg-slate-50 text-slate-600 border-slate-200',
   };
+
+  if (compact) {
+    return (
+      <div className={`${colors[color]} rounded-lg border px-3 py-2.5 min-w-0 h-full`}>
+        <div className="flex items-center gap-2 min-w-0">
+          <div className="shrink-0 scale-90 opacity-80">{icon}</div>
+          <div className="min-w-0 flex-1">
+            <div className="text-lg font-bold leading-none tabular-nums truncate">{value}</div>
+            <div className="text-[10px] font-semibold uppercase tracking-wide mt-1 opacity-75 truncate">
+              {label}
+            </div>
+          </div>
+          {trend && (
+            <span className="shrink-0 text-[10px] font-medium opacity-75">{trend}</span>
+          )}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={`${colors[color]} rounded-xl p-4 border-2 shadow-sm`}>
@@ -704,6 +727,11 @@ export default function ExperimentDetailScreen({
     return null;
   }
 
+  const runSummary = summarizeExperimentRuns(detail.runs, detail.run_count);
+  const metricsGridClass = runSummary.inProgress > 0
+    ? 'grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-7 gap-2.5 p-4'
+    : 'grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2.5 p-4';
+
   return (
     <DashboardShell
       asideWidthClass="w-56 lg:w-60"
@@ -731,16 +759,16 @@ export default function ExperimentDetailScreen({
       )}
     >
 
-        {/* Header with status + primary actions */}
-        <div className="mb-5 rounded-xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
-          <div className="flex flex-wrap items-start justify-between gap-4">
-            <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-4 gap-y-2">
+        {/* Overview: status, actions, and run-outcome metrics in one panel */}
+        <div className="mb-6 rounded-xl border border-slate-200 bg-white shadow-sm overflow-hidden">
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-100 bg-slate-50/60 px-4 py-3">
+            <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2">
               <StatusBadge status={detail.status} />
-              <p className="text-xs leading-snug text-slate-500">
-                Runs table lists each sweep combo and pipeline phase below.
+              <p className="text-xs text-slate-500">
+                {runSummary.complete} of {runSummary.expected} runs complete
               </p>
             </div>
-            <div className="flex shrink-0 flex-wrap items-center gap-3">
+            <div className="flex shrink-0 flex-wrap items-center gap-2">
               {(isTerminal || isRunning) && onExplore && (
                 <button
                   type="button"
@@ -750,9 +778,9 @@ export default function ExperimentDetailScreen({
                       ? 'Opens Search Explorer with data stored so far; more results appear as runs finish.'
                       : undefined
                   }
-                  className="px-6 py-3 bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white text-sm font-semibold rounded-xl shadow-md transition-all transform hover:scale-105"
+                  className="rounded-lg bg-gradient-to-r from-blue-600 to-blue-700 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:from-blue-700 hover:to-blue-800"
                 >
-                  {isRunning ? '🔍 Explore live results' : '🔍 Explore Results'}
+                  {isRunning ? '🔍 Explore live' : '🔍 Explore'}
                 </button>
               )}
               {isRunning && (
@@ -760,60 +788,48 @@ export default function ExperimentDetailScreen({
                   type="button"
                   onClick={handleCancel}
                   disabled={cancelling}
-                  className="px-6 py-3 bg-red-600 hover:bg-red-700 disabled:bg-red-300 text-white text-sm font-semibold rounded-xl shadow-md transition-all"
+                  className="rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-red-700 disabled:bg-red-300"
                 >
-                  {cancelling ? 'Cancelling...' : '⏹ Cancel Experiment'}
+                  {cancelling ? 'Cancelling…' : '⏹ Cancel'}
                 </button>
               )}
               {isTerminal && (
                 <button
                   type="button"
                   onClick={() => setShowDeleteModal(true)}
-                  className="px-6 py-3 bg-slate-100 hover:bg-red-50 border border-slate-300 hover:border-red-300 text-slate-700 hover:text-red-700 text-sm font-semibold rounded-xl shadow-sm transition-all"
+                  className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition-colors hover:border-red-300 hover:bg-red-50 hover:text-red-700"
                 >
                   🗑 Delete
                 </button>
               )}
             </div>
           </div>
-        </div>
 
-        {/* Key metrics cards */}
-        {detail && (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+          <div className={metricsGridClass}>
+            <StatCard compact label="Total" value={runSummary.expected} icon={icons.grid} color="blue" />
+            <StatCard compact label="Successful" value={runSummary.complete} icon={icons.check} color="green" />
+            <StatCard compact label="Failed" value={runSummary.failed} icon={icons.x} color="red" />
+            <StatCard compact label="Interrupted" value={runSummary.interrupted} icon={icons.x} color="amber" />
+            <StatCard compact label="Not Started" value={runSummary.neverStarted} icon={icons.grid} color="slate" />
+            {runSummary.inProgress > 0 && (
+              <StatCard compact label="In Progress" value={runSummary.inProgress} icon={icons.play} color="purple" />
+            )}
             <StatCard
-              label="Total Runs"
-              value={detail.run_count ?? 0}
-              icon={icons.grid}
-              color="blue"
-            />
-            <StatCard
-              label="Successful"
-              value={(detail.run_count ?? 0) - (detail.failed_count ?? 0)}
-              icon={icons.check}
-              color="green"
-            />
-            <StatCard
-              label="Failed"
-              value={detail.failed_count ?? 0}
-              icon={icons.x}
-              color="amber"
-            />
-            <StatCard
+              compact
               label="Duration"
               value={formatDuration(detail.started_at, detail.completed_at)}
               icon={icons.clock}
               color="purple"
             />
           </div>
-        )}
+        </div>
 
         {/* Progress visualization for running experiments */}
         {detail && isRunning && detail.runs && detail.runs.length > 0 && (
           <ExperimentProgressCard
             title="Experiment Progress"
-            subtitle={`${detail.runs.filter(r => r.phase === Phase.COMPLETE).length} of ${detail.runs.length} runs completed`}
-            percent={(detail.runs.filter(r => r.phase === Phase.COMPLETE).length / detail.runs.length) * 100}
+            subtitle={`${runSummary.complete} of ${runSummary.expected} runs completed`}
+            percent={runSummary.expected > 0 ? (runSummary.complete / runSummary.expected) * 100 : 0}
             variant="default"
             className="mb-6"
           />
@@ -1006,7 +1022,7 @@ export default function ExperimentDetailScreen({
                   <tbody className="divide-y divide-slate-100">
                     {paginatedRuns.map((run, idx) => {
                       const isComplete = run.phase === Phase.COMPLETE;
-                      const isFailed = run.phase === Phase.FAILED;
+                      const isFailed = run.phase === Phase.FAILED || run.phase === Phase.INTERRUPTED;
                       const rowBg = isFailed ? 'bg-red-50/50' : isComplete ? 'bg-green-50/30' : '';
                       const absoluteIndex = startIndex + idx;
 
@@ -1085,6 +1101,39 @@ export default function ExperimentDetailScreen({
           );
         })()}
 
+        {/* Interrupted runs detail */}
+        {detail?.runs && runSummary.interrupted > 0 && (
+          <div className="mt-6 bg-gradient-to-br from-amber-50 to-orange-50 border-2 border-amber-200 rounded-2xl p-6 shadow-lg">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="w-10 h-10 rounded-full bg-amber-500 flex items-center justify-center text-white">
+                {icons.x}
+              </div>
+              <h2 className="text-lg font-bold text-amber-900">
+                Interrupted Runs ({runSummary.interrupted})
+              </h2>
+            </div>
+            <div className="space-y-3">
+              {detail.runs.filter((run) => run.phase === Phase.INTERRUPTED).map((run) => (
+                <div key={run.run_id} className="bg-white border-l-4 border-amber-400 rounded-lg p-4 shadow-sm">
+                  <div className="flex items-center gap-3 mb-2">
+                    <span className="px-2 py-1 bg-amber-100 text-amber-800 text-xs font-mono font-bold rounded">
+                      {run.run_id.slice(0, 8)}
+                    </span>
+                    <span className="text-sm text-slate-700 font-medium">
+                      {run.embedding_model} · {run.chunking_method} · {run.chunk_size}+{run.overlap}
+                    </span>
+                  </div>
+                  <div className="bg-amber-50 rounded-md p-3 border border-amber-100">
+                    <p className="text-sm text-amber-900 font-mono whitespace-pre-wrap">
+                      {run.error_message || 'Run was interrupted before completion'}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
         {/* Failed runs detail */}
         {detail?.runs && detail.runs.filter(r => r.phase === Phase.FAILED).length > 0 && (
           <div className="mt-6 bg-gradient-to-br from-red-50 to-orange-50 border-2 border-red-200 rounded-2xl p-6 shadow-lg">
@@ -1124,8 +1173,8 @@ export default function ExperimentDetailScreen({
           </div>
         )}
 
-        {/* Success summary with explore CTA */}
-        {isTerminal && detail?.runs && detail.runs.filter(r => r.phase === Phase.FAILED).length === 0 && (
+        {/* Terminal outcome summary */}
+        {isTerminal && detail.status === 'complete' && (
           <div className="mt-6 bg-gradient-to-br from-green-50 to-emerald-50 border-2 border-green-300 rounded-2xl p-6 shadow-lg">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-4">
@@ -1137,7 +1186,7 @@ export default function ExperimentDetailScreen({
                     All Runs Completed Successfully!
                   </h3>
                   <p className="text-sm text-green-700 mt-1">
-                    {detail.runs.length} run(s) finished without errors
+                    {runSummary.complete} of {runSummary.expected} run(s) finished without errors
                   </p>
                 </div>
               </div>
@@ -1149,6 +1198,54 @@ export default function ExperimentDetailScreen({
                   🔍 Explore Results
                 </button>
               )}
+            </div>
+          </div>
+        )}
+
+        {isTerminal && detail.status === 'partial' && (
+          <div className="mt-6 bg-gradient-to-br from-amber-50 to-yellow-50 border-2 border-amber-300 rounded-2xl p-6 shadow-lg">
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex items-center gap-4">
+                <div className="w-12 h-12 rounded-full bg-amber-500 flex items-center justify-center text-white">
+                  {icons.x}
+                </div>
+                <div>
+                  <h3 className="text-lg font-bold text-amber-900">Sweep Incomplete</h3>
+                  <p className="text-sm text-amber-800 mt-1">
+                    {runSummary.complete} of {runSummary.expected} run(s) completed successfully.
+                    {runSummary.interrupted > 0 && ` ${runSummary.interrupted} interrupted.`}
+                    {runSummary.failed > 0 && ` ${runSummary.failed} failed.`}
+                    {runSummary.neverStarted > 0 && ` ${runSummary.neverStarted} never started.`}
+                  </p>
+                  <p className="text-xs text-amber-700 mt-2">
+                    The experiment stopped before every parameter combination ran — often after a server restart or cancellation mid-sweep.
+                  </p>
+                </div>
+              </div>
+              {onExplore && runSummary.complete > 0 && (
+                <button
+                  onClick={onExplore}
+                  className="px-6 py-3 bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white text-sm font-semibold rounded-xl shadow-md transition-all transform hover:scale-105 shrink-0"
+                >
+                  🔍 Explore Results
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+
+        {isTerminal && detail.status === 'cancelled' && (
+          <div className="mt-6 bg-gradient-to-br from-slate-50 to-slate-100 border-2 border-slate-300 rounded-2xl p-6 shadow-lg">
+            <div className="flex items-center gap-4">
+              <div className="w-12 h-12 rounded-full bg-slate-500 flex items-center justify-center text-white">
+                {icons.x}
+              </div>
+              <div>
+                <h3 className="text-lg font-bold text-slate-900">Experiment Cancelled</h3>
+                <p className="text-sm text-slate-700 mt-1">
+                  {runSummary.complete} of {runSummary.expected} run(s) completed before cancellation.
+                </p>
+              </div>
             </div>
           </div>
         )}

--- a/frontend/src/components/ExperimentDetailScreen.tsx
+++ b/frontend/src/components/ExperimentDetailScreen.tsx
@@ -14,22 +14,28 @@
  * - Color system: Blue (primary), Green (success), Red (failure), Amber (warning), Purple (secondary)
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { DETAIL_POLL_MS, LOADING_STALL_AFTER_MS, LOADING_STALL_REPEAT_MS } from '../constants';
+import { DETAIL_POLL_MS, DEV_POLL_LOG_INTERVAL_MS, LOADING_STALL_AFTER_MS, LOADING_STALL_REPEAT_MS, VECTOR_DB_STATS_POLL_MS } from '../constants';
 import AppPageChrome from './AppPageChrome';
 import DashboardShell from './DashboardShell';
 import LoadingFeedbackPanel from './LoadingFeedbackPanel';
 import ExperimentProgressCard from './ExperimentProgressCard';
+import ExperimentVectorDbStatsCard from './ExperimentVectorDbStatsCard';
 import type { FeedEntry } from './LoadingFeedbackPanel';
 import {
   cancelExperiment,
   deleteExperiment,
   getExperiment,
+  getExperimentDbStats,
   getExperimentWithProgress,
   type ExperimentProgressCallback,
 } from '../services/apiClient';
 import ConfirmDeleteModal from './ConfirmDeleteModal';
-import { RunStatus, Phase, EnvParams, SweepSummary, ExperimentStatus } from '../types';
+import CollapsibleCard from './CollapsibleCard';
+import { RunStatus, Phase, EnvParams, SweepSummary, ExperimentStatus, Experiment, ExperimentDbStatsSummary } from '../types';
 import { createStallWatcher, type FetchProgressUpdate } from '../services/fetchWithProgress';
+import { devDebugThrottled, devWarn } from '../utils/devLog';
+import { toExperimentDbStatsSummary } from '../utils/experimentDbStats';
+import { isRunningExperimentStatus, isTerminalExperimentStatus } from '../utils/experimentStatus';
 
 let detailFeedSeq = 0;
 
@@ -88,6 +94,7 @@ interface ExperimentDetail {
   experiment_id: string;
   experiment_name: string;
   status: ExperimentStatus;
+  created_at?: string;
   run_count?: number;
   failed_count?: number;
   runs?: RunStatus[];
@@ -342,16 +349,25 @@ function DimensionBadge({ label, values }: { label: string; values: (string | nu
 
 export default function ExperimentDetailScreen({
   experimentId,
+  initialExperiment,
+  initialDbStats,
   onBack,
   onExplore,
 }: {
   experimentId: string;
+  initialExperiment?: Experiment;
+  initialDbStats?: ExperimentDbStatsSummary;
   onBack: () => void;
   onExplore?: () => void;
 }) {
-  const [detail, setDetail] = useState<ExperimentDetail | null>(null);
+  const seededDetail =
+    initialExperiment?.experiment_id === experimentId
+      ? (initialExperiment as unknown as ExperimentDetail)
+      : null;
+
+  const [detail, setDetail] = useState<ExperimentDetail | null>(seededDetail);
   const [error, setError] = useState<string | null>(null);
-  const [hydrating, setHydrating] = useState(true);
+  const [hydrating, setHydrating] = useState(seededDetail === null);
   const [cancelling, setCancelling] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -359,6 +375,9 @@ export default function ExperimentDetailScreen({
   const [loadFeed, setLoadFeed] = useState<FeedEntry[]>([]);
   const [receivedBytes, setReceivedBytes] = useState<number | null>(null);
   const [totalBytes, setTotalBytes] = useState<number | null>(null);
+
+  const [dbStats, setDbStats] = useState<ExperimentDbStatsSummary | null>(initialDbStats ?? null);
+  const [dbStatsLoading, setDbStatsLoading] = useState(initialDbStats === undefined);
 
   const [runsCurrentPage, setRunsCurrentPage] = useState(1);
   const [runsItemsPerPage, setRunsItemsPerPage] = useState(15);
@@ -370,6 +389,100 @@ export default function ExperimentDetailScreen({
 
   const aliveRef = useRef(true);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollDevLogAtRef = useRef(new Map<string, number>());
+  const dbStatsInFlightRef = useRef<Promise<void> | null>(null);
+
+  const experimentMeta = useCallback((): Pick<Experiment, 'experiment_id' | 'experiment_name' | 'status' | 'created_at'> | null => {
+    if (detail) {
+      return {
+        experiment_id: detail.experiment_id,
+        experiment_name: detail.experiment_name,
+        status: detail.status,
+        created_at: detail.created_at ?? initialExperiment?.created_at ?? new Date(0).toISOString(),
+      };
+    }
+    if (initialExperiment?.experiment_id === experimentId) return initialExperiment;
+    return null;
+  }, [detail, initialExperiment, experimentId]);
+
+  const loadDbStats = useCallback(
+    async (options?: { showLoading?: boolean }) => {
+      if (dbStatsInFlightRef.current !== null) {
+        return dbStatsInFlightRef.current;
+      }
+
+      const request = (async () => {
+        const meta = experimentMeta();
+        if (!meta) return;
+        if (options?.showLoading) setDbStatsLoading(true);
+        try {
+          const response = await getExperimentDbStats(experimentId);
+          setDbStats(toExperimentDbStatsSummary(meta, response.db_stats));
+        } catch (err) {
+          devWarn(`DB stats load failed (${experimentId.slice(0, 8)}…):`, err);
+        } finally {
+          dbStatsInFlightRef.current = null;
+          setDbStatsLoading(false);
+        }
+      })();
+
+      dbStatsInFlightRef.current = request;
+      return request;
+    },
+    [experimentId, experimentMeta],
+  );
+
+  useEffect(() => {
+    if (!initialDbStats) {
+      void loadDbStats({ showLoading: true });
+    }
+
+    const statsTimer = window.setInterval(() => {
+      void loadDbStats();
+    }, VECTOR_DB_STATS_POLL_MS);
+
+    return () => window.clearInterval(statsTimer);
+  }, [experimentId, initialDbStats, loadDbStats]);
+
+  const stopDetailPoll = useCallback(() => {
+    if (pollRef.current !== null) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  const startDetailPollIfRunning = useCallback(
+    (status: ExperimentStatus | undefined) => {
+      stopDetailPoll();
+      if (!isRunningExperimentStatus(status)) return;
+
+      pollRef.current = window.setInterval(async () => {
+        if (!aliveRef.current) return;
+        try {
+          const next = await getExperiment(experimentId);
+          if (!aliveRef.current) return;
+          setDetail(next as unknown as ExperimentDetail);
+          setError(null);
+          devDebugThrottled(
+            `poll:detail:${experimentId}`,
+            DEV_POLL_LOG_INTERVAL_MS,
+            `Poll OK — experiment ${experimentId.slice(0, 8)}… status=${next.status}`,
+            pollDevLogAtRef.current,
+          );
+          if (isTerminalExperimentStatus(next.status)) {
+            stopDetailPoll();
+          }
+        } catch (pollErr) {
+          if (!aliveRef.current) return;
+          const pollMsg =
+            pollErr instanceof Error ? pollErr.message : 'Could not refresh experiment';
+          devWarn(`Detail poll failed (${experimentId.slice(0, 8)}…):`, pollMsg);
+          setError('Could not refresh experiment — transient network or server error.');
+        }
+      }, DETAIL_POLL_MS);
+    },
+    [experimentId, stopDetailPoll],
+  );
 
   useEffect(() => {
     aliveRef.current = true;
@@ -394,58 +507,61 @@ export default function ExperimentDetailScreen({
       );
     };
 
-    async function pollQuietly() {
-      if (!aliveRef.current) return;
-      try {
-        const next = await getExperiment(experimentId);
-        if (!aliveRef.current) return;
-        setDetail(next as unknown as ExperimentDetail);
-        setError(null);
-      } catch {
-        if (!aliveRef.current) return;
-        setError('Could not refresh experiment — transient network or server error.');
-      }
-    }
-
     async function hydrate() {
+      const hasSeed = initialExperiment?.experiment_id === experimentId;
       setHydrating(true);
       setError(null);
-      setDetail(null);
-      setLoadFeed([{ id: 'h0', text: 'Fetching experiment and run rows…', variant: 'default' }]);
+      if (!hasSeed) {
+        setDetail(null);
+      }
+      setLoadFeed([
+        {
+          id: 'h0',
+          text: hasSeed
+            ? 'Refreshing run rows and live status…'
+            : 'Fetching experiment and run rows…',
+          variant: 'default',
+        },
+      ]);
       setReceivedBytes(null);
       setTotalBytes(null);
       stall.start();
 
-      if (pollRef.current !== null) {
-        clearInterval(pollRef.current);
-        pollRef.current = null;
-      }
+      stopDetailPoll();
+
+      let loadedStatus: ExperimentStatus | undefined;
 
       try {
-        const loaded = await getExperimentWithProgress(
-          experimentId,
-          applyProg,
-          abortHydrate.signal,
-        );
+        const loaded = hasSeed
+          ? await getExperiment(experimentId, abortHydrate.signal)
+          : await getExperimentWithProgress(experimentId, applyProg, abortHydrate.signal);
         stall.stop();
         if (!aliveRef.current) return;
+        loadedStatus = loaded.status;
         setDetail(loaded as unknown as ExperimentDetail);
-        setLoadFeed((f) => appendDetailFeed(f, 'Hydrated UI — polling for live phase updates.', 'default'));
+        setLoadFeed((f) =>
+          appendDetailFeed(
+            f,
+            isRunningExperimentStatus(loaded.status)
+              ? 'Run rows loaded — live polling while experiment is running.'
+              : 'Run rows loaded.',
+            'default',
+          ),
+        );
       } catch (err) {
         stall.stop();
         if (!aliveRef.current) return;
         if (err instanceof DOMException && err.name === 'AbortError') return;
         const msg =
           err instanceof Error ? err.message : 'Failed to load experiment';
+        devWarn(`Detail hydrate failed (${experimentId.slice(0, 8)}…):`, msg);
         setError(msg);
         setLoadFeed((f) => appendDetailFeed(f, `Failed: ${msg}`, 'warning'));
       } finally {
         stall.stop();
         if (!aliveRef.current) return;
         setHydrating(false);
-
-        pollRef.current = window.setInterval(pollQuietly, DETAIL_POLL_MS);
-        void pollQuietly();
+        startDetailPollIfRunning(loadedStatus);
       }
     }
 
@@ -455,12 +571,9 @@ export default function ExperimentDetailScreen({
       aliveRef.current = false;
       abortHydrate.abort();
       stall.stop();
-      if (pollRef.current !== null) {
-        clearInterval(pollRef.current);
-        pollRef.current = null;
-      }
+      stopDetailPoll();
     };
-  }, [experimentId]);
+  }, [experimentId, initialExperiment, startDetailPollIfRunning, stopDetailPoll]);
 
   async function handleCancel() {
     if (!confirm('Cancel this experiment? Runs in progress will stop after the current phase.')) {
@@ -706,54 +819,79 @@ export default function ExperimentDetailScreen({
           />
         )}
 
+        <div className="mb-6">
+          <ExperimentVectorDbStatsCard
+            experimentId={experimentId}
+            stats={dbStats ?? undefined}
+            loading={dbStatsLoading && !dbStats}
+          />
+        </div>
+
         {/* Metadata sections */}
         {detail && (
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
-            {/* Git & Timeline */}
             <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-5">
-              <div className="flex items-center gap-2 mb-4">
-                {icons.code}
-                <h2 className="text-sm font-bold text-slate-700 uppercase tracking-wider">
-                  Git & Timeline
-                </h2>
-              </div>
-              <div className="space-y-3">
-                <MetadataItem
-                  label="Git Commit"
-                  value={detail.git_commit
-                    ? `${detail.git_commit.slice(0, 8)}${detail.git_dirty ? ' (dirty)' : ''}`
-                    : undefined}
-                />
-                <MetadataItem label="Git Branch" value={detail.git_branch} />
-                <MetadataItem
-                  label="Started"
-                  value={detail.started_at ? new Date(detail.started_at).toLocaleString() : undefined}
-                />
-                <MetadataItem
-                  label="Completed"
-                  value={detail.completed_at ? new Date(detail.completed_at).toLocaleString() : undefined}
-                />
-                <MetadataItem label="App Version" value={detail.app_version} />
-                <MetadataItem label="Python" value={detail.python_version} />
-              </div>
+              <CollapsibleCard
+                title="Git & Timeline"
+                icon={icons.code}
+                compact
+                storageKey={`detail-git-${experimentId}`}
+                headerExtra={
+                  detail.git_commit ? (
+                    <span className="font-mono text-xs text-slate-500">
+                      {detail.git_commit.slice(0, 8)}
+                      {detail.git_dirty ? ' *' : ''}
+                    </span>
+                  ) : null
+                }
+              >
+                <div className="space-y-3">
+                  <MetadataItem
+                    label="Git Commit"
+                    value={detail.git_commit
+                      ? `${detail.git_commit.slice(0, 8)}${detail.git_dirty ? ' (dirty)' : ''}`
+                      : undefined}
+                  />
+                  <MetadataItem label="Git Branch" value={detail.git_branch} />
+                  <MetadataItem
+                    label="Started"
+                    value={detail.started_at ? new Date(detail.started_at).toLocaleString() : undefined}
+                  />
+                  <MetadataItem
+                    label="Completed"
+                    value={detail.completed_at ? new Date(detail.completed_at).toLocaleString() : undefined}
+                  />
+                  <MetadataItem label="App Version" value={detail.app_version} />
+                  <MetadataItem label="Python" value={detail.python_version} />
+                </div>
+              </CollapsibleCard>
             </div>
 
-            {/* Sweep Configuration */}
             <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-5">
-              <div className="flex items-center gap-2 mb-4">
-                {icons.settings}
-                <h2 className="text-sm font-bold text-slate-700 uppercase tracking-wider">
-                  Configuration
-                </h2>
-              </div>
-              <div className="space-y-3">
-                <MetadataItem label="Rerank Model" value={detail.rerank_model ?? 'none'} />
-                <MetadataItem label="Top-K Initial" value={detail.top_k_initial} />
-                <MetadataItem label="Top-K Final" value={detail.top_k_final} />
-                <MetadataItem label="Parallelism" value={detail.parallelism} />
-                <MetadataItem label="On Error" value={detail.on_error} />
-                <MetadataItem label="Queries" value={detail.queries_file} />
-              </div>
+              <CollapsibleCard
+                title="Configuration"
+                icon={icons.settings}
+                compact
+                storageKey={`detail-config-${experimentId}`}
+                headerExtra={
+                  detail.rerank_model ? (
+                    <span className="text-xs text-slate-500 truncate max-w-[140px]" title={detail.rerank_model}>
+                      {detail.rerank_model}
+                    </span>
+                  ) : (
+                    <span className="text-xs text-slate-400">no rerank</span>
+                  )
+                }
+              >
+                <div className="space-y-3">
+                  <MetadataItem label="Rerank Model" value={detail.rerank_model ?? 'none'} />
+                  <MetadataItem label="Top-K Initial" value={detail.top_k_initial} />
+                  <MetadataItem label="Top-K Final" value={detail.top_k_final} />
+                  <MetadataItem label="Parallelism" value={detail.parallelism} />
+                  <MetadataItem label="On Error" value={detail.on_error} />
+                  <MetadataItem label="Queries" value={detail.queries_file} />
+                </div>
+              </CollapsibleCard>
             </div>
           </div>
         )}
@@ -780,29 +918,32 @@ export default function ExperimentDetailScreen({
         {/* Sweep Dimensions - Visual Grid */}
         {detail?.sweep_summary && (
           <div className="mb-6 bg-gradient-to-br from-purple-50 to-pink-50 rounded-2xl shadow-sm border border-purple-200 p-6">
-            <div className="flex items-center gap-2 mb-4">
-              {icons.grid}
-              <h2 className="text-lg font-bold text-slate-800">
-                Sweep Dimensions
-              </h2>
-              <span className="ml-auto text-sm text-purple-700 font-semibold">
-                {detail.sweep_summary.models.length *
-                  detail.sweep_summary.chunking_methods.length *
-                  detail.sweep_summary.chunk_sizes.length *
-                  detail.sweep_summary.overlaps.length *
-                  detail.sweep_summary.retrieval_methods.length} combinations
-              </span>
-            </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-              <DimensionBadge label="Database Provider" values={[detail.sweep_summary.database_provider || 'mongodb']} />
-              <DimensionBadge label="Embedding Provider" values={[detail.sweep_summary.embedding_provider || 'local']} />
-              <DimensionBadge label="Embedding Models" values={detail.sweep_summary.models} />
-              <DimensionBadge label="Chunking" values={detail.sweep_summary.chunking_methods} />
-              <DimensionBadge label="Chunk Sizes" values={detail.sweep_summary.chunk_sizes} />
-              <DimensionBadge label="Overlaps" values={detail.sweep_summary.overlaps} />
-              <DimensionBadge label="Retrieval" values={detail.sweep_summary.retrieval_methods} />
-              <DimensionBadge label="Rerank Provider" values={[detail.sweep_summary.rerank_provider || 'local']} />
-            </div>
+            <CollapsibleCard
+              title="Sweep Dimensions"
+              icon={icons.grid}
+              storageKey={`detail-sweep-${experimentId}`}
+              headerExtra={
+                <span className="text-sm text-purple-700 font-semibold">
+                  {detail.sweep_summary.models.length *
+                    detail.sweep_summary.chunking_methods.length *
+                    detail.sweep_summary.chunk_sizes.length *
+                    detail.sweep_summary.overlaps.length *
+                    detail.sweep_summary.retrieval_methods.length}{' '}
+                  combinations
+                </span>
+              }
+            >
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                <DimensionBadge label="Database Provider" values={[detail.sweep_summary.database_provider || 'mongodb']} />
+                <DimensionBadge label="Embedding Provider" values={[detail.sweep_summary.embedding_provider || 'local']} />
+                <DimensionBadge label="Embedding Models" values={detail.sweep_summary.models} />
+                <DimensionBadge label="Chunking" values={detail.sweep_summary.chunking_methods} />
+                <DimensionBadge label="Chunk Sizes" values={detail.sweep_summary.chunk_sizes} />
+                <DimensionBadge label="Overlaps" values={detail.sweep_summary.overlaps} />
+                <DimensionBadge label="Retrieval" values={detail.sweep_summary.retrieval_methods} />
+                <DimensionBadge label="Rerank Provider" values={[detail.sweep_summary.rerank_provider || 'local']} />
+              </div>
+            </CollapsibleCard>
           </div>
         )}
 

--- a/frontend/src/components/ExperimentVectorDbStatsCard.tsx
+++ b/frontend/src/components/ExperimentVectorDbStatsCard.tsx
@@ -1,0 +1,201 @@
+import CollapsibleCard from './CollapsibleCard';
+import type { ReactNode } from 'react';
+import type { ExperimentDbStatsSummary } from '../types';
+
+type ExperimentVectorDbStatsCardProps = {
+  experimentId: string;
+  stats?: ExperimentDbStatsSummary;
+  loading?: boolean;
+};
+
+const RUN_BREAKDOWN_PREVIEW = 8;
+
+export default function ExperimentVectorDbStatsCard({
+  experimentId,
+  stats,
+  loading = false,
+}: ExperimentVectorDbStatsCardProps) {
+  if (loading && !stats) {
+    return (
+      <div className="rounded-lg border border-indigo-100 bg-indigo-50/50 px-4 py-3 text-sm text-slate-600">
+        Loading vector database stats…
+      </div>
+    );
+  }
+
+  if (!stats) {
+    return (
+      <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-500">
+        No vector database stats yet — stats appear after chunks are stored.
+      </div>
+    );
+  }
+
+  const runPreview = stats.run_breakdown.slice(0, RUN_BREAKDOWN_PREVIEW);
+  const hiddenRuns = stats.run_breakdown.length - runPreview.length;
+
+  return (
+    <div className="rounded-lg border border-indigo-100 bg-gradient-to-br from-indigo-50/80 to-blue-50/50 px-4 py-3">
+      <CollapsibleCard
+        title="Vector Database"
+        compact
+        defaultOpen={false}
+        storageKey={`exp-vdb-stats-${experimentId}`}
+        headerExtra={
+          <span className="text-xs font-semibold text-indigo-700">
+            {stats.total_chunks.toLocaleString()} chunks · {stats.estimated_storage_mb} MB
+          </span>
+        }
+      >
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <StatTile label="Chunks" value={stats.total_chunks.toLocaleString()} />
+          <StatTile label="Query Results" value={stats.total_results.toLocaleString()} />
+          <StatTile
+            label="Storage (Est.)"
+            value={`${stats.estimated_storage_mb} MB`}
+            hint={`${stats.estimated_embedding_mb} MB vectors · ${stats.estimated_metadata_mb} MB meta`}
+          />
+          <StatTile label="Runs with Data" value={stats.runs_with_data} />
+        </div>
+
+        <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <InfoPanel title="Cluster & Collection">
+            <Row label="Provider" value={stats.database_provider} />
+            <Row label="Collection" value={stats.collection_name} mono />
+            <Row label="Atlas host" value={stats.cluster_host ?? '—'} mono />
+            <Row label="Source documents" value={String(stats.unique_documents)} />
+            <Row label="Unique queries" value={String(stats.unique_queries)} />
+            <Row label="Avg chunks / run" value={String(stats.avg_chunks_per_run)} />
+          </InfoPanel>
+
+          <InfoPanel title="Embeddings & Indexes">
+            <div className="mb-2 flex flex-wrap gap-1">
+              {stats.embedding_models.length > 0 ? (
+                stats.embedding_models.map((model) => (
+                  <span
+                    key={model}
+                    className="rounded-md bg-blue-100 px-2 py-0.5 font-mono text-[11px] text-blue-800"
+                  >
+                    {model}
+                  </span>
+                ))
+              ) : (
+                <span className="text-xs text-slate-500">—</span>
+              )}
+            </div>
+            <div className="mb-2 flex flex-wrap gap-1">
+              {stats.embedding_dimensions.map((dim) => (
+                <span
+                  key={dim}
+                  className="rounded-md bg-indigo-100 px-2 py-0.5 text-[11px] font-medium text-indigo-800"
+                >
+                  {dim}d
+                </span>
+              ))}
+            </div>
+            <div className="flex flex-wrap gap-1">
+              {stats.index_names.map((idx) => (
+                <span
+                  key={idx}
+                  className="rounded-md bg-purple-100 px-2 py-0.5 font-mono text-[11px] text-purple-800"
+                >
+                  {idx}
+                </span>
+              ))}
+            </div>
+          </InfoPanel>
+        </div>
+
+        {(stats.retrieval_methods.length > 0 || stats.chunking_methods.length > 0) && (
+          <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {stats.retrieval_methods.length > 0 && (
+              <InfoPanel title="Retrieval Methods">
+                <div className="flex flex-wrap gap-1">
+                  {stats.retrieval_methods.map((method) => (
+                    <span
+                      key={method}
+                      className="rounded-md bg-emerald-100 px-2 py-0.5 text-[11px] font-medium text-emerald-800"
+                    >
+                      {method}
+                    </span>
+                  ))}
+                </div>
+              </InfoPanel>
+            )}
+            {stats.chunking_methods.length > 0 && (
+              <InfoPanel title="Chunking Breakdown">
+                <div className="space-y-1">
+                  {Object.entries(stats.chunking_breakdown).map(([method, count]) => (
+                    <div key={method} className="flex justify-between gap-3 text-xs">
+                      <span className="font-medium text-slate-700">{method}</span>
+                      <span className="font-mono text-slate-900">{count.toLocaleString()}</span>
+                    </div>
+                  ))}
+                </div>
+              </InfoPanel>
+            )}
+          </div>
+        )}
+
+        {runPreview.length > 0 && (
+          <div className="mt-3 rounded-lg border border-indigo-100 bg-white/80 p-3">
+            <div className="mb-2 text-xs font-bold uppercase tracking-wider text-slate-500">
+              Per-run storage
+            </div>
+            <div className="space-y-1">
+              {runPreview.map((run) => (
+                <div key={run.run_id} className="flex justify-between gap-3 text-xs">
+                  <span className="truncate font-mono text-slate-600">{run.run_id.slice(0, 8)}…</span>
+                  <span className="shrink-0 text-slate-800">
+                    {run.chunks.toLocaleString()} chunks · {run.results.toLocaleString()} results
+                  </span>
+                </div>
+              ))}
+            </div>
+            {hiddenRuns > 0 && (
+              <p className="mt-2 text-[11px] text-slate-500">
+                + {hiddenRuns} more run{hiddenRuns === 1 ? '' : 's'} — open experiment detail for full list
+              </p>
+            )}
+          </div>
+        )}
+      </CollapsibleCard>
+    </div>
+  );
+}
+
+function StatTile({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string | number;
+  hint?: string;
+}) {
+  return (
+    <div className="rounded-md border border-indigo-100 bg-white/90 px-3 py-2">
+      <div className="text-[10px] uppercase tracking-wider text-slate-500">{label}</div>
+      <div className="text-lg font-bold text-indigo-600">{value}</div>
+      {hint ? <div className="mt-0.5 text-[10px] leading-snug text-slate-500">{hint}</div> : null}
+    </div>
+  );
+}
+
+function InfoPanel({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className="rounded-md border border-indigo-100 bg-white/90 p-3">
+      <div className="mb-2 text-[10px] font-bold uppercase tracking-wider text-slate-500">{title}</div>
+      <div className="space-y-1">{children}</div>
+    </div>
+  );
+}
+
+function Row({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="flex justify-between gap-3 text-xs">
+      <span className="text-slate-600">{label}</span>
+      <span className={`font-medium text-slate-900 ${mono ? 'font-mono text-[11px]' : ''}`}>{value}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/ExperimentsScreen.tsx
+++ b/frontend/src/components/ExperimentsScreen.tsx
@@ -1,17 +1,22 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
+  DEV_POLL_LOG_INTERVAL_MS,
   EXPERIMENTS_POLL_MS,
   LOADING_STALL_AFTER_MS,
   LOADING_STALL_REPEAT_MS,
+  VECTOR_DB_STATS_POLL_MS,
 } from '../constants';
 import AppPageChrome from './AppPageChrome';
 import DashboardShell from './DashboardShell';
 import LoadingFeedbackPanel, { type FeedEntry } from './LoadingFeedbackPanel';
 import PollingIndicator from './PollingIndicator';
 import ConfirmDeleteModal from './ConfirmDeleteModal';
+import VectorDbStatsPanel from './VectorDbStatsPanel';
+import ExperimentVectorDbStatsCard from './ExperimentVectorDbStatsCard';
 import { createStallWatcher, type FetchProgressUpdate } from '../services/fetchWithProgress';
-import { deleteExperiment, getExperiments, getExperimentsWithProgress } from '../services/apiClient';
-import { Experiment } from '../types';
+import { deleteExperiment, getExperiments, getExperimentsWithProgress, getVectorDbStatsGrouped } from '../services/apiClient';
+import { Experiment, ExperimentDbStatsSummary, VectorDbStatsGroup } from '../types';
+import { devDebugThrottled, devWarn } from '../utils/devLog';
 
 let feedSeq = 0;
 
@@ -100,10 +105,55 @@ function experimentsRailHelp() {
   );
 }
 
-export default function ExperimentsScreen({ onSelect }: { onSelect?: (id: string) => void }) {
-  const [experiments, setExperiments] = useState<Experiment[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [initialLoadDone, setInitialLoadDone] = useState(false);
+function statusBadgeClass(status: Experiment['status']): string {
+  if (status === 'complete') return 'bg-green-100 text-green-700';
+  if (status === 'running') return 'bg-blue-100 text-blue-700';
+  if (status === 'partial') return 'bg-yellow-100 text-yellow-700';
+  if (status === 'failed') return 'bg-red-100 text-red-700';
+  if (status === 'cancelled') return 'bg-orange-100 text-orange-700';
+  return 'bg-slate-100 text-slate-700';
+}
+
+function experimentStatsMap(groups: VectorDbStatsGroup[]): Map<string, ExperimentDbStatsSummary> {
+  const map = new Map<string, ExperimentDbStatsSummary>();
+  for (const group of groups) {
+    for (const exp of group.experiments) {
+      map.set(exp.experiment_id, exp);
+    }
+  }
+  return map;
+}
+
+/** True when we should show the full-page loading overlay (experiment list fetch only). */
+function shouldShowLoadingPanel(
+  initialLoadDone: boolean,
+  loading: boolean,
+  isPolling: boolean,
+  experimentsCount: number,
+  error: string | null,
+): boolean {
+  if (error !== null) return false;
+  if (!initialLoadDone || loading) return true;
+  if (experimentsCount === 0 && isPolling) return true;
+  return false;
+}
+
+export default function ExperimentsScreen({
+  onSelect,
+  cacheReady = false,
+  cachedExperiments,
+  cachedVectorDbGroups,
+  onCacheUpdate,
+}: {
+  onSelect?: (experiment: Experiment) => void;
+  cacheReady?: boolean;
+  cachedExperiments?: Experiment[];
+  cachedVectorDbGroups?: VectorDbStatsGroup[];
+  onCacheUpdate?: (update: { experiments: Experiment[]; vectorDbGroups: VectorDbStatsGroup[] }) => void;
+}) {
+  const [experiments, setExperiments] = useState<Experiment[]>(() => cachedExperiments ?? []);
+  const [loading, setLoading] = useState(() => !cacheReady);
+  const [initialLoadDone, setInitialLoadDone] = useState(() => cacheReady);
   const [isPolling, setIsPolling] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [feed, setFeed] = useState<FeedEntry[]>([]);
@@ -116,6 +166,13 @@ export default function ExperimentsScreen({ onSelect }: { onSelect?: (id: string
   const [selectedExperiments, setSelectedExperiments] = useState<Set<string>>(new Set());
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [collapsedExperiments, setCollapsedExperiments] = useState<Set<string>>(() => {
+    const stored = localStorage.getItem('collapsedExperiments');
+    return stored ? new Set(JSON.parse(stored)) : new Set();
+  });
+  const [vectorDbGroups, setVectorDbGroups] = useState<VectorDbStatsGroup[]>(() => cachedVectorDbGroups ?? []);
+  const [vectorDbLoading, setVectorDbLoading] = useState(false);
+  const [vectorDbError, setVectorDbError] = useState<string | null>(null);
 
   const handleItemsPerPageChange = useCallback((items: number) => {
     setItemsPerPage(items);
@@ -164,8 +221,55 @@ export default function ExperimentsScreen({ onSelect }: { onSelect?: (id: string
     }
   }, [selectedExperiments]);
 
+  const toggleCollapse = useCallback((experimentId: string) => {
+    setCollapsedExperiments(prev => {
+      const next = new Set(prev);
+      if (next.has(experimentId)) {
+        next.delete(experimentId);
+      } else {
+        next.add(experimentId);
+      }
+      localStorage.setItem('collapsedExperiments', JSON.stringify(Array.from(next)));
+      return next;
+    });
+  }, []);
+
   const aliveRef = useRef(true);
   const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const statsPollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollDevLogAtRef = useRef(new Map<string, number>());
+  const vectorDbStatsInFlightRef = useRef<Promise<void> | null>(null);
+
+  const loadVectorDbStats = useCallback(async (options?: { silent?: boolean }) => {
+    if (!aliveRef.current) return;
+    if (vectorDbStatsInFlightRef.current !== null) {
+      return vectorDbStatsInFlightRef.current;
+    }
+
+    const request = (async () => {
+      if (!options?.silent) setVectorDbLoading(true);
+      try {
+        const payload = await getVectorDbStatsGrouped();
+        if (!aliveRef.current) return;
+        setVectorDbGroups(payload.groups);
+        setVectorDbError(null);
+      } catch (err) {
+        if (!aliveRef.current) return;
+        setVectorDbError(err instanceof Error ? err.message : 'Failed to load vector DB stats');
+      } finally {
+        vectorDbStatsInFlightRef.current = null;
+        if (aliveRef.current && !options?.silent) setVectorDbLoading(false);
+      }
+    })();
+
+    vectorDbStatsInFlightRef.current = request;
+    return request;
+  }, []);
+
+  useEffect(() => {
+    if (!initialLoadDone) return;
+    onCacheUpdate?.({ experiments, vectorDbGroups });
+  }, [experiments, vectorDbGroups, initialLoadDone, onCacheUpdate]);
 
   useEffect(() => {
     aliveRef.current = true;
@@ -177,6 +281,67 @@ export default function ExperimentsScreen({ onSelect }: { onSelect?: (id: string
       repeatMs: LOADING_STALL_REPEAT_MS,
       onWarning: (text) => setFeed((f) => appendFeed(f, text, 'warning')),
     });
+
+    function startPollTimers() {
+      async function silentPoll() {
+        if (!aliveRef.current) return;
+        setIsPolling(true);
+        try {
+          const rows = await getExperiments();
+          if (!aliveRef.current) return;
+          setExperiments(rows);
+          setError(null);
+          devDebugThrottled(
+            'poll:experiments',
+            DEV_POLL_LOG_INTERVAL_MS,
+            `Poll OK — ${rows.length} experiment(s)`,
+            pollDevLogAtRef.current,
+          );
+        } catch (pollErr) {
+          if (!aliveRef.current) return;
+          const pollMsg =
+            pollErr instanceof Error ? pollErr.message : 'Polling failed — check server connectivity.';
+          devWarn('Experiments poll failed:', pollMsg);
+          setError(pollMsg);
+        } finally {
+          if (aliveRef.current) setIsPolling(false);
+        }
+      }
+
+      async function silentStatsPoll() {
+        if (!aliveRef.current) return;
+        await loadVectorDbStats({ silent: true });
+      }
+
+      if (pollTimerRef.current !== null) window.clearInterval(pollTimerRef.current);
+      pollTimerRef.current = setInterval(silentPoll, EXPERIMENTS_POLL_MS);
+
+      if (statsPollTimerRef.current !== null) window.clearInterval(statsPollTimerRef.current);
+      statsPollTimerRef.current = setInterval(silentStatsPoll, VECTOR_DB_STATS_POLL_MS);
+    }
+
+    if (cacheReady) {
+      startPollTimers();
+      void loadVectorDbStats({ silent: (cachedVectorDbGroups?.length ?? 0) > 0 });
+      void getExperiments()
+        .then((rows) => {
+          if (!aliveRef.current) return;
+          setExperiments(rows);
+          setError(null);
+        })
+        .catch(() => undefined);
+      return () => {
+        aliveRef.current = false;
+        if (pollTimerRef.current !== null) {
+          clearInterval(pollTimerRef.current);
+          pollTimerRef.current = null;
+        }
+        if (statsPollTimerRef.current !== null) {
+          clearInterval(statsPollTimerRef.current);
+          statsPollTimerRef.current = null;
+        }
+      };
+    }
 
     async function bootstrap() {
       setFeed([{ id: 'start', text: 'Starting experiments list load…', variant: 'default' }]);
@@ -200,14 +365,17 @@ export default function ExperimentsScreen({ onSelect }: { onSelect?: (id: string
         const data = await getExperimentsWithProgress(applyProg, abortInitial.signal);
         stall.stop();
         if (!aliveRef.current) return;
-        setFeed((f) => appendFeed(f, 'Ready.', 'default'));
         setExperiments(data);
         setError(null);
+        void loadVectorDbStats();
+        if (!aliveRef.current) return;
+        setFeed((f) => appendFeed(f, 'Experiments loaded — vector DB stats loading above.', 'default'));
       } catch (err) {
         stall.stop();
         if (!aliveRef.current) return;
         if (err instanceof DOMException && err.name === 'AbortError') return;
         const msg = err instanceof Error ? err.message : 'Failed to load experiments';
+        devWarn('Initial experiments load failed:', msg);
         setError(msg);
         setFeed((f) => appendFeed(f, `Failed: ${msg}`, 'warning'));
       } finally {
@@ -215,28 +383,7 @@ export default function ExperimentsScreen({ onSelect }: { onSelect?: (id: string
         if (!aliveRef.current) return;
         setLoading(false);
         setInitialLoadDone(true);
-
-        async function silentPoll() {
-          if (!aliveRef.current) return;
-          setIsPolling(true);
-          try {
-            const rows = await getExperiments();
-            if (!aliveRef.current) return;
-            setExperiments(rows);
-            setError(null);
-          } catch (pollErr) {
-            if (!aliveRef.current) return;
-            const pollMsg =
-              pollErr instanceof Error ? pollErr.message : 'Polling failed — check server connectivity.';
-            setError(pollMsg);
-          } finally {
-            if (aliveRef.current) setIsPolling(false);
-          }
-        }
-
-        if (pollTimerRef.current !== null) window.clearInterval(pollTimerRef.current);
-        pollTimerRef.current = setInterval(silentPoll, EXPERIMENTS_POLL_MS);
-        void silentPoll();
+        startPollTimers();
       }
     }
 
@@ -250,36 +397,40 @@ export default function ExperimentsScreen({ onSelect }: { onSelect?: (id: string
         clearInterval(pollTimerRef.current);
         pollTimerRef.current = null;
       }
+      if (statsPollTimerRef.current !== null) {
+        clearInterval(statsPollTimerRef.current);
+        statsPollTimerRef.current = null;
+      }
     };
-  }, []);
+  }, [cacheReady, loadVectorDbStats]);
 
-  if (!initialLoadDone && experiments.length === 0) {
-    return (
-      <DashboardShell
-        asideWidthClass="w-56 lg:w-60"
-        header={
-          <AppPageChrome
-            tone="darkFrame"
-            pageTitle="Experiments"
-            pageHint="Loading experiment list and run summaries from your server."
-          />
-        }
-        sidebar={experimentsRailHelp()}
-      >
-        <div className="flex justify-center py-8">
-          <LoadingFeedbackPanel
-            title="Loading experiments"
-            subtitle="Transfer + parse milestones (server does not stream row counts yet)."
-            feed={feed}
-            receivedBytes={receivedBytes}
-            totalBytes={totalBytes}
-            footer={`After load, list refreshes every ${EXPERIMENTS_POLL_MS / 1000}s without reopening this panel.`}
-            theme="light"
-          />
-        </div>
-      </DashboardShell>
-    );
-  }
+  const showLoadingPanel = shouldShowLoadingPanel(
+    initialLoadDone,
+    loading,
+    isPolling,
+    experiments.length,
+    error,
+  );
+  const showEmptyConfirmed =
+    initialLoadDone &&
+    !loading &&
+    !isPolling &&
+    experiments.length === 0 &&
+    error === null;
+
+  const loadingPanelTitle = !initialLoadDone
+    ? 'Connecting to server'
+    : experiments.length === 0
+      ? 'Checking for experiments'
+      : 'Refreshing experiments';
+
+  const loadingPanelSubtitle = !initialLoadDone
+    ? 'Contacting the API, loading experiment list, then vector database stats.'
+    : 'Waiting for the server to finish this refresh cycle.';
+
+  const pageHint = showLoadingPanel
+    ? 'Loading experiment list and vector database stats from your server.'
+    : `History and live status for every sweep. This table refreshes every ${EXPERIMENTS_POLL_MS / 1000}s while you keep the page open.`;
 
   return (
     <DashboardShell
@@ -288,7 +439,7 @@ export default function ExperimentsScreen({ onSelect }: { onSelect?: (id: string
         <AppPageChrome
           tone="darkFrame"
           pageTitle="Experiments"
-          pageHint={`History and live status for every sweep. This table refreshes every ${EXPERIMENTS_POLL_MS / 1000}s while you keep the page open.`}
+          pageHint={pageHint}
         />
       }
       sidebar={experimentsRailHelp()}
@@ -297,11 +448,36 @@ export default function ExperimentsScreen({ onSelect }: { onSelect?: (id: string
         <div className="mb-4 rounded-lg border border-red-200 bg-red-50 p-4 text-red-700">{error}</div>
       )}
 
-        {experiments.length === 0 && !error && (
+      <VectorDbStatsPanel
+        groups={vectorDbGroups}
+        loading={vectorDbLoading}
+        error={vectorDbError}
+      />
+
+      {showLoadingPanel && (
+        <div className="flex justify-center py-8">
+          <LoadingFeedbackPanel
+            title={loadingPanelTitle}
+            subtitle={loadingPanelSubtitle}
+            feed={feed}
+            receivedBytes={receivedBytes}
+            totalBytes={totalBytes}
+            footer={
+              initialLoadDone
+                ? `List auto-refreshes every ${EXPERIMENTS_POLL_MS / 1000}s once connected.`
+                : `After load, list refreshes every ${EXPERIMENTS_POLL_MS / 1000}s.`
+            }
+            theme="light"
+            expectPayloadProgress={!initialLoadDone || receivedBytes !== null}
+          />
+        </div>
+      )}
+
+        {showEmptyConfirmed && (
           <div className="rounded-xl border border-slate-200 bg-white p-12 text-center shadow-sm">
             <div className="mb-2 text-lg text-slate-400">No experiments yet</div>
             <div className="text-sm text-slate-500">
-              Submit your first experiment using the CLI:
+              The server is connected and returned an empty list. Submit your first experiment using the CLI:
               <code className="mt-2 block rounded bg-slate-100 p-2 text-xs">
                 rag-params-finder run --config configs/example.yaml
               </code>
@@ -309,12 +485,13 @@ export default function ExperimentsScreen({ onSelect }: { onSelect?: (id: string
           </div>
         )}
 
-        {experiments.length > 0 && (() => {
+        {!showLoadingPanel && experiments.length > 0 && (() => {
           const startIndex = (currentPage - 1) * itemsPerPage;
           const endIndex = startIndex + itemsPerPage;
           const paginatedExperiments = experiments.slice(startIndex, endIndex);
           const selectableCount = experiments.filter(exp => exp.status !== 'running').length;
           const allSelectableSelected = selectableCount > 0 && selectedExperiments.size === selectableCount;
+          const statsByExperimentId = experimentStatsMap(vectorDbGroups);
 
           return (
             <>
@@ -339,122 +516,125 @@ export default function ExperimentsScreen({ onSelect }: { onSelect?: (id: string
                   </button>
                 </div>
               )}
-              <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
-                <table className="w-full">
-                  <thead className="border-b border-slate-200 bg-slate-50">
-                    <tr>
-                      <th className="px-4 py-3 text-left w-12">
+              <div className="mb-3 flex items-center gap-3 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
+                <input
+                  type="checkbox"
+                  checked={allSelectableSelected}
+                  onChange={(e) => handleSelectAll(e.target.checked)}
+                  className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-500"
+                />
+                <span className="text-xs font-bold uppercase tracking-wider text-slate-600">
+                  Select all deletable experiments
+                </span>
+              </div>
+              <div className="space-y-3">
+                {paginatedExperiments.map((exp) => {
+                  const isSelected = selectedExperiments.has(exp.experiment_id);
+                  const isRunning = exp.status === 'running';
+                  const isCollapsed = collapsedExperiments.has(exp.experiment_id);
+                  const dbStats = statsByExperimentId.get(exp.experiment_id);
+                  return (
+                    <div
+                      key={exp.experiment_id}
+                      className={`overflow-hidden rounded-xl border bg-white shadow-sm transition-colors ${
+                        isSelected ? 'border-blue-300 ring-1 ring-blue-200' : 'border-slate-200'
+                      }`}
+                    >
+                      <div className="flex items-center gap-3 px-4 py-4">
                         <input
                           type="checkbox"
-                          checked={allSelectableSelected}
-                          onChange={(e) => handleSelectAll(e.target.checked)}
-                          className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-500"
+                          checked={isSelected}
+                          disabled={isRunning}
+                          onChange={(e) => handleSelectExperiment(exp.experiment_id, e.target.checked)}
+                          className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40"
+                          title={isRunning ? 'Cannot delete running experiment' : ''}
                         />
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-600">
-                        Experiment Name
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-600">
-                        Experiment ID
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-600">
-                        Runs
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-600">
-                        Status
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-600">
-                        Git Commit
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-bold uppercase tracking-wider text-slate-600">
-                        Created
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-slate-100">
-                    {paginatedExperiments.map((exp) => {
-                      const isSelected = selectedExperiments.has(exp.experiment_id);
-                      const isRunning = exp.status === 'running';
-                      return (
-                        <tr
-                          key={exp.experiment_id}
-                          className={`transition-colors ${isSelected ? 'bg-blue-50' : 'hover:bg-slate-50'}`}
+                        <button
+                          type="button"
+                          onClick={() => toggleCollapse(exp.experiment_id)}
+                          className="rounded p-1 transition-colors hover:bg-slate-100"
+                          title={isCollapsed ? 'Expand details' : 'Collapse details'}
                         >
-                          <td className="px-4 py-4" onClick={(e) => e.stopPropagation()}>
-                            <input
-                              type="checkbox"
-                              checked={isSelected}
-                              disabled={isRunning}
-                              onChange={(e) => handleSelectExperiment(exp.experiment_id, e.target.checked)}
-                              className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40"
-                              title={isRunning ? 'Cannot delete running experiment' : ''}
-                            />
-                          </td>
-                          <td
-                            className="px-6 py-4 text-sm font-medium text-slate-900 cursor-pointer"
-                            onClick={() => onSelect?.(exp.experiment_id)}
+                          <svg
+                            className={`h-4 w-4 text-slate-600 transition-transform ${isCollapsed ? '' : 'rotate-90'}`}
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
                           >
-                            {exp.experiment_name}
-                          </td>
-                          <td
-                            className="px-6 py-4 font-mono text-sm text-slate-600 cursor-pointer"
-                            onClick={() => onSelect?.(exp.experiment_id)}
-                          >
-                            {exp.experiment_id.slice(0, 8)}...
-                          </td>
-                          <td
-                            className="px-6 py-4 font-mono text-sm text-slate-600 cursor-pointer"
-                            onClick={() => onSelect?.(exp.experiment_id)}
-                          >
-                            {exp.run_count ?? '—'}
-                            {exp.failed_count ? (
-                              <span className="ml-1 text-red-500">({exp.failed_count} failed)</span>
-                            ) : null}
-                          </td>
-                          <td
-                            className="px-6 py-4 cursor-pointer"
-                            onClick={() => onSelect?.(exp.experiment_id)}
-                          >
-                            <div className="flex items-center gap-2">
-                              <span
-                                className={`inline-flex rounded px-2 py-1 text-xs font-bold ${
-                                  exp.status === 'complete'
-                                    ? 'bg-green-100 text-green-700'
-                                    : exp.status === 'running'
-                                      ? 'bg-blue-100 text-blue-700'
-                                      : exp.status === 'partial'
-                                        ? 'bg-yellow-100 text-yellow-700'
-                                        : exp.status === 'failed'
-                                          ? 'bg-red-100 text-red-700'
-                                          : exp.status === 'cancelled'
-                                            ? 'bg-orange-100 text-orange-700'
-                                            : 'bg-slate-100 text-slate-700'
-                                }`}
-                              >
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                          </svg>
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => onSelect?.(exp)}
+                          className="min-w-0 flex-1 text-left"
+                        >
+                          <div className="truncate text-sm font-semibold text-slate-900">{exp.experiment_name}</div>
+                          {isCollapsed && (
+                            <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                              <span className={`inline-flex rounded px-2 py-0.5 font-bold ${statusBadgeClass(exp.status)}`}>
                                 {exp.status}
                               </span>
-                              {(exp.status === 'failed' || exp.status === 'partial') && (
-                                <span className="text-xs text-red-400">click for details</span>
-                              )}
+                              <span>{exp.run_count ?? '—'} runs</span>
+                              {exp.failed_count ? <span className="text-red-500">({exp.failed_count} failed)</span> : null}
+                              {dbStats ? (
+                                <>
+                                  <span>{dbStats.total_chunks.toLocaleString()} chunks</span>
+                                  <span>{dbStats.total_results.toLocaleString()} results</span>
+                                  <span>{dbStats.estimated_storage_mb} MB</span>
+                                </>
+                              ) : null}
+                              <span>{new Date(exp.created_at).toLocaleString()}</span>
                             </div>
-                          </td>
-                          <td
-                            className="px-6 py-4 font-mono text-sm text-slate-500 cursor-pointer"
-                            onClick={() => onSelect?.(exp.experiment_id)}
-                          >
-                            {exp.git_commit ?? '—'}
-                          </td>
-                          <td
-                            className="px-6 py-4 text-sm text-slate-600 cursor-pointer"
-                            onClick={() => onSelect?.(exp.experiment_id)}
-                          >
-                            {new Date(exp.created_at).toLocaleString()}
-                          </td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-              </table>
+                          )}
+                        </button>
+                        <span className={`hidden sm:inline-flex rounded px-2 py-1 text-xs font-bold ${statusBadgeClass(exp.status)}`}>
+                          {exp.status}
+                        </span>
+                      </div>
+                      {!isCollapsed && (
+                        <div className="space-y-4 border-t border-slate-100 bg-slate-50/60 px-4 py-4">
+                          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                            <div>
+                              <div className="text-xs uppercase tracking-wider text-slate-500">Experiment ID</div>
+                              <button
+                                type="button"
+                                onClick={() => onSelect?.(exp)}
+                                className="font-mono text-sm text-blue-700 hover:underline"
+                              >
+                                {exp.experiment_id.slice(0, 8)}...
+                              </button>
+                            </div>
+                            <div>
+                              <div className="text-xs uppercase tracking-wider text-slate-500">Runs</div>
+                              <div className="text-sm text-slate-800">
+                                {exp.run_count ?? '—'}
+                                {exp.failed_count ? (
+                                  <span className="ml-1 text-red-500">({exp.failed_count} failed)</span>
+                                ) : null}
+                              </div>
+                            </div>
+                            <div>
+                              <div className="text-xs uppercase tracking-wider text-slate-500">Git Commit</div>
+                              <div className="font-mono text-sm text-slate-700">{exp.git_commit?.slice(0, 8) ?? '—'}</div>
+                            </div>
+                            <div>
+                              <div className="text-xs uppercase tracking-wider text-slate-500">Created</div>
+                              <div className="text-sm text-slate-700">{new Date(exp.created_at).toLocaleString()}</div>
+                            </div>
+                          </div>
+                          <ExperimentVectorDbStatsCard
+                            experimentId={exp.experiment_id}
+                            stats={dbStats}
+                            loading={vectorDbLoading && !dbStats}
+                          />
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+              <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
                 <Pagination
                   currentPage={currentPage}
                   totalItems={experiments.length}
@@ -467,10 +647,12 @@ export default function ExperimentsScreen({ onSelect }: { onSelect?: (id: string
           );
         })()}
 
-      <div className="mt-4 flex items-center justify-center gap-3 text-xs text-slate-500">
-        <span>Polling every {EXPERIMENTS_POLL_MS / 1000}s</span>
-        <PollingIndicator active={isPolling && !loading} />
-      </div>
+      {initialLoadDone && !showLoadingPanel && (
+        <div className="mt-4 flex items-center justify-center gap-3 text-xs text-slate-500">
+          <span>Auto-refresh every {EXPERIMENTS_POLL_MS / 1000}s</span>
+          <PollingIndicator active={isPolling} />
+        </div>
+      )}
 
       <ConfirmDeleteModal
         isOpen={showDeleteModal}

--- a/frontend/src/components/SearchExplorerScreen.tsx
+++ b/frontend/src/components/SearchExplorerScreen.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   DETAIL_POLL_MS,
+  DEV_POLL_LOG_INTERVAL_MS,
   LOADING_STALL_AFTER_MS,
   LOADING_STALL_REPEAT_MS,
 } from '../constants';
@@ -17,6 +18,7 @@ import {
 } from '../services/apiClient';
 import { createStallWatcher, formatBytes, type FetchProgressUpdate } from '../services/fetchWithProgress';
 import { DetailedResult, ExploreResponse, RankedConfig } from '../types';
+import { devDebugThrottled, devWarn } from '../utils/devLog';
 
 let xfSeq = 0;
 
@@ -520,6 +522,7 @@ export default function SearchExplorerScreen({
 
   const prevExperimentRef = useRef('');
   const aliveRef = useRef(true);
+  const pollDevLogAtRef = useRef(new Map<string, number>());
 
   useEffect(() => {
     setPollWhileRunning(true);
@@ -627,14 +630,20 @@ export default function SearchExplorerScreen({
           );
           setData(response);
           setError(null);
+          devDebugThrottled(
+            `poll:explore:${experimentId}`,
+            DEV_POLL_LOG_INTERVAL_MS,
+            `Explore poll OK — ${response.ranked_configs.length} configs`,
+            pollDevLogAtRef.current,
+          );
           setSelectedMethods((prev) => {
             if (prev.size > 0) {
               return prev;
             }
             return new Set(response.ranked_configs.map((c) => c.retrieval_method));
           });
-        } catch {
-          /* ignore transient poll errors */
+        } catch (pollErr) {
+          devWarn(`Explore poll failed (${experimentId.slice(0, 8)}…):`, pollErr);
         } finally {
           setIsPolling(false);
         }

--- a/frontend/src/components/VectorDbStatsPanel.tsx
+++ b/frontend/src/components/VectorDbStatsPanel.tsx
@@ -1,0 +1,205 @@
+import CollapsibleCard from './CollapsibleCard';
+import type { VectorDbStatsGroup } from '../types';
+
+function groupLabel(group: VectorDbStatsGroup): string {
+  if (group.cluster_host) return group.cluster_host;
+  return `${group.database_provider} (local)`;
+}
+
+type VectorDbStatsPanelProps = {
+  groups: VectorDbStatsGroup[];
+  loading?: boolean;
+  error?: string | null;
+};
+
+function formatStorageSummary(group: VectorDbStatsGroup): string {
+  const parts = [`${group.totals.total_chunks.toLocaleString()} chunks`];
+  if (group.totals.database_free_mb != null && group.totals.database_storage_limit_mb != null) {
+    parts.push(`${group.totals.database_free_mb} MB free`);
+  } else if (group.totals.database_used_mb != null) {
+    parts.push(`${group.totals.database_used_mb} MB used`);
+  } else {
+    parts.push(`${group.totals.estimated_storage_mb} MB est.`);
+  }
+  return parts.join(' · ');
+}
+
+function storageUsagePercent(group: VectorDbStatsGroup): number | null {
+  const used = group.totals.database_used_mb;
+  const limit = group.totals.database_storage_limit_mb;
+  if (used == null || limit == null || limit <= 0) return null;
+  return Math.min(100, Math.round((used / limit) * 100));
+}
+
+export default function VectorDbStatsPanel({
+  groups,
+  loading = false,
+  error = null,
+}: VectorDbStatsPanelProps) {
+  if (loading && groups.length === 0) {
+    return (
+      <div className="mb-6 rounded-2xl border border-indigo-200 bg-gradient-to-br from-indigo-50 to-blue-50 p-6 text-sm text-slate-600">
+        Loading vector database stats…
+      </div>
+    );
+  }
+
+  if (error && groups.length === 0) {
+    return (
+      <div className="mb-6 rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+        <p className="font-semibold">Could not load vector database stats</p>
+        <p className="mt-1">{error}</p>
+      </div>
+    );
+  }
+
+  if (groups.length === 0 && !loading && !error) {
+    return (
+      <div className="mb-6 rounded-2xl border border-indigo-200 bg-gradient-to-br from-indigo-50 to-blue-50 p-6 text-sm text-slate-600">
+        Vector database stats will appear after your first experiment stores chunks.
+      </div>
+    );
+  }
+
+  if (groups.length === 0) return null;
+
+  return (
+    <div className="mb-6 space-y-4">
+      {groups.map((group) => (
+        <div
+          key={group.vector_db_id}
+          className="rounded-2xl border border-indigo-200 bg-gradient-to-br from-indigo-50 to-blue-50 p-6 shadow-sm"
+        >
+          <CollapsibleCard
+            title="Vector Database"
+            defaultOpen
+            storageKey={`vectordb-group-${group.vector_db_id}`}
+            headerExtra={
+              <span className="text-sm font-semibold text-indigo-700">
+                {groupLabel(group)} · {formatStorageSummary(group)}
+              </span>
+            }
+          >
+            <div className="mb-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              <StatTile label="Experiments" value={group.totals.experiment_count} />
+              <StatTile label="Total Chunks" value={group.totals.total_chunks.toLocaleString()} />
+              <StatTile label="Query Results" value={group.totals.total_results.toLocaleString()} />
+              <StatTile
+                label="DB Used"
+                value={
+                  group.totals.database_used_mb != null
+                    ? `${group.totals.database_used_mb} MB`
+                    : '—'
+                }
+                hint={
+                  group.totals.database_data_mb != null
+                    ? `${group.totals.database_data_mb} MB data · ${group.totals.database_index_mb} MB indexes`
+                    : undefined
+                }
+              />
+              <StatTile
+                label="Free Storage"
+                value={
+                  group.totals.database_free_mb != null &&
+                  group.totals.database_storage_limit_mb != null
+                    ? `${group.totals.database_free_mb} MB`
+                    : '—'
+                }
+                hint={
+                  group.totals.database_storage_limit_mb != null
+                    ? `of ${group.totals.database_storage_limit_mb} MB cluster quota`
+                    : 'Set ATLAS_* API keys or MONGODB_STORAGE_LIMIT_MB to show quota'
+                }
+              />
+              <StatTile
+                label="Chunks (Est.)"
+                value={`${group.totals.estimated_storage_mb} MB`}
+                hint={`${group.totals.estimated_embedding_mb} MB vectors · ${group.totals.estimated_metadata_mb} MB meta`}
+              />
+            </div>
+
+            {storageUsagePercent(group) != null && (
+              <div className="mb-4 rounded-lg border border-indigo-200 bg-white p-4">
+                <div className="mb-2 flex items-center justify-between text-xs uppercase tracking-wider text-slate-500">
+                  <span>Cluster storage</span>
+                  <span className="font-mono text-slate-700">
+                    {group.totals.database_used_mb} / {group.totals.database_storage_limit_mb} MB
+                  </span>
+                </div>
+                <div className="h-2 overflow-hidden rounded-full bg-indigo-100">
+                  <div
+                    className={`h-full rounded-full ${
+                      (storageUsagePercent(group) ?? 0) >= 85 ? 'bg-amber-500' : 'bg-indigo-500'
+                    }`}
+                    style={{ width: `${storageUsagePercent(group)}%` }}
+                  />
+                </div>
+              </div>
+            )}
+
+            <div className="mb-4 grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div className="rounded-lg border border-indigo-200 bg-white p-4">
+                <div className="mb-2 text-xs uppercase tracking-wider text-slate-500">Cluster & Collection</div>
+                <div className="space-y-1 text-sm">
+                  <Row label="Provider" value={group.database_provider} />
+                  <Row label="Collection" value={group.collection_name} mono />
+                  <Row label="Atlas host" value={group.cluster_host ?? '—'} mono />
+                  {group.totals.database_storage_limit_mb != null && (
+                    <Row
+                      label="Cluster quota"
+                      value={`${group.totals.database_storage_limit_mb} MB`}
+                    />
+                  )}
+                </div>
+              </div>
+              <div className="rounded-lg border border-indigo-200 bg-white p-4">
+                <div className="mb-2 text-xs uppercase tracking-wider text-slate-500">Indexes & Dimensions</div>
+                <div className="mb-2 flex flex-wrap gap-1">
+                  {group.index_names.map((idx) => (
+                    <span key={idx} className="rounded-md bg-purple-100 px-2 py-1 font-mono text-xs text-purple-800">
+                      {idx}
+                    </span>
+                  ))}
+                </div>
+                <div className="flex flex-wrap gap-1">
+                  {group.embedding_dimensions.map((dim) => (
+                    <span key={dim} className="rounded-md bg-blue-100 px-2 py-1 text-xs font-medium text-blue-800">
+                      {dim}d
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </CollapsibleCard>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function StatTile({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string | number;
+  hint?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-indigo-200 bg-white p-4">
+      <div className="mb-1 text-xs uppercase tracking-wider text-slate-500">{label}</div>
+      <div className="text-2xl font-bold text-indigo-600">{value}</div>
+      {hint ? <div className="mt-1 text-xs text-slate-500">{hint}</div> : null}
+    </div>
+  );
+}
+
+function Row({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="flex justify-between gap-4">
+      <span className="text-slate-600">{label}</span>
+      <span className={`font-medium text-slate-900 ${mono ? 'font-mono text-xs' : ''}`}>{value}</span>
+    </div>
+  );
+}

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -7,7 +7,10 @@ export const APP_READ_ONLY_NOTE =
 export const APP_FOOTNOTE_SUMMARY = 'How this dashboard relates to CLI runs';
 
 /** Polling intervals (ms). */
-export const EXPERIMENTS_POLL_MS = 500;
+export const EXPERIMENTS_POLL_MS = 2000;
+
+/** Vector DB stats are expensive on the server — refresh less often than the list. */
+export const VECTOR_DB_STATS_POLL_MS = 60_000;
 
 export const DETAIL_POLL_MS = 2000;
 
@@ -16,3 +19,6 @@ export const LOADING_STALL_AFTER_MS = 1800;
 
 /** Repeat stalled warnings while awaiting response (ms). */
 export const LOADING_STALL_REPEAT_MS = 2400;
+
+/** Dev-console poll breadcrumbs — match backend info_throttled interval. */
+export const DEV_POLL_LOG_INTERVAL_MS = 60_000;

--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -1,5 +1,6 @@
-import { DeleteExperimentResponse, Experiment, ExploreResponse } from '../types';
+import { DeleteExperimentResponse, Experiment, ExperimentDbStatsResponse, ExploreResponse, VectorDbStatsGroupedResponse } from '../types';
 import { fetchJsonWithProgress, type FetchProgressUpdate } from './fetchWithProgress';
+import { devWarn } from '../utils/devLog';
 
 export { formatBytes } from './fetchWithProgress';
 
@@ -31,6 +32,7 @@ function rethrowWithFetchHint(url: string, err: unknown): never {
     throw err;
   }
   if (isLikelyNetworkFailure(err)) {
+    devWarn('Network failure:', url, err);
     const pageOrigin =
       typeof window !== 'undefined' && window.location?.origin != null
         ? window.location.origin
@@ -175,6 +177,35 @@ export async function getExperimentExploreWithProgress(
   });
 
   return data;
+}
+
+export async function getExperimentDbStats(
+  experimentId: string,
+  signal?: AbortSignal,
+): Promise<ExperimentDbStatsResponse> {
+  const url = `${API_BASE_URL}/experiments/${experimentId}/db-stats`;
+  let response: Response;
+  try {
+    response = await fetch(url, { signal });
+  } catch (err) {
+    rethrowWithFetchHint(url, err);
+  }
+  if (!response.ok) throw new Error('Failed to fetch experiment DB stats');
+  return response.json();
+}
+
+export async function getVectorDbStatsGrouped(
+  signal?: AbortSignal,
+): Promise<VectorDbStatsGroupedResponse> {
+  const url = `${API_BASE_URL}/experiments/vector-db-stats`;
+  let response: Response;
+  try {
+    response = await fetch(url, { signal });
+  } catch (err) {
+    rethrowWithFetchHint(url, err);
+  }
+  if (!response.ok) throw new Error('Failed to fetch vector DB stats');
+  return response.json();
 }
 
 export async function cancelExperiment(

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -185,3 +185,74 @@ export interface DeleteExperimentResponse {
   deleted_counts: DeletedCounts;
   message: string;
 }
+
+export interface RunDbBreakdown {
+  run_id: string;
+  chunks: number;
+  results: number;
+}
+
+export interface ExperimentDbStats {
+  database_provider: string;
+  collection_name: string;
+  cluster_host: string | null;
+  total_chunks: number;
+  unique_documents: number;
+  embedding_models: string[];
+  embedding_dimensions: number[];
+  index_names: string[];
+  retrieval_methods: string[];
+  chunking_methods: string[];
+  chunking_breakdown: Record<string, number>;
+  estimated_storage_mb: number;
+  estimated_embedding_mb: number;
+  estimated_metadata_mb: number;
+  runs_with_data: number;
+  avg_chunks_per_run: number;
+  total_results: number;
+  unique_queries: number;
+  run_breakdown: RunDbBreakdown[];
+}
+
+export interface ExperimentDbStatsResponse {
+  experiment_id: string;
+  db_stats: ExperimentDbStats;
+}
+
+export interface VectorDbGroupTotals {
+  experiment_count: number;
+  total_chunks: number;
+  total_results: number;
+  estimated_storage_mb: number;
+  estimated_embedding_mb: number;
+  estimated_metadata_mb: number;
+  /** Actual MongoDB dbStats totalSize (data + indexes). */
+  database_used_mb?: number;
+  database_data_mb?: number;
+  database_index_mb?: number;
+  /** Cluster quota from Atlas Admin API or MONGODB_STORAGE_LIMIT_MB override. */
+  database_storage_limit_mb?: number | null;
+  database_free_mb?: number | null;
+}
+
+export type ExperimentDbStatsSummary = {
+  experiment_id: string;
+  experiment_name: string;
+  status: ExperimentStatus;
+  created_at: string;
+} & ExperimentDbStats;
+
+export interface VectorDbStatsGroup {
+  vector_db_id: string;
+  database_provider: string;
+  collection_name: string;
+  cluster_host: string | null;
+  index_names: string[];
+  embedding_dimensions: number[];
+  totals: VectorDbGroupTotals;
+  experiments: ExperimentDbStatsSummary[];
+}
+
+export interface VectorDbStatsGroupedResponse {
+  groups: VectorDbStatsGroup[];
+}

--- a/frontend/src/utils/devLog.ts
+++ b/frontend/src/utils/devLog.ts
@@ -1,0 +1,30 @@
+/** Dev-only console helpers — stripped from production builds via dead-code elimination. */
+
+const PREFIX = '[rag-params-finder]';
+
+export function devDebug(...args: unknown[]): void {
+  if (import.meta.env.DEV) {
+    console.debug(PREFIX, ...args);
+  }
+}
+
+export function devWarn(...args: unknown[]): void {
+  if (import.meta.env.DEV) {
+    console.warn(PREFIX, ...args);
+  }
+}
+
+/** Log at most once per interval (dev console breadcrumb without 2s spam). */
+export function devDebugThrottled(
+  key: string,
+  intervalMs: number,
+  message: string,
+  lastAtByKey: Map<string, number>,
+): void {
+  if (!import.meta.env.DEV) return;
+  const now = Date.now();
+  const last = lastAtByKey.get(key) ?? 0;
+  if (now - last < intervalMs) return;
+  lastAtByKey.set(key, now);
+  console.debug(PREFIX, message);
+}

--- a/frontend/src/utils/experimentDbStats.ts
+++ b/frontend/src/utils/experimentDbStats.ts
@@ -1,0 +1,21 @@
+import type { ExperimentDbStats, ExperimentDbStatsSummary, Experiment } from '../types';
+
+type ExperimentLike = Pick<Experiment, 'experiment_id' | 'experiment_name' | 'status' | 'created_at'>;
+
+export function toExperimentDbStatsSummary(
+  experiment: ExperimentLike,
+  dbStats: ExperimentDbStats,
+): ExperimentDbStatsSummary {
+  return { ...experiment, ...dbStats };
+}
+
+export function findDbStatsInGroups(
+  groups: { experiments: ExperimentDbStatsSummary[] }[],
+  experimentId: string,
+): ExperimentDbStatsSummary | undefined {
+  for (const group of groups) {
+    const hit = group.experiments.find((row) => row.experiment_id === experimentId);
+    if (hit) return hit;
+  }
+  return undefined;
+}

--- a/frontend/src/utils/experimentStatus.ts
+++ b/frontend/src/utils/experimentStatus.ts
@@ -1,6 +1,32 @@
-import type { ExperimentStatus } from '../types';
+import type { ExperimentStatus, RunStatus } from '../types';
+import { Phase } from '../types';
 
 const TERMINAL_STATUSES: ExperimentStatus[] = ['complete', 'failed', 'partial', 'cancelled'];
+
+export interface ExperimentRunSummary {
+  expected: number;
+  started: number;
+  complete: number;
+  failed: number;
+  interrupted: number;
+  neverStarted: number;
+  inProgress: number;
+}
+
+export function summarizeExperimentRuns(
+  runs: RunStatus[] | undefined,
+  expectedRunCount: number | undefined,
+): ExperimentRunSummary {
+  const expected = expectedRunCount ?? runs?.length ?? 0;
+  const started = runs?.length ?? 0;
+  const complete = runs?.filter((run) => run.phase === Phase.COMPLETE).length ?? 0;
+  const failed = runs?.filter((run) => run.phase === Phase.FAILED).length ?? 0;
+  const interrupted = runs?.filter((run) => run.phase === Phase.INTERRUPTED).length ?? 0;
+  const neverStarted = Math.max(0, expected - started);
+  const inProgress = Math.max(0, started - complete - failed - interrupted);
+
+  return { expected, started, complete, failed, interrupted, neverStarted, inProgress };
+}
 
 export function isTerminalExperimentStatus(status: ExperimentStatus | undefined): boolean {
   if (!status) return false;

--- a/frontend/src/utils/experimentStatus.ts
+++ b/frontend/src/utils/experimentStatus.ts
@@ -1,0 +1,12 @@
+import type { ExperimentStatus } from '../types';
+
+const TERMINAL_STATUSES: ExperimentStatus[] = ['complete', 'failed', 'partial', 'cancelled'];
+
+export function isTerminalExperimentStatus(status: ExperimentStatus | undefined): boolean {
+  if (!status) return false;
+  return TERMINAL_STATUSES.includes(status);
+}
+
+export function isRunningExperimentStatus(status: ExperimentStatus | undefined): boolean {
+  return status === 'running';
+}

--- a/server/api/experiments.py
+++ b/server/api/experiments.py
@@ -8,6 +8,8 @@ from server.api.experiments_shared import (
     mongo_delete_experiment_data,
     mongo_find_experiment_by_id,
     mongo_find_experiment_with_runs,
+    mongo_get_experiment_db_stats,
+    mongo_get_vector_db_stats_grouped,
     mongo_insert_experiment_doc,
     mongo_list_all_experiment_docs,
     mongo_list_results_for_experiment,
@@ -17,6 +19,7 @@ from server.api.experiments_shared import (
 from server.core.orchestrator import request_cancel, run_sweep
 from server.models.config import ExperimentConfig, expand_sweep
 from server.models.enums import ExperimentStatus
+from server.utils.log_throttle import info_throttled
 from server.utils.logger import get_logger
 from server.utils.metadata import collect_experiment_metadata
 
@@ -88,6 +91,20 @@ async def list_experiments():
     return {"experiments": experiments}
 
 
+@router.get("/vector-db-stats")
+async def get_vector_db_stats_grouped():
+    """Vector DB stats for all experiments, grouped by cluster."""
+    logger.debug("GET /experiments/vector-db-stats")
+    payload = await asyncio.to_thread(mongo_get_vector_db_stats_grouped)
+    info_throttled(
+        logger,
+        "poll:vector-db-stats",
+        "Vector DB stats: %s group(s)",
+        len(payload["groups"]),
+    )
+    return payload
+
+
 @router.get("/{experiment_id}")
 async def get_experiment(experiment_id: str):
     """Get a single experiment with its run statuses."""
@@ -107,8 +124,34 @@ async def get_experiment_results(experiment_id: str):
     """Get all query results for an experiment."""
     logger.debug(f"GET /experiments/{experiment_id}/results")
     results = await asyncio.to_thread(mongo_list_results_for_experiment, experiment_id)
-    logger.info(f"Returning {len(results)} results for experiment {experiment_id}")
+    info_throttled(
+        logger,
+        f"poll:results:{experiment_id}",
+        "Returning %s results for experiment %s",
+        len(results),
+        experiment_id,
+    )
     return {"experiment_id": experiment_id, "results": results}
+
+
+@router.get("/{experiment_id}/db-stats")
+async def get_experiment_db_stats(experiment_id: str):
+    """Get vector database statistics for an experiment."""
+    logger.debug(f"GET /experiments/{experiment_id}/db-stats")
+    experiment = await asyncio.to_thread(mongo_find_experiment_by_id, experiment_id)
+    if not experiment:
+        raise HTTPException(status_code=404, detail="Experiment not found")
+
+    stats = await asyncio.to_thread(mongo_get_experiment_db_stats, experiment_id)
+    info_throttled(
+        logger,
+        f"poll:db-stats:{experiment_id}",
+        "DB stats for %s: %s chunks, %s MB",
+        experiment_id,
+        stats["total_chunks"],
+        stats["estimated_storage_mb"],
+    )
+    return {"experiment_id": experiment_id, "db_stats": stats}
 
 
 @router.get("/{experiment_id}/explore")
@@ -128,10 +171,14 @@ async def explore_experiment(experiment_id: str, query: str | None = None):
     explored["experiment_id"] = experiment_id
     explored["experiment_name"] = experiment_doc.get("experiment_name", "")
 
-    logger.info(
-        f"Explore {experiment_id}: {explored['query_count']} queries, "
-        f"{explored['total_matches']} matches, "
-        f"{len(explored['ranked_configs'])} configs"
+    info_throttled(
+        logger,
+        f"poll:explore:{experiment_id}",
+        "Explore %s: %s queries, %s matches, %s configs",
+        experiment_id,
+        explored["query_count"],
+        explored["total_matches"],
+        len(explored["ranked_configs"]),
     )
     return explored
 

--- a/server/api/experiments_shared.py
+++ b/server/api/experiments_shared.py
@@ -106,3 +106,269 @@ def mongo_delete_experiment_data(experiment_id: str) -> dict[str, int]:
         "chunks": chunks_deleted,
         "results": results_deleted,
     }
+
+
+def _retrieval_methods_for_experiment(experiment: dict | None) -> list[str]:
+    if not experiment:
+        return []
+    sweep = experiment.get("sweep_summary") or {}
+    methods = sweep.get("retrieval_methods")
+    if isinstance(methods, list):
+        return [str(method) for method in methods]
+    config = experiment.get("config") or {}
+    retrieval = config.get("retrieval") or {}
+    config_methods = retrieval.get("methods")
+    if isinstance(config_methods, list):
+        return [str(method) for method in config_methods]
+    return []
+
+
+def _mongodb_cluster_hint() -> str | None:
+    from server.settings import settings
+
+    uri = settings.mongodb_uri.strip()
+    if not uri:
+        return None
+    without_scheme = uri.split("://", 1)[-1]
+    host_part = without_scheme.split("@")[-1].split("/")[0].split("?")[0]
+    return host_part or None
+
+
+def _mongodb_cluster_storage_mb() -> dict[str, float | None]:
+    """Actual database footprint from MongoDB dbStats (data + indexes)."""
+    from server.core.atlas_storage import resolve_storage_limit_mb
+    from server.db.atlas import get_database
+
+    db = get_database()
+    stats = db.command("dbStats")
+    data_bytes = float(stats.get("dataSize") or 0)
+    index_bytes = float(stats.get("indexSize") or 0)
+    total_bytes = float(stats.get("totalSize") or data_bytes + index_bytes)
+    used_mb = _bytes_to_mb(total_bytes)
+
+    limit_mb = resolve_storage_limit_mb()
+    has_quota = limit_mb is not None and limit_mb > 0
+    quota_mb = limit_mb if has_quota else None
+    return {
+        "database_used_mb": used_mb,
+        "database_data_mb": _bytes_to_mb(data_bytes),
+        "database_index_mb": _bytes_to_mb(index_bytes),
+        "database_storage_limit_mb": quota_mb,
+        "database_free_mb": round(max(0.0, quota_mb - used_mb), 2)
+        if quota_mb is not None
+        else None,
+    }
+
+
+def _bytes_to_mb(value: float) -> float:
+    return round(value / (1024 * 1024), 2)
+
+
+def _storage_breakdown_mb(
+    total_chunks: int, embedding_models: list[str]
+) -> tuple[float, float, float]:
+    if total_chunks == 0:
+        return 0.0, 0.0, 0.0
+    from server.core.model_registry import EMBEDDING_MODELS, get_dimensions
+
+    dims = [get_dimensions(model) for model in embedding_models if model in EMBEDDING_MODELS]
+    if not dims:
+        return 0.0, 0.0, 0.0
+    avg_dim = sum(dims) / len(dims)
+    embedding_bytes = total_chunks * int(avg_dim) * 4
+    metadata_bytes = total_chunks * 500
+    total_bytes = embedding_bytes + metadata_bytes
+    return (
+        _bytes_to_mb(embedding_bytes),
+        _bytes_to_mb(metadata_bytes),
+        _bytes_to_mb(total_bytes),
+    )
+
+
+def _estimate_storage_mb(total_chunks: int, embedding_models: list[str]) -> float:
+    _, _, total_mb = _storage_breakdown_mb(total_chunks, embedding_models)
+    return total_mb
+
+
+def _chunking_breakdown(chunks_coll, experiment_id: str) -> dict[str, int]:
+    pipeline = [
+        {"$match": {"experiment_id": experiment_id}},
+        {"$group": {"_id": "$chunk_method", "count": {"$sum": 1}}},
+    ]
+    breakdown: dict[str, int] = {}
+    for row in chunks_coll.aggregate(pipeline):
+        method = row.get("_id")
+        if method:
+            breakdown[str(method)] = int(row["count"])
+    return breakdown
+
+
+def _document_counts_by_run_id(collection, experiment_id: str) -> dict[str, int]:
+    pipeline = [
+        {"$match": {"experiment_id": experiment_id}},
+        {"$group": {"_id": "$run_id", "count": {"$sum": 1}}},
+    ]
+    counts: dict[str, int] = {}
+    for row in collection.aggregate(pipeline):
+        run_id = row.get("_id")
+        if run_id:
+            counts[str(run_id)] = int(row["count"])
+    return counts
+
+
+def _run_breakdown_for_experiment(chunks_coll, results_coll, experiment_id: str) -> list[dict]:
+    chunk_counts = _document_counts_by_run_id(chunks_coll, experiment_id)
+    result_counts = _document_counts_by_run_id(results_coll, experiment_id)
+    run_ids = chunks_coll.distinct("run_id", {"experiment_id": experiment_id})
+    breakdown: list[dict] = []
+    for run_id in run_ids:
+        key = str(run_id)
+        run_chunks = chunk_counts.get(key, 0)
+        run_results = result_counts.get(key, 0)
+        if run_chunks > 0 or run_results > 0:
+            breakdown.append({"run_id": run_id, "chunks": run_chunks, "results": run_results})
+    return breakdown
+
+
+def mongo_get_experiment_db_stats(experiment_id: str) -> dict:
+    """Get vector database statistics for an experiment."""
+    from server.core.model_registry import EMBEDDING_MODELS, get_dimensions, get_index_name
+    from server.db.atlas import CHUNKS_COLLECTION
+    from server.db.indexes import TEXT_SEARCH_INDEX_NAME
+
+    experiment = get_collection(EXPERIMENTS_COLLECTION).find_one(
+        {"experiment_id": experiment_id},
+        {"data_paths": 1, "sweep_summary": 1, "config": 1},
+    )
+    chunks_coll = get_collection(CHUNKS_COLLECTION)
+    results_coll = get_collection(RESULTS_COLLECTION)
+
+    total_chunks = chunks_coll.count_documents({"experiment_id": experiment_id})
+    embedding_models = chunks_coll.distinct("embedding_model", {"experiment_id": experiment_id})
+
+    embedding_dimensions = sorted(
+        {get_dimensions(model) for model in embedding_models if model in EMBEDDING_MODELS}
+    )
+
+    unique_documents = len((experiment or {}).get("data_paths") or [])
+    total_results = results_coll.count_documents({"experiment_id": experiment_id})
+    unique_queries = len(results_coll.distinct("query_id", {"experiment_id": experiment_id}))
+
+    run_breakdown = _run_breakdown_for_experiment(chunks_coll, results_coll, experiment_id)
+
+    index_names = sorted(
+        {get_index_name(model) for model in embedding_models if model in EMBEDDING_MODELS}
+    )
+    retrieval_methods = _retrieval_methods_for_experiment(experiment)
+    if any(method in {"sparse", "hybrid"} for method in retrieval_methods):
+        index_names.append(TEXT_SEARCH_INDEX_NAME)
+        index_names = sorted(set(index_names))
+
+    runs_with_data = len(run_breakdown)
+    avg_chunks_per_run = round(total_chunks / runs_with_data, 1) if runs_with_data else 0.0
+    embedding_mb, metadata_mb, total_mb = _storage_breakdown_mb(total_chunks, embedding_models)
+    chunking_breakdown = _chunking_breakdown(chunks_coll, experiment_id)
+    sweep = (experiment or {}).get("sweep_summary") or {}
+
+    return {
+        "database_provider": str(sweep.get("database_provider") or "mongodb"),
+        "collection_name": CHUNKS_COLLECTION,
+        "cluster_host": _mongodb_cluster_hint(),
+        "total_chunks": total_chunks,
+        "unique_documents": unique_documents,
+        "embedding_models": embedding_models,
+        "embedding_dimensions": embedding_dimensions,
+        "index_names": index_names,
+        "retrieval_methods": retrieval_methods,
+        "chunking_methods": sorted(chunking_breakdown.keys()),
+        "chunking_breakdown": chunking_breakdown,
+        "estimated_storage_mb": total_mb,
+        "estimated_embedding_mb": embedding_mb,
+        "estimated_metadata_mb": metadata_mb,
+        "runs_with_data": runs_with_data,
+        "avg_chunks_per_run": avg_chunks_per_run,
+        "total_results": total_results,
+        "unique_queries": unique_queries,
+        "run_breakdown": run_breakdown,
+    }
+
+
+def _vector_db_group_key(database_provider: str, cluster_host: str | None) -> str:
+    return f"{database_provider}:{cluster_host or 'unknown'}"
+
+
+def _merge_group_totals(group: dict, stats: dict) -> None:
+    totals = group["totals"]
+    totals["experiment_count"] += 1
+    totals["total_chunks"] += stats["total_chunks"]
+    totals["total_results"] += stats["total_results"]
+    totals["estimated_storage_mb"] = round(
+        totals["estimated_storage_mb"] + stats["estimated_storage_mb"], 2
+    )
+    totals["estimated_embedding_mb"] = round(
+        totals["estimated_embedding_mb"] + stats["estimated_embedding_mb"], 2
+    )
+    totals["estimated_metadata_mb"] = round(
+        totals["estimated_metadata_mb"] + stats["estimated_metadata_mb"], 2
+    )
+    group["index_names"] = sorted(set(group["index_names"]) | set(stats["index_names"]))
+    group["embedding_dimensions"] = sorted(
+        set(group["embedding_dimensions"]) | set(stats["embedding_dimensions"])
+    )
+
+
+def mongo_get_vector_db_stats_grouped() -> dict:
+    """Aggregate DB stats for all experiments, grouped by vector database cluster."""
+    experiments = mongo_list_all_experiment_docs()
+    groups: dict[str, dict] = {}
+
+    for experiment in experiments:
+        experiment_id = str(experiment["experiment_id"])
+        stats = mongo_get_experiment_db_stats(experiment_id)
+        group_key = _vector_db_group_key(stats["database_provider"], stats["cluster_host"])
+
+        if group_key not in groups:
+            groups[group_key] = {
+                "vector_db_id": group_key,
+                "database_provider": stats["database_provider"],
+                "collection_name": stats["collection_name"],
+                "cluster_host": stats["cluster_host"],
+                "index_names": [],
+                "embedding_dimensions": [],
+                "totals": {
+                    "experiment_count": 0,
+                    "total_chunks": 0,
+                    "total_results": 0,
+                    "estimated_storage_mb": 0.0,
+                    "estimated_embedding_mb": 0.0,
+                    "estimated_metadata_mb": 0.0,
+                },
+                "experiments": [],
+            }
+
+        group = groups[group_key]
+        _merge_group_totals(group, stats)
+
+        created_at = experiment.get("created_at")
+        created_at_str = created_at.isoformat() if hasattr(created_at, "isoformat") else created_at
+
+        group["experiments"].append(
+            {
+                "experiment_id": experiment_id,
+                "experiment_name": experiment.get("experiment_name", ""),
+                "status": experiment.get("status", ""),
+                "created_at": created_at_str,
+                **stats,
+            }
+        )
+
+    grouped = list(groups.values())
+    cluster_storage = _mongodb_cluster_storage_mb()
+    for group in grouped:
+        group["totals"].update(cluster_storage)
+        group["experiments"].sort(
+            key=lambda row: row.get("created_at") or "",
+            reverse=True,
+        )
+    grouped.sort(key=lambda row: row["totals"]["total_chunks"], reverse=True)
+    return {"groups": grouped}

--- a/server/core/atlas_storage.py
+++ b/server/core/atlas_storage.py
@@ -1,0 +1,151 @@
+"""Resolve MongoDB Atlas cluster storage quota for dashboard UI."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import httpx
+
+from server.settings import settings
+from server.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+ATLAS_API_BASE = "https://cloud.mongodb.com/api/atlas/v2"
+ATLAS_ACCEPT = "application/vnd.atlas.2023-01-01+json"
+CACHE_TTL_SECONDS = 300
+
+# Shared-tier logical storage caps (MB). Dedicated tiers use diskSizeGB from the API.
+TIER_STORAGE_LIMIT_MB: dict[str, float] = {
+    "M0": 512.0,
+    "M2": 2048.0,
+    "M5": 5120.0,
+}
+
+_limit_cache: tuple[float | None, float] | None = None
+
+
+def parse_atlas_cluster_name(uri: str) -> str | None:
+    """Extract Atlas cluster name from an SRV connection string host."""
+    trimmed = uri.strip()
+    if not trimmed or ".mongodb.net" not in trimmed:
+        return None
+    without_scheme = trimmed.split("://", 1)[-1]
+    host_part = without_scheme.split("@")[-1].split("/")[0].split("?")[0]
+    if not host_part.endswith(".mongodb.net"):
+        return None
+    cluster_part = host_part.removesuffix(".mongodb.net")
+    name = cluster_part.split(".")[0]
+    return name or None
+
+
+def is_atlas_uri(uri: str) -> bool:
+    return ".mongodb.net" in uri.strip()
+
+
+def resolve_storage_limit_mb() -> float | None:
+    """Return cluster storage quota in MB, or None when unknown."""
+    override = settings.mongodb_storage_limit_mb
+    if override > 0:
+        return override
+
+    if not is_atlas_uri(settings.mongodb_uri):
+        return None
+
+    if not _atlas_api_configured():
+        return None
+
+    return _cached_atlas_storage_limit_mb()
+
+
+def _atlas_api_configured() -> bool:
+    return bool(
+        settings.atlas_public_key.strip()
+        and settings.atlas_private_key.strip()
+        and settings.atlas_group_id.strip()
+    )
+
+
+def _cached_atlas_storage_limit_mb() -> float | None:
+    global _limit_cache
+    now = time.monotonic()
+    if _limit_cache is not None:
+        limit_mb, expires_at = _limit_cache
+        if now < expires_at:
+            return limit_mb
+
+    limit_mb = _fetch_atlas_storage_limit_mb()
+    _limit_cache = (limit_mb, now + CACHE_TTL_SECONDS)
+    return limit_mb
+
+
+def _fetch_atlas_storage_limit_mb() -> float | None:
+    cluster_name = settings.atlas_cluster_name.strip() or parse_atlas_cluster_name(
+        settings.mongodb_uri
+    )
+    if not cluster_name:
+        logger.warning("Atlas storage quota: could not derive cluster name from MONGODB_URI")
+        return None
+
+    url = f"{ATLAS_API_BASE}/groups/{settings.atlas_group_id.strip()}/clusters/{cluster_name}"
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            response = client.get(
+                url,
+                auth=(settings.atlas_public_key.strip(), settings.atlas_private_key.strip()),
+                headers={"Accept": ATLAS_ACCEPT},
+            )
+            response.raise_for_status()
+            payload = response.json()
+    except httpx.HTTPError as exc:
+        logger.warning("Atlas storage quota lookup failed for cluster %s: %s", cluster_name, exc)
+        return None
+
+    return _storage_limit_mb_from_cluster(payload)
+
+
+def _storage_limit_mb_from_cluster(cluster: dict[str, Any]) -> float | None:
+    disk_gb = _disk_size_gb(cluster)
+    if disk_gb is not None and disk_gb > 0:
+        return round(disk_gb * 1024, 2)
+
+    tier = _instance_size_name(cluster)
+    if tier and tier in TIER_STORAGE_LIMIT_MB:
+        return TIER_STORAGE_LIMIT_MB[tier]
+
+    if tier:
+        logger.info("Atlas storage quota: unknown tier %s — quota hidden", tier)
+    return None
+
+
+def _disk_size_gb(cluster: dict[str, Any]) -> float | None:
+    top_level = cluster.get("diskSizeGB")
+    if isinstance(top_level, int | float) and top_level > 0:
+        return float(top_level)
+
+    for spec in cluster.get("replicationSpecs") or []:
+        for region in spec.get("regionConfigs") or []:
+            for electable in region.get("electableSpecs") or []:
+                disk = electable.get("diskSizeGB")
+                if isinstance(disk, int | float) and disk > 0:
+                    return float(disk)
+            disk = region.get("diskSizeGB")
+            if isinstance(disk, int | float) and disk > 0:
+                return float(disk)
+    return None
+
+
+def _instance_size_name(cluster: dict[str, Any]) -> str | None:
+    provider = cluster.get("providerSettings") or {}
+    name = provider.get("instanceSizeName")
+    if isinstance(name, str) and name.strip():
+        return name.strip().upper()
+
+    for spec in cluster.get("replicationSpecs") or []:
+        for region in spec.get("regionConfigs") or []:
+            for electable in region.get("electableSpecs") or []:
+                size = electable.get("instanceSize")
+                if isinstance(size, str) and size.strip():
+                    return size.strip().upper()
+    return None

--- a/server/core/embedder.py
+++ b/server/core/embedder.py
@@ -91,7 +91,7 @@ def _embed_documents_voyage(texts: list[str], model: str) -> list[list[float]]:
 
 def _embed_query_voyage(text: str, model: str) -> list[float]:
     """Embed a single query using Voyage AI."""
-    logger.info(f"Embedding query with model={model}")
+    logger.debug(f"Embedding query with model={model}")
 
     client = get_client()
     tokens = estimate_tokens([text])
@@ -102,7 +102,7 @@ def _embed_query_voyage(text: str, model: str) -> list[float]:
     )
 
     embedding = cast(list[float], result.embeddings[0])
-    logger.info(f"Generated query embedding, dim={len(embedding)}")
+    logger.debug(f"Generated query embedding, dim={len(embedding)}")
     return embedding
 
 

--- a/server/core/local_embedder.py
+++ b/server/core/local_embedder.py
@@ -38,9 +38,9 @@ def embed_documents_local(texts: list[str], model_id: str) -> list[list[float]]:
 
 def embed_query_local(text: str, model_id: str) -> list[float]:
     """Embed a single query using a local SentenceTransformer model."""
-    logger.info(f"Embedding query locally with {model_id}")
+    logger.debug(f"Embedding query locally with {model_id}")
     model = _get_model(model_id)
     embedding = model.encode(text, show_progress_bar=False, normalize_embeddings=True)
     result = embedding.tolist()
-    logger.info(f"Generated local query embedding, dim={len(result)}")
+    logger.debug(f"Generated local query embedding, dim={len(result)}")
     return result

--- a/server/core/local_reranker.py
+++ b/server/core/local_reranker.py
@@ -37,7 +37,7 @@ def rerank_local(
     if not search_results:
         return []
 
-    logger.info(f"Reranking {len(search_results)} results locally with {model_id}, top_k={top_k}")
+    logger.debug(f"Reranking {len(search_results)} results locally with {model_id}, top_k={top_k}")
 
     model = _get_model(model_id)
     pairs = [(query, r.chunk.text) for r in search_results]
@@ -61,5 +61,5 @@ def rerank_local(
             )
         )
 
-    logger.info(f"Local reranking complete: {len(reranked)} results returned")
+    logger.debug(f"Local reranking complete: {len(reranked)} results returned")
     return reranked

--- a/server/core/orchestrator.py
+++ b/server/core/orchestrator.py
@@ -88,7 +88,7 @@ def _run_sweep_inner(experiment_id: str, config: ExperimentConfig) -> dict:
             break
         except Exception as e:
             failed += 1
-            logger.error(f"Run {run_id} failed: {e}")
+            logger.error(f"Run {run_id} failed: {e}", exc_info=True)
             if config.execution.on_error == "stop":
                 break
 
@@ -247,7 +247,7 @@ def _run_single(experiment_id: str, run_id: str, params: RunParams) -> None:
         _update_phase(run_id, Phase.INTERRUPTED, error_message="Cancelled by user")
         raise
     except Exception as e:
-        logger.error(f"Run {run_id} failed: {e}")
+        logger.error(f"Run {run_id} failed: {e}", exc_info=True)
         _update_phase(run_id, Phase.FAILED, error_message=str(e))
         raise
 
@@ -262,7 +262,7 @@ def _update_phase(run_id: str, phase: Phase, error_message: str | None = None) -
         _run_start_times[run_id] = now
 
     elapsed_ms = int((now - _run_start_times[run_id]) * 1000)
-    logger.info(f"Run {run_id} → {phase.value} ({elapsed_ms}ms)")
+    logger.debug(f"Run {run_id} → {phase.value} ({elapsed_ms}ms)")
 
     update: dict = {
         "phase": phase.value,

--- a/server/core/rate_limiter.py
+++ b/server/core/rate_limiter.py
@@ -55,7 +55,7 @@ class RateLimiter:
             sleep_for = self._request_times[0] + _WINDOW_S - now + 0.1
             if sleep_for <= 0:
                 return
-            logger.info(f"Rate limiter: RPM ceiling ({self._rpm}), sleeping {sleep_for:.1f}s")
+            logger.debug(f"Rate limiter: RPM ceiling ({self._rpm}), sleeping {sleep_for:.1f}s")
             self._lock.release()
             time.sleep(sleep_for)
             self._lock.acquire()
@@ -73,7 +73,7 @@ class RateLimiter:
             sleep_for = self._token_log[0][0] + _WINDOW_S - now + 0.1
             if sleep_for <= 0:
                 return
-            logger.info(f"Rate limiter: TPM ceiling ({self._tpm}), sleeping {sleep_for:.1f}s")
+            logger.debug(f"Rate limiter: TPM ceiling ({self._tpm}), sleeping {sleep_for:.1f}s")
             self._lock.release()
             time.sleep(sleep_for)
             self._lock.acquire()

--- a/server/core/reranker.py
+++ b/server/core/reranker.py
@@ -31,7 +31,7 @@ def _rerank_voyage(
     top_k: int,
 ) -> list[SearchResult]:
     """Rerank search results using Voyage reranker and return top_k."""
-    logger.info(f"Reranking {len(search_results)} results with {model}, top_k={top_k}")
+    logger.debug(f"Reranking {len(search_results)} results with {model}, top_k={top_k}")
 
     client = get_client()
     documents = [r.chunk.text for r in search_results]
@@ -55,5 +55,5 @@ def _rerank_voyage(
             )
         )
 
-    logger.info(f"Reranking complete: {len(reranked)} results returned")
+    logger.debug(f"Reranking complete: {len(reranked)} results returned")
     return reranked

--- a/server/core/results_analyzer.py
+++ b/server/core/results_analyzer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Any
 
+from server.utils.log_throttle import info_throttled
 from server.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -66,9 +67,14 @@ def analyze_results(
     if score_range == 0:
         score_range = 1.0
 
-    logger.info(
-        f"Score normalization: min={min_raw:.2f}, max={max_raw:.2f}, "
-        f"range={score_range:.2f}, scores={len(all_scores)}"
+    info_throttled(
+        logger,
+        "poll:score-normalization",
+        "Score normalization: min=%.2f, max=%.2f, range=%.2f, scores=%s",
+        min_raw,
+        max_raw,
+        score_range,
+        len(all_scores),
     )
 
     config_scores: dict[tuple, list[float]] = defaultdict(list)

--- a/server/core/retriever.py
+++ b/server/core/retriever.py
@@ -16,7 +16,7 @@ def dense_search(
     """Perform dense vector search using Atlas $vectorSearch."""
 
     index_name = get_index_name(embedding_model)
-    logger.info(
+    logger.debug(
         f"Dense search for experiment={experiment_id}, model={embedding_model}, "
         f"index={index_name}, k={top_k}"
     )
@@ -51,7 +51,7 @@ def dense_search(
     ]
 
     results = list(chunks_collection.aggregate(pipeline))
-    logger.info(f"Dense search returned {len(results)} results")
+    logger.debug(f"Dense search returned {len(results)} results")
 
     return _to_search_results(results, retrieval_method="dense")
 
@@ -65,7 +65,9 @@ def sparse_search(
     with field mappings for 'text' (string), 'experiment_id' (token), and
     'embedding_model' (token).  See CLAUDE.local.md for index creation steps.
     """
-    logger.info(f"Sparse search for experiment={experiment_id}, model={embedding_model}, k={top_k}")
+    logger.debug(
+        f"Sparse search for experiment={experiment_id}, model={embedding_model}, k={top_k}"
+    )
 
     chunks_collection = get_collection(CHUNKS_COLLECTION)
 
@@ -97,7 +99,7 @@ def sparse_search(
     ]
 
     results = list(chunks_collection.aggregate(pipeline))
-    logger.info(f"Sparse search returned {len(results)} results")
+    logger.debug(f"Sparse search returned {len(results)} results")
 
     return _to_search_results(results, retrieval_method="sparse")
 
@@ -116,7 +118,9 @@ def hybrid_search(
     k=60 is the standard default from the original RRF paper; it softens the
     advantage of rank-1 results and reduces sensitivity to outliers.
     """
-    logger.info(f"Hybrid search for experiment={experiment_id}, model={embedding_model}, k={top_k}")
+    logger.debug(
+        f"Hybrid search for experiment={experiment_id}, model={embedding_model}, k={top_k}"
+    )
 
     dense_results = dense_search(query_embedding, experiment_id, embedding_model, top_k)
     sparse_results = sparse_search(query_text, experiment_id, embedding_model, top_k)
@@ -149,7 +153,7 @@ def hybrid_search(
             )
         )
 
-    logger.info(f"Hybrid search returned {len(merged)} results after RRF merge")
+    logger.debug(f"Hybrid search returned {len(merged)} results after RRF merge")
     return merged
 
 

--- a/server/core/startup_reconciliation.py
+++ b/server/core/startup_reconciliation.py
@@ -1,0 +1,113 @@
+"""Reconcile experiments left in RUNNING after server restart or crash."""
+
+from datetime import datetime
+
+from server.db.atlas import EXPERIMENTS_COLLECTION, RUN_STATUS_COLLECTION, get_collection
+from server.models.enums import ExperimentStatus, Phase
+from server.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+_TERMINAL_RUN_PHASES = frozenset(
+    {
+        Phase.COMPLETE.value,
+        Phase.FAILED.value,
+        Phase.INTERRUPTED.value,
+    }
+)
+
+_ORPHAN_ERROR = "Interrupted — server restarted while run was in progress"
+
+
+def reconcile_orphaned_experiments() -> int:
+    """Mark stale RUNNING experiments after process restart.
+
+    Sweep tasks run in FastAPI BackgroundTasks and live only in memory.
+    Any experiment still RUNNING when the server starts cannot be executing.
+
+    Returns the number of experiments reconciled.
+    """
+    exp_coll = get_collection(EXPERIMENTS_COLLECTION)
+    running = list(exp_coll.find({"status": ExperimentStatus.RUNNING}))
+    if not running:
+        return 0
+
+    run_coll = get_collection(RUN_STATUS_COLLECTION)
+    reconciled = 0
+    for experiment in running:
+        experiment_id = str(experiment["_id"])
+        _reconcile_one(experiment_id, experiment, run_coll, exp_coll)
+        reconciled += 1
+
+    logger.info("Reconciled %s orphaned experiment(s) left in RUNNING", reconciled)
+    return reconciled
+
+
+def _reconcile_one(
+    experiment_id: str,
+    experiment: dict,
+    run_coll,
+    exp_coll,
+) -> None:
+    runs = list(run_coll.find({"experiment_id": experiment_id}))
+    in_flight = [run for run in runs if run.get("phase") not in _TERMINAL_RUN_PHASES]
+    now = datetime.utcnow()
+
+    for run in in_flight:
+        run_coll.update_one(
+            {"run_id": run["run_id"]},
+            {
+                "$set": {
+                    "phase": Phase.INTERRUPTED.value,
+                    "updated_at": now,
+                    "error_message": _ORPHAN_ERROR,
+                }
+            },
+        )
+        logger.warning(
+            "Marked run %s interrupted (was %s) for experiment %s",
+            run["run_id"],
+            run.get("phase"),
+            experiment_id,
+        )
+
+    runs = list(run_coll.find({"experiment_id": experiment_id}))
+    status, failed_count = _derive_experiment_status(experiment, runs)
+    complete_count = sum(1 for run in runs if run.get("phase") == Phase.COMPLETE.value)
+    expected = int(experiment.get("run_count") or 0)
+
+    exp_coll.update_one(
+        {"_id": experiment_id},
+        {
+            "$set": {
+                "status": status,
+                "failed_count": failed_count,
+                "completed_at": now,
+            }
+        },
+    )
+    logger.info(
+        "Experiment %s reconciled → %s (%s/%s runs complete, %s interrupted in-flight, "
+        "%s never started)",
+        experiment_id,
+        status.value,
+        complete_count,
+        expected,
+        len(in_flight),
+        max(0, expected - len(runs)),
+    )
+
+
+def _derive_experiment_status(
+    experiment: dict,
+    runs: list[dict],
+) -> tuple[ExperimentStatus, int]:
+    expected = int(experiment.get("run_count") or 0)
+    complete = sum(1 for run in runs if run.get("phase") == Phase.COMPLETE.value)
+    failed = sum(1 for run in runs if run.get("phase") == Phase.FAILED.value)
+
+    if complete == expected and failed == 0:
+        return ExperimentStatus.COMPLETE, failed
+    if failed == expected or (failed > 0 and complete == 0 and failed == len(runs)):
+        return ExperimentStatus.FAILED, failed
+    return ExperimentStatus.PARTIAL, failed

--- a/server/main.py
+++ b/server/main.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from server.api import experiments, runs
+from server.core.startup_reconciliation import reconcile_orphaned_experiments
 from server.db.indexes import ensure_indexes
 from server.settings import LOCALHOST_CORS_ORIGIN_REGEX, settings
 from server.utils.logger import get_logger
@@ -22,6 +23,15 @@ async def lifespan(app: FastAPI):
         ensure_indexes()
     except Exception as e:
         logger.warning(f"Index check failed (server will start without indexes): {e}")
+    try:
+        reconcile_orphaned_experiments()
+    except Exception as e:
+        logger.error(f"Orphaned experiment reconciliation failed: {e}", exc_info=True)
+    if settings.recover_on_boot:
+        logger.info(
+            "RECOVER_ON_BOOT is enabled; automatic retry of interrupted runs is not "
+            "implemented yet (see docs/slices/SLICE-10-RUN-RECOVERY.md)"
+        )
     logger.info("Server ready")
     yield
     logger.info("Server shutting down...")

--- a/server/settings.py
+++ b/server/settings.py
@@ -43,6 +43,19 @@ class Settings(BaseSettings):
     voyage_rpm_limit: int = 3
     voyage_tpm_limit: int = 10_000
 
+    # Manual cluster storage quota override (MB). When > 0, skips Atlas API auto-detect.
+    # Set MONGODB_STORAGE_LIMIT_MB=0 (default) to auto-detect via Atlas Admin API or hide quota.
+    mongodb_storage_limit_mb: float = 0.0
+
+    # Optional Atlas Admin API credentials for auto-detecting cluster storage quota.
+    # Create keys at cloud.mongodb.com → Organization Access Manager → API Keys.
+    # ATLAS_GROUP_ID is the 24-char project ID from your Atlas project URL.
+    atlas_public_key: str = ""
+    atlas_private_key: str = ""
+    atlas_group_id: str = ""
+    # Leave blank to derive from MONGODB_URI host (e.g. thesandboxcluster.5uaqybx.mongodb.net).
+    atlas_cluster_name: str = ""
+
     @field_validator("cors_origins", mode="before")
     @classmethod
     def parse_cors_origins(cls, value: object) -> list[str]:

--- a/server/utils/log_throttle.py
+++ b/server/utils/log_throttle.py
@@ -1,0 +1,26 @@
+"""Rate-limit repetitive INFO logs from polling endpoints."""
+
+from __future__ import annotations
+
+import logging
+import time
+
+POLL_LOG_INTERVAL_S = 60.0
+
+_last_info_at: dict[str, float] = {}
+
+
+def info_throttled(
+    logger: logging.Logger,
+    key: str,
+    message: str,
+    *args: object,
+    interval_s: float = POLL_LOG_INTERVAL_S,
+) -> None:
+    """Log at INFO at most once per interval; otherwise DEBUG."""
+    now = time.monotonic()
+    if now - _last_info_at.get(key, 0.0) >= interval_s:
+        _last_info_at[key] = now
+        logger.info(message, *args)
+        return
+    logger.debug(message, *args)


### PR DESCRIPTION
## Summary

- Add **vector DB stats** to the dashboard: cluster- and experiment-level MongoDB storage/chunk metrics, collapsible list rows, list-to-detail cache handoff, and Atlas Admin API quota detection (with manual `MONGODB_STORAGE_LIMIT_MB` override).
- **Reconcile orphaned sweeps on server boot** — experiments left `running` after a reload/crash get in-flight runs marked `interrupted` and status recomputed (`partial` / `complete` / `failed`).
- Fix **experiment detail UI** for partial sweeps: compact overview metrics (successful, failed, interrupted, not started), status-accurate outcome banners, and interrupted-run detail panel.

## Test plan

- [ ] Start server; confirm no errors on boot and orphaned `running` experiments are reconciled to terminal status
- [ ] Experiments list: expand rows, verify vector DB stats panel and collapsible sections
- [ ] Experiment detail: partial experiment shows correct metric breakdown (counts sum to total) and "Sweep Incomplete" banner — not green success
- [ ] Complete experiment still shows green success banner and correct counts
- [ ] `GET /experiments/vector-db-stats` and per-experiment db-stats endpoints return expected payloads
- [ ] Pre-commit / CI: ruff, mypy, frontend typecheck + build pass


Made with [Cursor](https://cursor.com)