### PR TITLE
Document vector DB stats, boot reconciliation, and partial sweep UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,9 +58,11 @@ List/detail: dashboard or `GET /experiments` / `GET /experiments/{id}` (see `htt
 
 | File | Purpose |
 |---|---|
-| `server/main.py` | FastAPI app entry; lifespan ensures DB indexes |
+| `server/main.py` | FastAPI app entry; lifespan ensures DB indexes + orphan reconciliation |
 | `server/settings.py` | Centralized pydantic-settings config |
 | `server/core/orchestrator.py` | End-to-end pipeline executor |
+| `server/core/startup_reconciliation.py` | Mark stale `running` experiments on server boot |
+| `server/core/atlas_storage.py` | Atlas Admin API cluster quota + dbStats helpers |
 | `server/core/model_registry.py` | Embedding + reranking model catalog |
 | `server/core/embedder.py` | Voyage embedding client |
 | `server/core/local_embedder.py` | sentence-transformers embedding (lazy-load) |
@@ -69,8 +71,8 @@ List/detail: dashboard or `GET /experiments` / `GET /experiments/{id}` (see `htt
 | `server/core/retriever.py` | Atlas Vector Search (dense/sparse/hybrid) |
 | `server/models/config.py` | Pydantic experiment config + provider validators |
 | `server/models/enums.py` | ChunkingMethod, RetrievalMethod, Phase |
-| `server/api/experiments.py` | Experiments CRUD, results/explore, cancel, delete |
-| `server/api/experiments_shared.py` | Shared delete helpers (cascade deletion logic) |
+| `server/api/experiments.py` | Experiments CRUD, results/explore, db-stats, cancel, delete |
+| `server/api/experiments_shared.py` | Shared Mongo helpers (delete cascade, db-stats aggregation) |
 | `server/db/indexes.py` | Collection + index creation helpers |
 | `cli/main.py` | Typer app (`run`, `cancel`, `delete`, `version`) |
 | `cli/config_loader.py` | YAML parser + model registry validation |
@@ -82,8 +84,11 @@ List/detail: dashboard or `GET /experiments` / `GET /experiments/{id}` (see `htt
 | `frontend/src/components/ExperimentProgressCard.tsx` | Reusable experiment progress card with circular indicator |
 | `frontend/src/components/PollingIndicator.tsx` | Subtle "Syncing..." badge during background polls |
 | `frontend/src/components/ConfirmDeleteModal.tsx` | Delete confirmation modal with experiment details and stats |
-| `frontend/src/components/ExperimentsScreen.tsx` | Experiments list with delete actions (paginated) |
-| `frontend/src/components/ExperimentDetailScreen.tsx` | Experiment detail with delete action in header (paginated) |
+| `frontend/src/components/ExperimentsScreen.tsx` | Experiments list with collapsible rows, vector DB stats, delete |
+| `frontend/src/components/ExperimentDetailScreen.tsx` | Detail view with overview metrics, outcome banners, runs table |
+| `frontend/src/components/VectorDbStatsPanel.tsx` | Cluster-grouped storage stats panel |
+| `frontend/src/components/CollapsibleCard.tsx` | Reusable collapsible section (localStorage persistence) |
+| `frontend/src/utils/experimentStatus.ts` | Run outcome summarization + terminal status helpers |
 | `frontend/src/types/index.ts` | Hand-mirrored TypeScript types from Python models |
 | `frontend/src/services/apiClient.ts` | Fetch wrapper (all server API calls, including DELETE) |
 | `frontend/src/services/fetchWithProgress.ts` | ReadableStream-based fetch with progress tracking |

--- a/README.md
+++ b/README.md
@@ -115,9 +115,10 @@ Open `http://localhost:5173` to watch live progress and explore results.
 - **Multi-format data loading**: PDF, TXT, Markdown, CSV — files or directories
 - **Cartesian sweep**: one YAML config → N models × M methods × P sizes × Q overlaps runs
 - **Live phase tracking**: QUEUED → PARSING → CHUNKING → EMBEDDING → STORING → QUERYING → RERANKING → COMPLETE
-- **Experiment management**: Cancel running experiments, delete experiments with cascade cleanup
+- **Experiment management**: Cancel running experiments, delete experiments with cascade cleanup, boot orphan reconciliation
+- **Vector DB stats**: Cluster and per-experiment chunk/storage estimates in the dashboard; optional Atlas quota bar
 - **Progress feedback**: Byte-level network loading, circular progress indicators, background polling with "Syncing..." badges
-- **Pagination**: All list views paginated (10 items per page for experiments/runs, 5 for configs)
+- **Pagination**: All list views paginated (10 items per page for experiments/runs, 5 for configs); collapsible experiment rows
 
 ---
 

--- a/docs/_internal/PROGRESS.md
+++ b/docs/_internal/PROGRESS.md
@@ -1,7 +1,7 @@
 # rag-params-finder — Build Progress
 
-**Last Updated**: 2026-05-19 (Vector DB stats + collapsible experiment rows — in progress on `feat/vector-db-stats-and-collapsible-cards`)
-**Current**: Slices 1–9 ✅ COMPLETE | 🔨 IN PROGRESS: Vector DB stats panel + collapsible list rows | Next: Slice 10 📋 PLANNED (failed-run recovery) · Slice 11 📋 PLANNED (Search Explorer enhancements) · Slice 16 📋 PLANNED (honor `parallelism`)
+**Last Updated**: 2026-05-19 (Vector DB stats + orphan sweep reconciliation — complete on `feat/vector-db-stats-and-collapsible-cards`)
+**Current**: Slices 1–9 ✅ COMPLETE | Vector DB stats + collapsible rows + boot reconciliation ✅ COMPLETE | Next: Slice 10 📋 PLANNED (failed-run recovery retry) · Slice 11 📋 PLANNED (Search Explorer enhancements) · Slice 16 📋 PLANNED (honor `parallelism`)
 
 ---
 
@@ -18,8 +18,8 @@
 | 7 — Free/local embedding + reranking | ✅ COMPLETE | ~15 min | sentence-transformers, no API key needed |
 | 8 — Dashboard UX improvements | ✅ COMPLETE | ~2 h | Loading feedback panels, polling indicators, pagination, unified chrome |
 | 9 — Experiment deletion | ✅ COMPLETE | ~1 h | CLI delete command + dashboard confirmation modal, cascade cleanup |
-| — — Vector DB stats + collapsible rows | 🔨 IN PROGRESS | ~1 h | `GET /experiments/{id}/db-stats`; detail stats panel; list row collapse (localStorage) |
-| 10 — Run recovery | 📋 PLANNED | ~1–2 h | Retry FAILED `(± INTERRUPTED)` runs in-place; see [`SLICE-10-RUN-RECOVERY.md`](../slices/SLICE-10-RUN-RECOVERY.md) |
+| — — Vector DB stats + collapsible rows + boot reconciliation | ✅ COMPLETE | ~1.5 h | Cluster/experiment storage stats; collapsible panels; orphan `running` → `partial` on server boot |
+| 10 — Run recovery (retry) | 📋 PLANNED | ~1–2 h | Retry FAILED `(± INTERRUPTED)` runs in-place; boot **reconciliation** done; **retry** not yet — see [`SLICE-10-RUN-RECOVERY.md`](../slices/SLICE-10-RUN-RECOVERY.md) |
 | 11 — Search Explorer enhancements | 📋 PLANNED | ~1 h | Better visualization, export results, query filtering improvements |
 | 16 — Parallel sweep execution | 📋 PLANNED | ~2–4 h | Bounded concurrent `_run_single`; see [`SLICE-16-PARALLEL-SWEEP-RUNS.md`](../slices/SLICE-16-PARALLEL-SWEEP-RUNS.md) |
 
@@ -411,6 +411,46 @@ Manually verified:
 
 ---
 
+## Vector DB Stats + Collapsible Rows + Boot Reconciliation ✅
+
+**Status**: ✅ COMPLETE | **Started**: 2026-05-19 | **Completed**: 2026-05-19 | **Target**: ~1.5 h
+
+### Goal
+Surface MongoDB/Atlas storage footprint in the dashboard, improve experiments list UX with collapsible rows, and automatically fix experiments left `running` after server restart or crash.
+
+### What Changed
+- **NEW**: `server/core/atlas_storage.py` — Atlas Admin API cluster quota lookup + `dbStats` footprint; manual `MONGODB_STORAGE_LIMIT_MB` override
+- **NEW**: `server/core/startup_reconciliation.py` — on boot, mark in-flight runs `interrupted` and recompute experiment status (`partial` / `complete` / `failed`)
+- **NEW**: `server/utils/log_throttle.py` — throttle repetitive polling log lines
+- **EDIT**: `server/api/experiments_shared.py` — `mongo_get_experiment_db_stats`, `mongo_get_vector_db_stats_grouped`
+- **EDIT**: `server/api/experiments.py` — `GET /experiments/vector-db-stats`, `GET /experiments/{id}/db-stats`
+- **EDIT**: `server/main.py` — call `reconcile_orphaned_experiments()` in lifespan
+- **NEW**: `frontend/src/components/CollapsibleCard.tsx`, `VectorDbStatsPanel.tsx`, `ExperimentVectorDbStatsCard.tsx`
+- **NEW**: `frontend/src/utils/experimentStatus.ts` — `summarizeExperimentRuns()` for outcome buckets
+- **EDIT**: `frontend/src/components/ExperimentsScreen.tsx` — collapsible list rows, cluster stats panel, list→detail cache handoff
+- **EDIT**: `frontend/src/components/ExperimentDetailScreen.tsx` — compact overview metrics (successful / failed / interrupted / not started), status-accurate outcome banners
+- **EDIT**: `.env.example` — Atlas Admin API + storage limit vars
+
+### Key Design Decisions
+| Decision | Why |
+|---|---|
+| Reconcile orphans on every boot (not gated by `RECOVER_ON_BOOT`) | Status correction is safe and idempotent; retry remains opt-in via Slice 10 |
+| `partial` when sweep incomplete | Distinguishes “41/90 complete + 48 never started” from green `complete` |
+| Atlas quota via Admin API with manual fallback | M0 tier limits vary; hardcoded 512 MB was misleading |
+| Outcome metrics from `run_status` phases | `run_count - failed_count` lied when runs never started |
+| Collapsible state in `localStorage` | Per-panel persistence without server round-trips |
+
+### Acceptance Criteria
+- [x] `GET /experiments/vector-db-stats` returns grouped cluster stats
+- [x] `GET /experiments/{id}/db-stats` returns per-experiment chunk/storage breakdown
+- [x] Experiments list shows collapsible rows + vector DB stats panel
+- [x] Experiment detail shows run-outcome buckets that sum to total runs
+- [x] Partial experiments show “Sweep Incomplete” — not green success banner
+- [x] Server boot reconciles stale `running` experiments to terminal status
+- [x] Pre-commit hooks pass
+
+---
+
 ## Slice 6: Additional Chunkers + Retrieval Methods ✅
 
 **Status**: ✅ COMPLETE | **Started**: 2026-05-17 | **Completed**: 2026-05-17 | **Target**: ~45 min
@@ -483,6 +523,9 @@ Implement the 4 stubbed chunkers (fixed, token, sentence, semantic), add sparse/
 | 2026-05-17 | 8 | Pagination defaults 10 (lists) / 5 (configs) | Prevents DOM overload and cognitive fatigue; configs more verbose so lower per-page count |
 | 2026-05-17 | 8 | initialLoadDone flag per screen | Polling indicator only shows after first load completes; avoids visual confusion during hydration |
 | 2026-05-18 | 8 | ExperimentProgressCard reusable component | Extracted circular progress pattern from detail screen; enables consistent progress visualization across screens; separates network progress (LoadingFeedbackPanel) from execution progress (ExperimentProgressCard) |
+| 2026-05-19 | — | Boot orphan reconciliation always on | BackgroundTasks die on reload; Mongo `running` must be corrected without waiting for Slice 10 retry |
+| 2026-05-19 | — | Run outcome buckets in dashboard | successful + failed + interrupted + not started must sum to `run_count`; fixes misleading partial UI |
+| 2026-05-19 | — | Atlas storage quota via Admin API | Avoid hardcoded M0 512 MB; optional manual `MONGODB_STORAGE_LIMIT_MB` override |
 
 ---
 

--- a/docs/contributor-guide/architecture.md
+++ b/docs/contributor-guide/architecture.md
@@ -95,14 +95,16 @@ FastAPI Server
 ```
 rag-params-finder/
 ├── server/
-│   ├── main.py              # FastAPI app entry; lifespan ensures DB indexes
+│   ├── main.py              # FastAPI app entry; lifespan: indexes + orphan reconciliation
 │   ├── settings.py          # Centralized pydantic-settings config
 │   ├── api/
-│   │   ├── experiments.py   # experiments CRUD, results/explore, cancel, delete
-│   │   ├── experiments_shared.py  # shared delete helpers (cascade deletion)
+│   │   ├── experiments.py   # CRUD, explore, db-stats, cancel, delete
+│   │   ├── experiments_shared.py  # Mongo helpers incl. db-stats aggregation
 │   │   └── runs.py          # GET /runs/{id}/status
 │   ├── core/
 │   │   ├── orchestrator.py  # run_sweep() + run_single() pipeline
+│   │   ├── startup_reconciliation.py  # fix stale running experiments on boot
+│   │   ├── atlas_storage.py # Atlas Admin API quota + dbStats footprint
 │   │   ├── pdf_parser.py    # pypdf text extraction
 │   │   ├── query_loader.py  # persona JSON → Query dataclass list
 │   │   ├── model_registry.py  # embedding + reranking model catalog
@@ -139,12 +141,18 @@ rag-params-finder/
     │   ├── ExperimentProgressCard.tsx  # experiment progress card (circular indicator, reusable)
     │   ├── PollingIndicator.tsx        # subtle "Syncing..." indicator during polls
     │   ├── ConfirmDeleteModal.tsx      # delete confirmation modal with experiment details
-    │   ├── ExperimentsScreen.tsx       # list view (polling every 2s, paginated, delete actions)
-    │   ├── ExperimentDetailScreen.tsx  # detail view (runs table, phase dots, metrics, paginated, delete action)
+    │   ├── CollapsibleCard.tsx         # reusable collapsible section (localStorage state)
+    │   ├── VectorDbStatsPanel.tsx      # cluster-grouped storage stats (experiments list)
+    │   ├── ExperimentVectorDbStatsCard.tsx  # per-experiment db-stats on detail screen
+    │   ├── ExperimentsScreen.tsx       # list view (collapsible rows, vector DB stats, delete)
+    │   ├── ExperimentDetailScreen.tsx  # overview metrics, outcome banners, runs table
     │   └── SearchExplorerScreen.tsx    # results analysis (ranked configs, per-query, paginated)
     ├── services/
     │   ├── apiClient.ts       # fetch wrapper (all server API calls)
     │   └── fetchWithProgress.ts  # streamed fetch with byte-level progress tracking
+    ├── utils/
+    │   ├── experimentStatus.ts   # terminal/running helpers + summarizeExperimentRuns()
+    │   └── experimentDbStats.ts  # db-stats response normalizers
     └── types/index.ts         # hand-mirrored TypeScript types from Python models
 ```
 
@@ -219,6 +227,8 @@ See `docs/adr/` for Architecture Decision Records:
 | Dual loading indicators (panel + polling badge) | Initial load → full progress panel; background polls → subtle "Syncing..." badge; clear state transitions |
 | Two progress patterns (network vs experiment) | `LoadingFeedbackPanel` for network/API loads (byte-level); `ExperimentProgressCard` for experiment execution (run completion); distinct concerns, reusable components |
 | Cascade delete with confirmation | DELETE endpoint scrubs all collections (experiments, run_status, chunks, results); `ConfirmDeleteModal` shows experiment details + deletion statistics; prevents deletion of running experiments |
+| Boot orphan reconciliation | `BackgroundTasks` sweeps die on process exit; startup marks in-flight runs `interrupted` and sets terminal experiment status — separate from Slice 10 retry |
+| Vector DB stats API + dashboard | `GET /experiments/vector-db-stats` and `/{id}/db-stats`; estimated storage from chunk counts + model dimensions; optional Atlas quota bar |
 
 ---
 
@@ -226,7 +236,7 @@ See `docs/adr/` for Architecture Decision Records:
 
 | Enhancement | Notes |
 |---|---|
-| Run recovery (failed / interrupted runs) | Planned as [Slice 10 — Run Recovery](../slices/SLICE-10-RUN-RECOVERY.md): `recover` CLI + API; per-`run_id` artifact scrub; **`RECOVER_ON_BOOT`** = **INTERRUPTED** only |
+| Run recovery (retry failed / interrupted runs) | **Reconciliation on boot** ✅ — status fix only. **Retry** planned as [Slice 10](../slices/SLICE-10-RUN-RECOVERY.md): `recover` CLI + API; **`RECOVER_ON_BOOT`** = retry **INTERRUPTED** only |
 | SSE live updates | Replace 2-second polling with Server-Sent Events |
 | Parallel sweep (`execution.parallelism` > 1) | Planned as [Slice 16 — Parallel Sweep Runs](../slices/SLICE-16-PARALLEL-SWEEP-RUNS.md); bounded in-process pool first; **Celery + Redis** when multi-process fairness or isolation is needed |
 | Dashboard-triggered runs | Submit experiments from the React UI, not just CLI |

--- a/docs/contributor-guide/local-environment.md
+++ b/docs/contributor-guide/local-environment.md
@@ -78,17 +78,26 @@ VOYAGE_API_KEY=vo-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 SERVER_URL=http://localhost:8001
 
 # Rate limits (Voyage only — set based on your tier)
-VOYAGE_RPM_LIMIT=300
-VOYAGE_TPM_LIMIT=1000000
+VOYAGE_RPM_LIMIT=3
+VOYAGE_TPM_LIMIT=10000
 
-# Optional — stored in experiment metadata / dashboard (“Recover on Boot”); no runtime retry on boot yet (planned: docs/slices/SLICE-10-RUN-RECOVERY.md — boot = INTERRUPTED only).
+# Optional — Atlas Admin API for dashboard storage quota bar
+# ATLAS_PUBLIC_KEY=
+# ATLAS_PRIVATE_KEY=
+# ATLAS_GROUP_ID=                         # 24-char project ID from Atlas URL
+# ATLAS_CLUSTER_NAME=                     # omit to parse from MONGODB_URI host
+# MONGODB_STORAGE_LIMIT_MB=512            # manual override (MB); 0 = try API
+
+# Optional — stored in experiment metadata / dashboard (“Recover on Boot”).
+# Status reconciliation on boot always runs (marks stale running → partial).
+# Automatic retry of interrupted runs is not implemented yet (Slice 10).
 RECOVER_ON_BOOT=false
 
 # Logging
 LOG_LEVEL=INFO   # DEBUG for verbose output
 ```
 
-Slice 10 *(planned)* documents CLI/API recovery and boot semantics: [`SLICE-10-RUN-RECOVERY.md`](../slices/SLICE-10-RUN-RECOVERY.md).
+Slice 10 *(planned)* documents CLI/API **retry** of failed/interrupted runs: [`SLICE-10-RUN-RECOVERY.md`](../slices/SLICE-10-RUN-RECOVERY.md). **Boot status reconciliation** (fix stale `running` experiments) is already implemented in `server/core/startup_reconciliation.py`.
 
 **Never commit `.env` to git** — it is in `.gitignore`.
 

--- a/docs/slices/SLICE-10-RUN-RECOVERY.md
+++ b/docs/slices/SLICE-10-RUN-RECOVERY.md
@@ -2,7 +2,7 @@
 
 **MoSCoW:** COULD *(ops ergonomics; workarounds today are manual YAML subsets or Mongo cleanup + resubmit)*
 **Target time:** ~1–2 h *(CLI + API + orchestration hooks; boot path is a small add-on if scoped narrowly)*
-**Status:** 📋 PLANNED
+**Status:** 🔨 PARTIAL — boot **status reconciliation** shipped; **retry** CLI/API still planned
 
 ---
 
@@ -15,7 +15,8 @@ Today:
 - `rag-params-finder run` always creates a **new** `experiment_id` and `run_sweep` assigns a **fresh** `run_id` per sweep row.
 - Partial sweeps (`on_error: continue`) yield experiment status **PARTIAL** with a mix of **COMPLETE** and **FAILED** runs.
 - Cancellation marks in-flight runs **INTERRUPTED**.
-- **`RECOVER_ON_BOOT`** is stored in metadata for the dashboard only — **no** server startup retry is implemented.
+- **Boot reconciliation** *(implemented)*: on server start, experiments still `running` get in-flight runs marked **INTERRUPTED** and status recomputed (`partial` / `complete` / `failed`). See `server/core/startup_reconciliation.py`.
+- **`RECOVER_ON_BOOT`** retry of interrupted runs is **not** implemented yet — flag is metadata-only until Slice 10 ships.
 - The only supported workflow for “redo the bad ones” is trimming YAML (or multiple YAMLs) and submitting a **new** experiment.
 
 ---
@@ -51,12 +52,9 @@ Recovery should **reuse the same `run_id`** for a retried run so dashboards, URL
 
 ## `RECOVER_ON_BOOT` Semantics *(narrow scope)*
 
-To avoid endlessly retrying **FAILED** runs caused by bad configs:
+**Already shipped (status only):** `server/main.py` lifespan calls `reconcile_orphaned_experiments()` on **every** boot — not gated by `RECOVER_ON_BOOT`. This fixes MongoDB status when the process died mid-sweep; it does **not** re-execute runs.
 
-- **Boot path** *(when implemented)* should target **INTERRUPTED** runs only *(process died mid-sweep)*, **not** all historical **FAILED** rows.
-- Optional future: allow opt-in `--also-failed` for advanced operators *(YAGNI until asked)*.
-
-Wire `settings.recover_on_boot` in `server/main.py` lifespan (or a small startup task) to enqueue the same recovery engine as the CLI — **same code path**.
+**Still planned (retry):** When `RECOVER_ON_BOOT=true`, enqueue the same recovery engine as the CLI to **retry INTERRUPTED** runs only *(process died mid-sweep)* — **not** all historical **FAILED** rows.
 
 ---
 
@@ -68,6 +66,7 @@ Wire `settings.recover_on_boot` in `server/main.py` lifespan (or a small startup
 | `cli/api_client.py` | POST recover endpoint |
 | `server/api/experiments.py` | `POST /experiments/{id}/recover`; BackgroundTask for recovery sweep |
 | `server/core/orchestrator.py` | `recover_failed_runs(...)` or extend `run_sweep` with a “recovery mode”; shared cleanup helper |
+| `server/core/startup_reconciliation.py` | ✅ Boot status fix *(shipped)* — mark orphans `interrupted`, recompute experiment status |
 | `server/api/experiments_shared.py` *(or new db helper)* | Bulk delete chunks/results by `run_id`; experiment status recomputation |
 | `docs/user-guide/cli-reference.md` | Document `recover` |
 | `docs/_internal/PROGRESS.md` | Mark slice complete; decision log |

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -125,7 +125,9 @@ The server exposes a REST API at `http://localhost:8001`. Full interactive docs 
 | GET | `/healthz` | Health check — returns `{"ok": true}` |
 | POST | `/experiments` | Submit an experiment sweep |
 | GET | `/experiments` | List all experiments |
+| GET | `/experiments/vector-db-stats` | Cluster-grouped vector DB / storage stats for all experiments |
 | GET | `/experiments/{id}` | Get experiment details + run statuses |
+| GET | `/experiments/{id}/db-stats` | Per-experiment chunk counts, storage estimates, index names |
 | GET | `/experiments/{id}/results` | Get query results for an experiment |
 | GET | `/experiments/{id}/explore` | Get data for the Search Explorer screen |
 | POST | `/experiments/{id}/cancel` | Request cancellation while status is running |

--- a/docs/user-guide/dashboard-guide.md
+++ b/docs/user-guide/dashboard-guide.md
@@ -29,6 +29,10 @@ The landing screen shows all submitted experiments, newest first.
 
 **Pagination**: Shows 10 experiments per page. Navigate using Previous/Next buttons at the bottom.
 
+**Collapsible rows**: Click the chevron on a row to expand inline details without leaving the list. Expansion state is remembered per experiment (`localStorage`).
+
+**Vector DB stats panel** (top of list): Aggregated storage footprint for your Atlas cluster — total chunks, estimated embedding storage, active index names, and per-experiment breakdown. Polls `GET /experiments/vector-db-stats` on refresh. Cluster quota bar appears when Atlas Admin API credentials or `MONGODB_STORAGE_LIMIT_MB` is configured.
+
 **Actions**:
 - **View details**: Click any row to open the Experiment Detail screen
 - **Delete**: Click the trash icon button in the Actions column to delete an experiment (confirmation required)
@@ -39,9 +43,9 @@ The landing screen shows all submitted experiments, newest first.
 
 | Badge | Color | Meaning |
 |---|---|---|
-| `complete` | Green | All runs finished successfully |
+| `complete` | Green | All planned runs finished successfully |
 | `running` | Blue | One or more runs still active |
-| `partial` | Yellow | Some runs completed, some failed |
+| `partial` | Yellow | Sweep stopped early — some runs complete, some failed/interrupted, and/or some parameter combos never started |
 | `failed` | Red | All runs failed |
 | `cancelled` | Gray | Experiment was cancelled |
 
@@ -49,13 +53,33 @@ The landing screen shows all submitted experiments, newest first.
 
 ### 🔬 Experiment Detail
 
-Opened by clicking a row in the Experiments List. Polls every 2 seconds while status is non-terminal.
+Opened by clicking a row in the Experiments List. Polls every 2 seconds while status is non-terminal. List→detail navigation reuses cached experiment payloads when available to reduce duplicate fetches.
 
-**Metric cards** (top row):
-- Total Runs — number of config combinations in the sweep
-- Successful — runs that reached COMPLETE
-- Failed — runs that hit an error
-- Avg Duration — mean elapsed time across completed runs
+**Overview panel** (top): Status badge, action buttons, and compact run-outcome metrics in one card:
+
+| Metric | Meaning |
+|---|---|
+| Total | Planned sweep size (`run_count` from config) |
+| Successful | Runs that reached `COMPLETE` |
+| Failed | Runs that ended in `FAILED` |
+| Interrupted | Runs stopped mid-pipeline (cancel or server restart) |
+| Not Started | Parameter combos never queued — sweep stopped before reaching them |
+| In Progress | Runs currently executing *(running experiments only)* |
+| Duration | Wall time from `started_at` to `completed_at` |
+
+These buckets always sum to **Total** on terminal experiments.
+
+**Outcome banners** (below runs table):
+
+| Status | Banner |
+|---|---|
+| `complete` | Green — all planned runs succeeded |
+| `partial` | Amber — “Sweep Incomplete” with breakdown (e.g. 41/90 complete, 48 never started) |
+| `cancelled` | Gray — runs completed before cancellation |
+| Failed runs | Red panel listing `error_message` per run |
+| Interrupted runs | Amber panel listing interruption reason |
+
+**Vector DB stats card**: Collapsible panel with per-experiment chunk counts, embedding model breakdown, estimated storage, and index names. Loaded from `GET /experiments/{id}/db-stats`.
 
 **Phase indicator dots**: one row of colored dots per run, representing each pipeline phase in order:
 
@@ -68,7 +92,7 @@ QUEUED → PARSING → CHUNKING → EMBEDDING → STORING → QUERYING → RERAN
 | Green | Phase completed |
 | Blue pulsing | Phase currently active |
 | Gray | Phase not yet started |
-| Red | Phase failed |
+| Red | Phase failed or run interrupted |
 
 **Runs table**: each row is one config combination (model + chunking method + chunk size + overlap + retrieval method). Expand a row to see per-query results with dense scores and rerank scores.
 
@@ -151,7 +175,7 @@ For **running experiments**, the Experiment Detail screen shows an **Experiment 
 - Completion status (e.g., "1 of 2 runs completed")
 - Visual feedback: blue gradient background, green progress ring
 
-This card appears **only when status is "running"** and updates every 2 seconds via background polling. Once the experiment completes, the card is replaced with a success/failure summary.
+This card appears **only when status is "running"** and updates every 2 seconds via background polling. Progress is measured against **planned** run count (`run_count`), not just runs already in `run_status`. Once the experiment reaches a terminal status, the card is replaced with the outcome banner described above.
 
 **Note**: This is distinct from network loading — the Loading Feedback Panel tracks API data transfer, while the Experiment Progress Card tracks pipeline execution (runs completing).
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -55,11 +55,15 @@ MONGODB_URI=mongodb+srv://<user>:<pass>@<cluster>.mongodb.net/rag_params_finder?
 # Optional — only needed for Voyage models
 VOYAGE_API_KEY=vo-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
-# Optional — defaults shown
+# Optional — defaults shown (free-tier Voyage limits)
 SERVER_URL=http://localhost:8001
-VOYAGE_RPM_LIMIT=300
-VOYAGE_TPM_LIMIT=1000000
+VOYAGE_RPM_LIMIT=3
+VOYAGE_TPM_LIMIT=10000
 LOG_LEVEL=INFO
+
+# Optional — dashboard cluster storage quota bar (Atlas Admin API)
+# ATLAS_PUBLIC_KEY= / ATLAS_PRIVATE_KEY= / ATLAS_GROUP_ID=
+# Or set MONGODB_STORAGE_LIMIT_MB=512 for a manual quota override
 ```
 
 **MongoDB Atlas setup** (one-time):

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -141,6 +141,33 @@ embedding:
 
 ---
 
+## 🔁 Experiment stuck `running` or shows `partial` after server restart
+
+**Symptom**: Dashboard shows an experiment as `running` for hours/days, or `partial` with many “Not Started” runs after you restarted uvicorn (`--reload`) or the server crashed mid-sweep.
+
+**Cause**: Sweep execution runs in FastAPI `BackgroundTasks` (in-memory only). When the process dies, MongoDB may still show `status: running` and in-flight runs mid-phase — even though nothing is executing.
+
+**Automatic fix (server ≥ 2026-05-19)**: On every server start, `reconcile_orphaned_experiments()` in `server/core/startup_reconciliation.py`:
+
+1. Finds experiments still marked `running`
+2. Marks in-flight runs as `interrupted` with error *“Interrupted — server restarted while run was in progress”*
+3. Recomputes experiment status → usually `partial` when some runs completed and others never started
+
+**What to do**:
+
+1. Restart the server once — reconciliation runs at startup (check logs for `Reconciled N orphaned experiment(s)`)
+2. On the detail screen, verify outcome metrics: **Successful + Failed + Interrupted + Not Started = Total**
+3. To finish remaining parameter combos, either submit a trimmed YAML for the missing combos, or wait for Slice 10 `recover` (retry in-place)
+
+**Prevention during long sweeps**:
+
+- Avoid editing server code (triggers `--reload`) while a large sweep is running
+- Run uvicorn **without** `--reload` for production-length sweeps: `uvicorn server.main:app --port 8001`
+
+**Note**: `RECOVER_ON_BOOT=true` does **not** yet retry interrupted runs — it only logs a reminder. Status reconciliation always runs regardless of that flag.
+
+---
+
 ## 🌀 Dashboard stuck on "Loading…"
 
 **Symptom**: browser shows a loading spinner indefinitely or a "Failed to fetch" error.
@@ -217,9 +244,14 @@ db.results.deleteMany({experiment_id: exp_id})
 | `MONGODB_URI` | Yes | — | MongoDB Atlas connection string |
 | `VOYAGE_API_KEY` | No | — | Voyage AI API key (only if using Voyage models) |
 | `SERVER_URL` | No | `http://localhost:8001` | FastAPI server URL (used by CLI) |
-| `VOYAGE_RPM_LIMIT` | No | `300` | Voyage requests-per-minute limit (throttle guard) |
-| `VOYAGE_TPM_LIMIT` | No | `1000000` | Voyage tokens-per-minute limit |
-| `RECOVER_ON_BOOT` | No | `false` | Persisted into experiment metadata for the dashboard only; **does not** start or retry runs on server boot yet. When implemented ([Slice 10](../slices/SLICE-10-RUN-RECOVERY.md)), boot recovery will target **INTERRUPTED** runs only — not every **FAILED** run. |
+| `VOYAGE_RPM_LIMIT` | No | `3` | Voyage requests-per-minute limit (throttle guard; free-tier default) |
+| `VOYAGE_TPM_LIMIT` | No | `10000` | Voyage tokens-per-minute limit (free-tier default) |
+| `ATLAS_PUBLIC_KEY` | No | — | Atlas Admin API public key — enables cluster storage quota in dashboard |
+| `ATLAS_PRIVATE_KEY` | No | — | Atlas Admin API private key |
+| `ATLAS_GROUP_ID` | No | — | 24-char Atlas **project** ID (from cloud.mongodb.com URL) |
+| `ATLAS_CLUSTER_NAME` | No | *(from URI)* | Cluster name for quota lookup; parsed from `MONGODB_URI` host if omitted |
+| `MONGODB_STORAGE_LIMIT_MB` | No | `0` | Manual cluster quota override (MB). `0` = try Atlas API; omit quota bar if unavailable |
+| `RECOVER_ON_BOOT` | No | `false` | Stored in experiment metadata for the dashboard. **Status reconciliation on boot always runs.** Automatic **retry** of interrupted runs is not implemented yet ([Slice 10](../slices/SLICE-10-RUN-RECOVERY.md)). |
 | `LOG_LEVEL` | No | `INFO` | Logging verbosity (`DEBUG` for verbose output) |
 
 ---


### PR DESCRIPTION
## Summary

- Update dashboard, troubleshooting, and getting-started guides for vector DB stats panels, run-outcome metrics, and partial sweep status
- Document boot orphan reconciliation (`startup_reconciliation.py`) and clarify Slice 10 scope (status fix shipped, retry still planned)
- Add db-stats API endpoints to CLI reference; refresh architecture module map, PROGRESS.md, CLAUDE.md, and README

## Test plan

- [ ] Docs render correctly on GitHub (links, tables, code blocks)
- [ ] Cross-references to Slice 10 and env vars match `.env.example`
- [ ] No stale claims that `RECOVER_ON_BOOT` triggers retry (reconciliation only)


Made with [Cursor](https://cursor.com)