### PR TITLE
Pause/resume sweeps, Voyage model expansion, and cloud setup guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,8 @@ VOYAGE_API_KEY=your_voyage_api_key_here
 # ──────────────────────────────────────────────────────────────────────────────
 # Free tier (no payment method): 3 RPM, 10 000 TPM.
 # Tier 1 (payment method added — free tokens still apply):
-#   voyage-3.5-lite / voyage-4-lite  → 2 000 RPM, 16M TPM
-#   voyage-3.5 / voyage-4            → 2 000 RPM,  8M TPM
+#   voyage-4-lite / voyage-3.5-lite  → 2 000 RPM, 16M TPM
+#   voyage-4 / voyage-3.5            → 2 000 RPM,  8M TPM
 #   rerank-2.5-lite                  → 2 000 RPM,  4M TPM
 #   rerank-2.5                       → 2 000 RPM,  2M TPM
 # Tier 2 (≥$100 paid): 2× Tier 1.  Tier 3 (≥$1000 paid): 3× Tier 1.
@@ -21,16 +21,17 @@ VOYAGE_API_KEY=your_voyage_api_key_here
 # If you add a payment method, override via .env with your higher limits:
 #
 #   VOYAGE_RPM_LIMIT=2000     # Tier 1 (requests per minute)
-#   VOYAGE_TPM_LIMIT=16000000 # Tier 1, voyage-3.5-lite (tokens per minute)
+#   VOYAGE_TPM_LIMIT=16000000 # Tier 1, voyage-4-lite / voyage-3.5-lite (tokens per minute)
 #
 # Voyage pricing & free tokens:
 #   https://docs.voyageai.com/docs/pricing
 #   200M free tokens for Voyage series 3 models.
 #
-# To unlock Tier 1 rate limits, add a payment method at:
-#   https://dashboard.voyageai.com/
+# REQUIRED for Tier 1: add a payment method (billing page). Until then Voyage enforces
+# 3 RPM / 10K TPM org-wide — the dashboard will show a reminder. Free 200M tokens for
+# Voyage series 3 still apply after you add payment.
+#   https://dashboard.voyageai.com/organization/billing/payment-methods
 # Limits increase within a few minutes after adding payment.
-# Free tokens still apply even with a payment method.
 # ──────────────────────────────────────────────────────────────────────────────
 #
 # requests per minute

--- a/.env.example
+++ b/.env.example
@@ -1,47 +1,13 @@
-# Voyage AI API Key
-# Get yours at: https://dash.voyageai.com/
-# NOTE: Not required if using only local models (all-MiniLM-L6-v2 + cross-encoder reranker).
-#       Leave blank or omit to run fully offline with configs/example-local.yaml.
+# ── Minimum for sweeps ────────────────────────────────────────────────────────
+# Local sweep (example-mongodb-local.yaml):  MONGODB_URI only
+# Voyage sweep (example-mongodb-voyage.yaml): MONGODB_URI + VOYAGE_API_KEY + Tier 1 limits below
+# Full checklist: docs/user-guide/cloud-setup.md#before-you-run-a-sweep
 VOYAGE_API_KEY=your_voyage_api_key_here
+# Voyage rate limits — free tier defaults below; override for Tier 1 (Voyage sweep)
+VOYAGE_RPM_LIMIT=3          # Tier 1 Voyage sweep: 2000
+VOYAGE_TPM_LIMIT=10000      # Tier 1 Voyage sweep: 16000000
 
-# ──────────────────────────────────────────────────────────────────────────────
-# Voyage AI Rate Limits
-# ──────────────────────────────────────────────────────────────────────────────
-# Free tier (no payment method): 3 RPM, 10 000 TPM.
-# Tier 1 (payment method added — free tokens still apply):
-#   voyage-4-lite / voyage-3.5-lite  → 2 000 RPM, 16M TPM
-#   voyage-4 / voyage-3.5            → 2 000 RPM,  8M TPM
-#   rerank-2.5-lite                  → 2 000 RPM,  4M TPM
-#   rerank-2.5                       → 2 000 RPM,  2M TPM
-# Tier 2 (≥$100 paid): 2× Tier 1.  Tier 3 (≥$1000 paid): 3× Tier 1.
-# Full table: https://docs.voyageai.com/docs/rate-limits
-#
-# The server defaults to free-tier limits (3 RPM, 10 000 TPM) and
-# auto-throttles all Voyage API calls (embed + rerank) accordingly.
-# If you add a payment method, override via .env with your higher limits:
-#
-#   VOYAGE_RPM_LIMIT=2000     # Tier 1 (requests per minute)
-#   VOYAGE_TPM_LIMIT=16000000 # Tier 1, voyage-4-lite / voyage-3.5-lite (tokens per minute)
-#
-# Voyage pricing & free tokens:
-#   https://docs.voyageai.com/docs/pricing
-#   200M free tokens for Voyage series 3 models.
-#
-# REQUIRED for Tier 1: add a payment method (billing page). Until then Voyage enforces
-# 3 RPM / 10K TPM org-wide — the dashboard will show a reminder. Free 200M tokens for
-# Voyage series 3 still apply after you add payment.
-#   https://dashboard.voyageai.com/organization/billing/payment-methods
-# Limits increase within a few minutes after adding payment.
-# ──────────────────────────────────────────────────────────────────────────────
-#
-# requests per minute
-VOYAGE_RPM_LIMIT=3
-
-# tokens per minute
-VOYAGE_TPM_LIMIT=10000
-
-# MongoDB Atlas Connection String
-# Format: mongodb+srv://username:password@cluster.mongodb.net/dbname?retryWrites=true&w=majority
+# MongoDB Atlas — required for all sweeps
 MONGODB_URI=your_mongodb_atlas_uri_here
 
 # Optional — auto-detect cluster storage quota for the dashboard (Atlas Admin API).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,8 @@ Agent session entry point for `rag-params-finder`.
 # Backend
 uvicorn server.main:app --reload --port 8001   # start server
 rag-params-finder run --config configs/example-mongodb-local.yaml  # submit experiment
+rag-params-finder pause <experiment-id>   # pause after current phase
+rag-params-finder resume <experiment-id>  # continue paused sweep
 uv pip install -e ".[dev]" && uv run ruff check . && uv run mypy server/ cli/ && uv run pytest
 
 # Frontend

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,9 +58,11 @@ List/detail: dashboard or `GET /experiments` / `GET /experiments/{id}` (see `htt
 
 | File | Purpose |
 |---|---|
-| `server/main.py` | FastAPI app entry; lifespan ensures DB indexes |
+| `server/main.py` | FastAPI app entry; lifespan ensures DB indexes + orphan reconciliation |
 | `server/settings.py` | Centralized pydantic-settings config |
 | `server/core/orchestrator.py` | End-to-end pipeline executor |
+| `server/core/startup_reconciliation.py` | Mark stale `running` experiments on server boot |
+| `server/core/atlas_storage.py` | Atlas Admin API cluster quota + dbStats helpers |
 | `server/core/model_registry.py` | Embedding + reranking model catalog |
 | `server/core/embedder.py` | Voyage embedding client |
 | `server/core/local_embedder.py` | sentence-transformers embedding (lazy-load) |
@@ -69,8 +71,8 @@ List/detail: dashboard or `GET /experiments` / `GET /experiments/{id}` (see `htt
 | `server/core/retriever.py` | Atlas Vector Search (dense/sparse/hybrid) |
 | `server/models/config.py` | Pydantic experiment config + provider validators |
 | `server/models/enums.py` | ChunkingMethod, RetrievalMethod, Phase |
-| `server/api/experiments.py` | Experiments CRUD, results/explore, cancel, delete |
-| `server/api/experiments_shared.py` | Shared delete helpers (cascade deletion logic) |
+| `server/api/experiments.py` | Experiments CRUD, results/explore, db-stats, cancel, delete |
+| `server/api/experiments_shared.py` | Shared Mongo helpers (delete cascade, db-stats aggregation) |
 | `server/db/indexes.py` | Collection + index creation helpers |
 | `cli/main.py` | Typer app (`run`, `cancel`, `delete`, `version`) |
 | `cli/config_loader.py` | YAML parser + model registry validation |
@@ -82,8 +84,11 @@ List/detail: dashboard or `GET /experiments` / `GET /experiments/{id}` (see `htt
 | `frontend/src/components/ExperimentProgressCard.tsx` | Reusable experiment progress card with circular indicator |
 | `frontend/src/components/PollingIndicator.tsx` | Subtle "Syncing..." badge during background polls |
 | `frontend/src/components/ConfirmDeleteModal.tsx` | Delete confirmation modal with experiment details and stats |
-| `frontend/src/components/ExperimentsScreen.tsx` | Experiments list with delete actions (paginated) |
-| `frontend/src/components/ExperimentDetailScreen.tsx` | Experiment detail with delete action in header (paginated) |
+| `frontend/src/components/ExperimentsScreen.tsx` | Experiments list with collapsible rows, vector DB stats, delete |
+| `frontend/src/components/ExperimentDetailScreen.tsx` | Detail view with overview metrics, outcome banners, runs table |
+| `frontend/src/components/VectorDbStatsPanel.tsx` | Cluster-grouped storage stats panel |
+| `frontend/src/components/CollapsibleCard.tsx` | Reusable collapsible section (localStorage persistence) |
+| `frontend/src/utils/experimentStatus.ts` | Run outcome summarization + terminal status helpers |
 | `frontend/src/types/index.ts` | Hand-mirrored TypeScript types from Python models |
 | `frontend/src/services/apiClient.ts` | Fetch wrapper (all server API calls, including DELETE) |
 | `frontend/src/services/fetchWithProgress.ts` | ReadableStream-based fetch with progress tracking |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,10 +98,10 @@ List/detail: dashboard or `GET /experiments` / `GET /experiments/{id}` (see `htt
 **Two independent provider settings**:
 - `embedding.provider`: "local" or "voyage"
   - Local → `server/core/local_embedder.py` → `all-MiniLM-L6-v2` (384-dim)
-  - Voyage → `server/core/embedder.py` → `voyage-3.5-lite|voyage-3.5|voyage-context-3` (1024-dim)
+  - Voyage → `server/core/embedder.py` → all models in `EMBEDDING_MODELS` with `provider: voyage` (1024-dim; `voyage-context-3` uses contextualized API)
 - `retrieval.rerank_provider`: "local" or "voyage"
   - Local → `server/core/local_reranker.py` → `cross-encoder/ms-marco-MiniLM-L-6-v2`
-  - Voyage → `server/core/reranker.py` → `rerank-2.5-lite|rerank-2.5`
+  - Voyage → `server/core/reranker.py` → `rerank-2.5-lite|rerank-2.5` (+ legacy `rerank-2*`, `rerank-1*`)
 
 Provider/model must match — registry in `model_registry.py` validates at config load time.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,9 @@ Agent guidance for `rag-params-finder`. Start with `AGENTS.md` → this file →
 **rag-params-finder** is a RAG parameter sweep experimentation tool with three components:
 1. **Python CLI** — submits experiment configs
 2. **FastAPI Server** — orchestrates PDF → chunk → embed → search pipeline
-3. **React Dashboard** — read-only visualization of experiments and results
+3. **React Dashboard** — visualization and sweep controls (pause, resume, cancel, delete)
 
-Two-process architecture: config submission (CLI) is separate from execution (Server). Dashboard is observer-only.
+Two-process architecture: config submission (CLI) is separate from execution (Server). Dashboard observes and controls active sweeps (pause/resume/cancel/delete).
 
 ## Development Commands
 
@@ -47,6 +47,8 @@ npm run build
 rag-params-finder run --config configs/example-mongodb-local.yaml
 rag-params-finder run --config configs/example-mongodb-local.yaml --detach
 rag-params-finder cancel <experiment-id>
+rag-params-finder pause <experiment-id>
+rag-params-finder resume <experiment-id>
 rag-params-finder delete <experiment-id>           # Delete experiment and all data
 rag-params-finder delete <experiment-id> --force   # Skip confirmation
 rag-params-finder version
@@ -64,17 +66,17 @@ List/detail: dashboard or `GET /experiments` / `GET /experiments/{id}` (see `htt
 | `server/core/startup_reconciliation.py` | Mark stale `running` experiments on server boot |
 | `server/core/atlas_storage.py` | Atlas Admin API cluster quota + dbStats helpers |
 | `server/core/model_registry.py` | Embedding + reranking model catalog |
-| `server/core/embedder.py` | Voyage embedding client |
+| `server/core/embedder.py` | Voyage embedding client; `voyage-context-3` uses contextualized API with segment splitting |
 | `server/core/local_embedder.py` | sentence-transformers embedding (lazy-load) |
 | `server/core/reranker.py` | Voyage reranking client |
 | `server/core/local_reranker.py` | CrossEncoder reranking (lazy-load) |
 | `server/core/retriever.py` | Atlas Vector Search (dense/sparse/hybrid) |
 | `server/models/config.py` | Pydantic experiment config + provider validators |
 | `server/models/enums.py` | ChunkingMethod, RetrievalMethod, Phase |
-| `server/api/experiments.py` | Experiments CRUD, results/explore, db-stats, cancel, delete |
+| `server/api/experiments.py` | Experiments CRUD, results/explore, db-stats, pause, resume, cancel, delete |
 | `server/api/experiments_shared.py` | Shared Mongo helpers (delete cascade, db-stats aggregation) |
 | `server/db/indexes.py` | Collection + index creation helpers |
-| `cli/main.py` | Typer app (`run`, `cancel`, `delete`, `version`) |
+| `cli/main.py` | Typer app (`run`, `cancel`, `pause`, `resume`, `delete`, `version`) |
 | `cli/config_loader.py` | YAML parser + model registry validation |
 | `cli/api_client.py` | HTTP client to server (POST /experiments, DELETE, etc.) |
 | `frontend/src/App.tsx` | Root component (screen routing) |
@@ -84,6 +86,7 @@ List/detail: dashboard or `GET /experiments` / `GET /experiments/{id}` (see `htt
 | `frontend/src/components/ExperimentProgressCard.tsx` | Reusable experiment progress card with circular indicator |
 | `frontend/src/components/PollingIndicator.tsx` | Subtle "Syncing..." badge during background polls |
 | `frontend/src/components/ConfirmDeleteModal.tsx` | Delete confirmation modal with experiment details and stats |
+| `frontend/src/components/ExperimentControlButtons.tsx` | Pause, resume, cancel buttons on detail screen |
 | `frontend/src/components/ExperimentsScreen.tsx` | Experiments list with collapsible rows, vector DB stats, delete |
 | `frontend/src/components/ExperimentDetailScreen.tsx` | Detail view with overview metrics, outcome banners, runs table |
 | `frontend/src/components/VectorDbStatsPanel.tsx` | Cluster-grouped storage stats panel |
@@ -98,7 +101,7 @@ List/detail: dashboard or `GET /experiments` / `GET /experiments/{id}` (see `htt
 **Two independent provider settings**:
 - `embedding.provider`: "local" or "voyage"
   - Local → `server/core/local_embedder.py` → `all-MiniLM-L6-v2` (384-dim)
-  - Voyage → `server/core/embedder.py` → all models in `EMBEDDING_MODELS` with `provider: voyage` (1024-dim; `voyage-context-3` uses contextualized API)
+  - Voyage → `server/core/embedder.py` → all models in `EMBEDDING_MODELS` with `provider: voyage` (1024-dim; `voyage-context-3` uses `contextualized_embed()` with automatic segment splitting for long documents)
 - `retrieval.rerank_provider`: "local" or "voyage"
   - Local → `server/core/local_reranker.py` → `cross-encoder/ms-marco-MiniLM-L-6-v2`
   - Voyage → `server/core/reranker.py` → `rerank-2.5-lite|rerank-2.5` (+ legacy `rerank-2*`, `rerank-1*`)

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Open `http://localhost:5173` to watch live progress and explore results.
 - **Multi-format data loading**: PDF, TXT, Markdown, CSV — files or directories
 - **Cartesian sweep**: one YAML config → N models × M methods × P sizes × Q overlaps runs
 - **Live phase tracking**: QUEUED → PARSING → CHUNKING → EMBEDDING → STORING → QUERYING → RERANKING → COMPLETE
-- **Experiment management**: Cancel running experiments, delete experiments with cascade cleanup, boot orphan reconciliation
+- **Experiment management**: Pause/resume long sweeps, cancel running experiments, delete with cascade cleanup, boot orphan reconciliation
 - **Vector DB stats**: Cluster and per-experiment chunk/storage estimates in the dashboard; optional Atlas quota bar
 - **Progress feedback**: Byte-level network loading, circular progress indicators, background polling with "Syncing..." badges
 - **Pagination**: All list views paginated (10 items per page for experiments/runs, 5 for configs); collapsible experiment rows

--- a/README.md
+++ b/README.md
@@ -115,9 +115,10 @@ Open `http://localhost:5173` to watch live progress and explore results.
 - **Multi-format data loading**: PDF, TXT, Markdown, CSV — files or directories
 - **Cartesian sweep**: one YAML config → N models × M methods × P sizes × Q overlaps runs
 - **Live phase tracking**: QUEUED → PARSING → CHUNKING → EMBEDDING → STORING → QUERYING → RERANKING → COMPLETE
-- **Experiment management**: Cancel running experiments, delete experiments with cascade cleanup
+- **Experiment management**: Cancel running experiments, delete experiments with cascade cleanup, boot orphan reconciliation
+- **Vector DB stats**: Cluster and per-experiment chunk/storage estimates in the dashboard; optional Atlas quota bar
 - **Progress feedback**: Byte-level network loading, circular progress indicators, background polling with "Syncing..." badges
-- **Pagination**: All list views paginated (10 items per page for experiments/runs, 5 for configs)
+- **Pagination**: All list views paginated (10 items per page for experiments/runs, 5 for configs); collapsible experiment rows
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ One YAML. N experiments. Evidence-based decision. Ship the right config first.
 
 ## 🚀 Quick Start
 
-**Prerequisites:** Python 3.12+, Node.js 22+, MongoDB Atlas account (free tier)
+**Prerequisites:** Python 3.12+, Node.js 22+, [MongoDB Atlas account](docs/user-guide/cloud-setup.md#mongodb-atlas-required) (free tier). [Voyage AI](docs/user-guide/cloud-setup.md#voyage-ai-optional) optional for local-only sweeps.
 
 ```bash
 # Clone and install
@@ -71,19 +71,16 @@ uv venv && source .venv/bin/activate
 uv pip install -e .
 cd frontend && npm install && cd ..
 
-# Configure
+# Configure — see docs/user-guide/cloud-setup.md for minimal Atlas + Voyage checklist
 cp .env.example .env
-# Edit .env: add MONGODB_URI (required) and VOYAGE_API_KEY (optional)
 
 # Start
 uvicorn server.main:app --reload --port 8001   # Terminal 1
-cd frontend && npm run dev                      # Terminal 2
+cd frontend && npm run dev                      # Terminal 2 (optional)
 
-# Full sweep — local models, no API key needed (90 runs)
-rag-params-finder run --config configs/example-mongodb-local.yaml
-
-# Full sweep — Voyage AI models, requires VOYAGE_API_KEY (90 runs)
-rag-params-finder run --config configs/example-mongodb-voyage.yaml
+# Sweeps — complete cloud-setup.md checklist first
+rag-params-finder run --config configs/example-mongodb-local.yaml   # 90 runs, no API key
+rag-params-finder run --config configs/example-mongodb-voyage.yaml  # 90 runs, Voyage + Tier 1
 ```
 
 Open `http://localhost:5173` to watch live progress and explore results.
@@ -94,6 +91,7 @@ Open `http://localhost:5173` to watch live progress and explore results.
 
 | I want to… | Start here |
 |---|---|
+| Set up MongoDB Atlas or Voyage AI accounts | [Cloud Account Setup](docs/user-guide/cloud-setup.md) |
 | Run my first experiment | [Getting Started](docs/user-guide/getting-started.md) |
 | Understand all config options | [Configuration Reference](docs/user-guide/configuration.md) |
 | Learn all CLI commands | [CLI Reference](docs/user-guide/cli-reference.md) |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ shows you exactly which configuration performs best.
 
 ## What it sweeps
 
-- **Embedding models**: `voyage-3.5-lite`, `voyage-3.5`, `voyage-context-3`
+- **Embedding models**: 12 Voyage models (voyage-4 series, domain, context, voyage-3 legacy) — see `server/core/model_registry.py`
 - **Chunking methods**: Fixed · Recursive · Token · Sentence · Semantic
 - **Retrieval methods**: Dense · Sparse · Hybrid
 - **Questions**: Persona-organised — realistic, not synthetic
@@ -110,7 +110,7 @@ Open `http://localhost:5173` to watch live progress and explore results.
 
 - **5 chunking methods**: Fixed, Recursive, Token, Sentence, Semantic
 - **3 retrieval methods**: Dense (vector search), Sparse (BM25), Hybrid (Reciprocal Rank Fusion)
-- **Voyage AI models**: `voyage-3.5-lite`, `voyage-3.5`, `voyage-context-3` + `rerank-2.5-lite`
+- **Voyage AI models**: all registered embeddings in `model_registry.py` (voyage-4/3/domain/context) + rerankers `rerank-2.5-lite`, `rerank-2.5`, and legacy rerank APIs
 - **Local models** (no API key): `all-MiniLM-L6-v2` + `cross-encoder/ms-marco-MiniLM-L-6-v2`
 - **Multi-format data loading**: PDF, TXT, Markdown, CSV — files or directories
 - **Cartesian sweep**: one YAML config → N models × M methods × P sizes × Q overlaps runs

--- a/cli/api_client.py
+++ b/cli/api_client.py
@@ -85,6 +85,44 @@ def cancel_experiment(experiment_id: str) -> dict[str, Any]:
         return data
 
 
+def pause_experiment(experiment_id: str) -> dict[str, Any]:
+    """Request pause of a running experiment."""
+    server_url = get_server_url()
+    url = f"{server_url}/experiments/{experiment_id}/pause"
+    logger.info(f"POST {url}")
+
+    with httpx.Client() as client:
+        response = client.post(url, timeout=_DEFAULT_TIMEOUT_S)
+        if response.status_code == 404:
+            raise RuntimeError(f"Experiment {experiment_id} not found")
+        if response.status_code == 409:
+            detail = response.json().get("detail", "Experiment is not running")
+            raise RuntimeError(detail)
+        response.raise_for_status()
+        data: dict[str, Any] = cast(dict[str, Any], response.json())
+        logger.info(f"Pause response: {data}")
+        return data
+
+
+def resume_experiment(experiment_id: str) -> dict[str, Any]:
+    """Resume a paused experiment."""
+    server_url = get_server_url()
+    url = f"{server_url}/experiments/{experiment_id}/resume"
+    logger.info(f"POST {url}")
+
+    with httpx.Client() as client:
+        response = client.post(url, timeout=_DEFAULT_TIMEOUT_S)
+        if response.status_code == 404:
+            raise RuntimeError(f"Experiment {experiment_id} not found")
+        if response.status_code == 409:
+            detail = response.json().get("detail", "Experiment cannot be resumed")
+            raise RuntimeError(detail)
+        response.raise_for_status()
+        data: dict[str, Any] = cast(dict[str, Any], response.json())
+        logger.info(f"Resume response: {data}")
+        return data
+
+
 def delete_experiment(experiment_id: str) -> dict[str, Any]:
     """Delete an experiment and all its associated data."""
     server_url = get_server_url()

--- a/cli/main.py
+++ b/cli/main.py
@@ -11,6 +11,8 @@ from cli.api_client import (
     cancel_experiment,
     delete_experiment,
     get_experiment,
+    pause_experiment,
+    resume_experiment,
     submit_experiment,
 )
 from cli.config_loader import load_config
@@ -84,7 +86,13 @@ def _watch_experiment(experiment_id: str) -> None:
             table = _build_runs_table(runs)
             live.update(table)
 
-            if status in TERMINAL_PHASES or status in ("partial", "cancelled"):
+            if status in TERMINAL_PHASES or status in (
+                "partial",
+                "cancelled",
+                "paused",
+                "complete",
+                "failed",
+            ):
                 break
 
             all_done = runs and all(r.get("phase") in TERMINAL_PHASES for r in runs)
@@ -132,6 +140,7 @@ def _print_summary(data: dict) -> None:
         "partial": "yellow",
         "failed": "red",
         "cancelled": "yellow",
+        "paused": "magenta",
     }.get(status, "cyan")
 
     lines = [f"[{status_style} bold]{status.upper()}[/{status_style} bold]  {name}"]
@@ -295,6 +304,64 @@ def cancel(
     except Exception as e:
         logger.error(f"Cancel request failed: {e}", exc_info=True)
         console.print(f"[red]Failed to cancel experiment: {e}[/red]")
+        raise typer.Exit(1)
+
+
+@app.command()
+def pause(
+    experiment_id: str = typer.Argument(..., help="Experiment ID to pause"),
+):
+    """Pause a running experiment (stops after the current phase)."""
+    logger.info(f"CLI pause command: experiment_id={experiment_id}")
+    console.print(f"[cyan]Requesting pause for {experiment_id[:8]}...[/cyan]")
+
+    try:
+        response = pause_experiment(experiment_id)
+        eid = experiment_id[:8]
+        console.print(
+            Panel.fit(
+                f"[yellow]⏸[/yellow]  Pause requested for experiment [bold]{eid}[/bold]\n"
+                f"{response.get('message', 'Experiment will pause after current phase')}",
+                title="Pause",
+                border_style="yellow",
+            )
+        )
+    except RuntimeError as e:
+        logger.error(f"Pause failed: {e}")
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+    except Exception as e:
+        logger.error(f"Pause request failed: {e}", exc_info=True)
+        console.print(f"[red]Failed to pause experiment: {e}[/red]")
+        raise typer.Exit(1)
+
+
+@app.command()
+def resume(
+    experiment_id: str = typer.Argument(..., help="Experiment ID to resume"),
+):
+    """Resume a paused experiment from the next incomplete parameter combination."""
+    logger.info(f"CLI resume command: experiment_id={experiment_id}")
+    console.print(f"[cyan]Resuming experiment {experiment_id[:8]}...[/cyan]")
+
+    try:
+        response = resume_experiment(experiment_id)
+        eid = experiment_id[:8]
+        console.print(
+            Panel.fit(
+                f"[green]▶[/green]  Resume requested for experiment [bold]{eid}[/bold]\n"
+                f"{response.get('message', 'Remaining runs will execute')}",
+                title="Resume",
+                border_style="green",
+            )
+        )
+    except RuntimeError as e:
+        logger.error(f"Resume failed: {e}")
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+    except Exception as e:
+        logger.error(f"Resume request failed: {e}", exc_info=True)
+        console.print(f"[red]Failed to resume experiment: {e}[/red]")
         raise typer.Exit(1)
 
 

--- a/configs/example-mongodb-local.yaml
+++ b/configs/example-mongodb-local.yaml
@@ -8,10 +8,10 @@
 # Chunking:   fixed · recursive · token · sentence · semantic
 # Retrieval:  dense · sparse · hybrid
 #
-# Atlas prerequisites:
-#   - vector_index_384  (vector search, 384-dim cosine) — required for dense and hybrid
-#   - text_search_index (Atlas Search, BM25)            — required for sparse and hybrid
-#   See CLAUDE.local.md or docs/user-guide/getting-started.md for index creation steps.
+# Atlas prerequisites (M0 — create before running sweep):
+#   - chunks collection in rag_params_finder database
+#   - vector_index_384  + text_search_index
+#   See docs/user-guide/cloud-setup.md#before-you-run-a-sweep
 
 experiment_name: example-mongodb-local
 

--- a/configs/example-mongodb-voyage.yaml
+++ b/configs/example-mongodb-voyage.yaml
@@ -1,13 +1,12 @@
 # MongoDB Atlas — Voyage AI models (requires VOYAGE_API_KEY in .env)
 #
-# Full Cartesian sweep:
+# Default sweep (3 embedding models enabled below):
 #   3 embedding models × 5 chunking methods × 2 chunk sizes × 1 overlap × 3 retrieval methods
 #   = 90 runs
 #
-# Params are narrower than the local config to keep Voyage API costs reasonable.
-# Estimated cost: ~$0.65 total across all models and runs.
+# Uncomment additional models for a full sweep (12 models → 360 runs). See comments per model.
 #
-# Embedding:  voyage-3.5-lite · voyage-3.5 · voyage-context-3 (1024-dim)
+# Embedding (1024-dim, vector_index_1024): voyage-4-* · domain · context · voyage-3.*
 # Chunking:   fixed · recursive · token · sentence · semantic
 # Retrieval:  dense · sparse · hybrid
 #
@@ -28,9 +27,21 @@ database_provider: mongodb
 embedding:
   provider: voyage
   models:
+    # Voyage 4 series
+    # - voyage-4-large       # 1024-dim, flagship quality
+    # - voyage-4             # 1024-dim, general-purpose balanced
+    # - voyage-4-lite        # 1024-dim, fastest and cheapest (Voyage 4)
+    # Domain-specific
+    # - voyage-code-3        # 1024-dim, optimised for code retrieval
+    # - voyage-finance-2     # 1024-dim, finance domain
+    # - voyage-law-2         # 1024-dim, legal domain
+    - voyage-context-3     # 1024-dim, optimised for long contexts (contextualized API)
+    # Voyage 3 series (legacy API)
+    # - voyage-3-large       # 1024-dim, highest quality (legacy)
     - voyage-3.5-lite      # 1024-dim, fastest and cheapest
     - voyage-3.5           # 1024-dim, balanced quality
-    - voyage-context-3     # 1024-dim, optimised for long contexts
+    # - voyage-3             # 1024-dim, general-purpose (legacy)
+    # - voyage-multilingual-2 # 1024-dim, multilingual retrieval (legacy)
 
 chunking:
   methods:

--- a/configs/example-mongodb-voyage.yaml
+++ b/configs/example-mongodb-voyage.yaml
@@ -10,10 +10,12 @@
 # Chunking:   fixed · recursive · token · sentence · semantic
 # Retrieval:  dense · sparse · hybrid
 #
-# Atlas prerequisites:
-#   - vector_index_1024 (vector search, 1024-dim cosine) — required for dense and hybrid
-#   - text_search_index (Atlas Search, BM25)             — required for sparse and hybrid
-#   See CLAUDE.local.md or docs/user-guide/getting-started.md for index creation steps.
+# Atlas prerequisites (M0 — create before running sweep):
+#   - chunks collection in rag_params_finder database
+#   - vector_index_1024 + text_search_index
+# Voyage prerequisites:
+#   - VOYAGE_API_KEY + Tier 1 billing (≥$5 credits) in .env
+#   See docs/user-guide/cloud-setup.md#before-you-run-a-sweep
 
 experiment_name: example-mongodb-voyage
 

--- a/docs/_internal/PROGRESS.md
+++ b/docs/_internal/PROGRESS.md
@@ -1,7 +1,7 @@
 # rag-params-finder — Build Progress
 
-**Last Updated**: 2026-05-19 (Vector DB stats + orphan sweep reconciliation — complete on `feat/vector-db-stats-and-collapsible-cards`)
-**Current**: Slices 1–9 ✅ COMPLETE | Vector DB stats + collapsible rows + boot reconciliation ✅ COMPLETE | Next: Slice 10 📋 PLANNED (failed-run recovery retry) · Slice 11 📋 PLANNED (Search Explorer enhancements) · Slice 16 📋 PLANNED (honor `parallelism`)
+**Last Updated**: 2026-05-19 (Pause/resume sweeps + Voyage model catalog expansion + voyage-context-3 segment splitting)
+**Current**: Slices 1–9 ✅ COMPLETE | Vector DB stats + collapsible rows + boot reconciliation ✅ COMPLETE | Pause/resume + expanded Voyage catalog ✅ COMPLETE | Next: Slice 10 📋 PLANNED (failed-run recovery retry) · Slice 11 📋 PLANNED (Search Explorer enhancements) · Slice 16 📋 PLANNED (honor `parallelism`)
 
 ---
 
@@ -19,7 +19,8 @@
 | 8 — Dashboard UX improvements | ✅ COMPLETE | ~2 h | Loading feedback panels, polling indicators, pagination, unified chrome |
 | 9 — Experiment deletion | ✅ COMPLETE | ~1 h | CLI delete command + dashboard confirmation modal, cascade cleanup |
 | — — Vector DB stats + collapsible rows + boot reconciliation | ✅ COMPLETE | ~1.5 h | Cluster/experiment storage stats; collapsible panels; orphan `running` → `partial` on server boot |
-| 10 — Run recovery (retry) | 📋 PLANNED | ~1–2 h | Retry FAILED `(± INTERRUPTED)` runs in-place; boot **reconciliation** done; **retry** not yet — see [`SLICE-10-RUN-RECOVERY.md`](../slices/SLICE-10-RUN-RECOVERY.md) |
+| — — Pause/resume + Voyage catalog expansion | ✅ COMPLETE | ~2 h | Cooperative pause/resume; 12 Voyage embedding models; `voyage-context-3` contextualized API + segment splitting |
+| 10 — Run recovery (retry) | 📋 PLANNED | ~1–2 h | Retry FAILED `(± INTERRUPTED)` runs in-place; boot **reconciliation** done; pause/resume covers not-yet-started combos; **retry** not yet — see [`SLICE-10-RUN-RECOVERY.md`](../slices/SLICE-10-RUN-RECOVERY.md) |
 | 11 — Search Explorer enhancements | 📋 PLANNED | ~1 h | Better visualization, export results, query filtering improvements |
 | 16 — Parallel sweep execution | 📋 PLANNED | ~2–4 h | Bounded concurrent `_run_single`; see [`SLICE-16-PARALLEL-SWEEP-RUNS.md`](../slices/SLICE-16-PARALLEL-SWEEP-RUNS.md) |
 
@@ -526,6 +527,9 @@ Implement the 4 stubbed chunkers (fixed, token, sentence, semantic), add sparse/
 | 2026-05-19 | — | Boot orphan reconciliation always on | BackgroundTasks die on reload; Mongo `running` must be corrected without waiting for Slice 10 retry |
 | 2026-05-19 | — | Run outcome buckets in dashboard | successful + failed + interrupted + not started must sum to `run_count`; fixes misleading partial UI |
 | 2026-05-19 | — | Atlas storage quota via Admin API | Avoid hardcoded M0 512 MB; optional manual `MONGODB_STORAGE_LIMIT_MB` override |
+| 2026-05-19 | — | Pause/resume cooperative sweep control | `_SweepControl` threading events; `resume_sweep()` skips completed param signatures; status `paused` non-terminal |
+| 2026-05-19 | — | voyage-context-3 segment splitting | Contextualized API 32K window; tiktoken cl100k_base sizing; standard Voyage models unchanged (`embed()` path) |
+| 2026-05-19 | — | Expanded Voyage model registry | voyage-4 series, domain models, voyage-context-3, voyage-3 legacy; `contextualized` flag drives embedder dispatch |
 
 ---
 

--- a/docs/_internal/PROGRESS.md
+++ b/docs/_internal/PROGRESS.md
@@ -1,7 +1,7 @@
 # rag-params-finder — Build Progress
 
-**Last Updated**: 2026-05-19 (Vector DB stats + collapsible experiment rows — in progress on `feat/vector-db-stats-and-collapsible-cards`)
-**Current**: Slices 1–9 ✅ COMPLETE | 🔨 IN PROGRESS: Vector DB stats panel + collapsible list rows | Next: Slice 10 📋 PLANNED (failed-run recovery) · Slice 11 📋 PLANNED (Search Explorer enhancements) · Slice 16 📋 PLANNED (honor `parallelism`)
+**Last Updated**: 2026-05-19 (Vector DB stats + orphan sweep reconciliation — complete on `feat/vector-db-stats-and-collapsible-cards`)
+**Current**: Slices 1–9 ✅ COMPLETE | Vector DB stats + collapsible rows + boot reconciliation ✅ COMPLETE | Next: Slice 10 📋 PLANNED (failed-run recovery retry) · Slice 11 📋 PLANNED (Search Explorer enhancements) · Slice 16 📋 PLANNED (honor `parallelism`)
 
 ---
 
@@ -18,8 +18,8 @@
 | 7 — Free/local embedding + reranking | ✅ COMPLETE | ~15 min | sentence-transformers, no API key needed |
 | 8 — Dashboard UX improvements | ✅ COMPLETE | ~2 h | Loading feedback panels, polling indicators, pagination, unified chrome |
 | 9 — Experiment deletion | ✅ COMPLETE | ~1 h | CLI delete command + dashboard confirmation modal, cascade cleanup |
-| — — Vector DB stats + collapsible rows | 🔨 IN PROGRESS | ~1 h | `GET /experiments/{id}/db-stats`; detail stats panel; list row collapse (localStorage) |
-| 10 — Run recovery | 📋 PLANNED | ~1–2 h | Retry FAILED `(± INTERRUPTED)` runs in-place; see [`SLICE-10-RUN-RECOVERY.md`](../slices/SLICE-10-RUN-RECOVERY.md) |
+| — — Vector DB stats + collapsible rows + boot reconciliation | ✅ COMPLETE | ~1.5 h | Cluster/experiment storage stats; collapsible panels; orphan `running` → `partial` on server boot |
+| 10 — Run recovery (retry) | 📋 PLANNED | ~1–2 h | Retry FAILED `(± INTERRUPTED)` runs in-place; boot **reconciliation** done; **retry** not yet — see [`SLICE-10-RUN-RECOVERY.md`](../slices/SLICE-10-RUN-RECOVERY.md) |
 | 11 — Search Explorer enhancements | 📋 PLANNED | ~1 h | Better visualization, export results, query filtering improvements |
 | 16 — Parallel sweep execution | 📋 PLANNED | ~2–4 h | Bounded concurrent `_run_single`; see [`SLICE-16-PARALLEL-SWEEP-RUNS.md`](../slices/SLICE-16-PARALLEL-SWEEP-RUNS.md) |
 
@@ -411,6 +411,46 @@ Manually verified:
 
 ---
 
+## Vector DB Stats + Collapsible Rows + Boot Reconciliation ✅
+
+**Status**: ✅ COMPLETE | **Started**: 2026-05-19 | **Completed**: 2026-05-19 | **Target**: ~1.5 h
+
+### Goal
+Surface MongoDB/Atlas storage footprint in the dashboard, improve experiments list UX with collapsible rows, and automatically fix experiments left `running` after server restart or crash.
+
+### What Changed
+- **NEW**: `server/core/atlas_storage.py` — Atlas Admin API cluster quota lookup + `dbStats` footprint; manual `MONGODB_STORAGE_LIMIT_MB` override
+- **NEW**: `server/core/startup_reconciliation.py` — on boot, mark in-flight runs `interrupted` and recompute experiment status (`partial` / `complete` / `failed`)
+- **NEW**: `server/utils/log_throttle.py` — throttle repetitive polling log lines
+- **EDIT**: `server/api/experiments_shared.py` — `mongo_get_experiment_db_stats`, `mongo_get_vector_db_stats_grouped`
+- **EDIT**: `server/api/experiments.py` — `GET /experiments/vector-db-stats`, `GET /experiments/{id}/db-stats`
+- **EDIT**: `server/main.py` — call `reconcile_orphaned_experiments()` in lifespan
+- **NEW**: `frontend/src/components/CollapsibleCard.tsx`, `VectorDbStatsPanel.tsx`, `ExperimentVectorDbStatsCard.tsx`
+- **NEW**: `frontend/src/utils/experimentStatus.ts` — `summarizeExperimentRuns()` for outcome buckets
+- **EDIT**: `frontend/src/components/ExperimentsScreen.tsx` — collapsible list rows, cluster stats panel, list→detail cache handoff
+- **EDIT**: `frontend/src/components/ExperimentDetailScreen.tsx` — compact overview metrics (successful / failed / interrupted / not started), status-accurate outcome banners
+- **EDIT**: `.env.example` — Atlas Admin API + storage limit vars
+
+### Key Design Decisions
+| Decision | Why |
+|---|---|
+| Reconcile orphans on every boot (not gated by `RECOVER_ON_BOOT`) | Status correction is safe and idempotent; retry remains opt-in via Slice 10 |
+| `partial` when sweep incomplete | Distinguishes “41/90 complete + 48 never started” from green `complete` |
+| Atlas quota via Admin API with manual fallback | M0 tier limits vary; hardcoded 512 MB was misleading |
+| Outcome metrics from `run_status` phases | `run_count - failed_count` lied when runs never started |
+| Collapsible state in `localStorage` | Per-panel persistence without server round-trips |
+
+### Acceptance Criteria
+- [x] `GET /experiments/vector-db-stats` returns grouped cluster stats
+- [x] `GET /experiments/{id}/db-stats` returns per-experiment chunk/storage breakdown
+- [x] Experiments list shows collapsible rows + vector DB stats panel
+- [x] Experiment detail shows run-outcome buckets that sum to total runs
+- [x] Partial experiments show “Sweep Incomplete” — not green success banner
+- [x] Server boot reconciles stale `running` experiments to terminal status
+- [x] Pre-commit hooks pass
+
+---
+
 ## Slice 6: Additional Chunkers + Retrieval Methods ✅
 
 **Status**: ✅ COMPLETE | **Started**: 2026-05-17 | **Completed**: 2026-05-17 | **Target**: ~45 min
@@ -483,6 +523,9 @@ Implement the 4 stubbed chunkers (fixed, token, sentence, semantic), add sparse/
 | 2026-05-17 | 8 | Pagination defaults 10 (lists) / 5 (configs) | Prevents DOM overload and cognitive fatigue; configs more verbose so lower per-page count |
 | 2026-05-17 | 8 | initialLoadDone flag per screen | Polling indicator only shows after first load completes; avoids visual confusion during hydration |
 | 2026-05-18 | 8 | ExperimentProgressCard reusable component | Extracted circular progress pattern from detail screen; enables consistent progress visualization across screens; separates network progress (LoadingFeedbackPanel) from execution progress (ExperimentProgressCard) |
+| 2026-05-19 | — | Boot orphan reconciliation always on | BackgroundTasks die on reload; Mongo `running` must be corrected without waiting for Slice 10 retry |
+| 2026-05-19 | — | Run outcome buckets in dashboard | successful + failed + interrupted + not started must sum to `run_count`; fixes misleading partial UI |
+| 2026-05-19 | — | Atlas storage quota via Admin API | Avoid hardcoded M0 512 MB; optional manual `MONGODB_STORAGE_LIMIT_MB` override |
 
 ---
 

--- a/docs/adr/ADR-002-voyage-and-local-providers.md
+++ b/docs/adr/ADR-002-voyage-and-local-providers.md
@@ -19,7 +19,7 @@ Support two providers via an **explicit `provider` field** in the experiment YAM
 | Provider | Embedding model | Reranking model | Requirements |
 |---|---|---|---|
 | `local` | `all-MiniLM-L6-v2` (384-dim, ~23 MB) | `cross-encoder/ms-marco-MiniLM-L-6-v2` (~23 MB) | None — downloaded from HuggingFace on first use |
-| `voyage` | `voyage-3.5-lite`, `voyage-3.5`, `voyage-context-3` (1024-dim) | `rerank-2.5-lite`, `rerank-2.5` | `VOYAGE_API_KEY` in `.env` |
+| `voyage` | 12 embeddings in `EMBEDDING_MODELS` (voyage-4/3/domain/context; 1024-dim) | `rerank-2.5-lite`, `rerank-2.5`, + legacy rerankers in `RERANKER_MODELS` | `VOYAGE_API_KEY` in `.env` |
 
 The `provider` field is the **single source of truth** for routing — the server never infers provider from model names at runtime.
 

--- a/docs/adr/ADR-002-voyage-and-local-providers.md
+++ b/docs/adr/ADR-002-voyage-and-local-providers.md
@@ -42,6 +42,7 @@ The `provider` field is the **single source of truth** for routing — the serve
 - **Two Atlas vector indexes required** for projects using both providers. Each experiment config uses one provider; vectors cannot be mixed.
 - **`numpy<2` pin required**: PyTorch (used by sentence-transformers) was compiled against NumPy 1.x ABI. NumPy 2.x causes `_ARRAY_API not found` crashes.
 - **Model download on first use**: Local models are ~23 MB each, cached in `~/.cache/huggingface/hub/`. First run may be slow on cold cache.
+- **`voyage-context-3` uses a different API**: Registered with `contextualized: True` in `model_registry.py`; routed to `contextualized_embed()` with automatic segment splitting for documents exceeding 32K tokens. All other Voyage models use standard `embed()`.
 - **Provider flows end-to-end**: `EmbeddingConfig.provider` → `RunParams.embedding_provider` → `embedder.py` dispatcher. No runtime inference; server restart issues cannot mis-route.
 
 ---

--- a/docs/contributor-guide/architecture.md
+++ b/docs/contributor-guide/architecture.md
@@ -95,14 +95,16 @@ FastAPI Server
 ```
 rag-params-finder/
 ├── server/
-│   ├── main.py              # FastAPI app entry; lifespan ensures DB indexes
+│   ├── main.py              # FastAPI app entry; lifespan: indexes + orphan reconciliation
 │   ├── settings.py          # Centralized pydantic-settings config
 │   ├── api/
-│   │   ├── experiments.py   # experiments CRUD, results/explore, cancel, delete
-│   │   ├── experiments_shared.py  # shared delete helpers (cascade deletion)
+│   │   ├── experiments.py   # CRUD, explore, db-stats, cancel, delete
+│   │   ├── experiments_shared.py  # Mongo helpers incl. db-stats aggregation
 │   │   └── runs.py          # GET /runs/{id}/status
 │   ├── core/
 │   │   ├── orchestrator.py  # run_sweep() + run_single() pipeline
+│   │   ├── startup_reconciliation.py  # fix stale running experiments on boot
+│   │   ├── atlas_storage.py # Atlas Admin API quota + dbStats footprint
 │   │   ├── pdf_parser.py    # pypdf text extraction
 │   │   ├── query_loader.py  # persona JSON → Query dataclass list
 │   │   ├── model_registry.py  # embedding + reranking model catalog
@@ -139,12 +141,18 @@ rag-params-finder/
     │   ├── ExperimentProgressCard.tsx  # experiment progress card (circular indicator, reusable)
     │   ├── PollingIndicator.tsx        # subtle "Syncing..." indicator during polls
     │   ├── ConfirmDeleteModal.tsx      # delete confirmation modal with experiment details
-    │   ├── ExperimentsScreen.tsx       # list view (polling every 2s, paginated, delete actions)
-    │   ├── ExperimentDetailScreen.tsx  # detail view (runs table, phase dots, metrics, paginated, delete action)
+    │   ├── CollapsibleCard.tsx         # reusable collapsible section (localStorage state)
+    │   ├── VectorDbStatsPanel.tsx      # cluster-grouped storage stats (experiments list)
+    │   ├── ExperimentVectorDbStatsCard.tsx  # per-experiment db-stats on detail screen
+    │   ├── ExperimentsScreen.tsx       # list view (collapsible rows, vector DB stats, delete)
+    │   ├── ExperimentDetailScreen.tsx  # overview metrics, outcome banners, runs table
     │   └── SearchExplorerScreen.tsx    # results analysis (ranked configs, per-query, paginated)
     ├── services/
     │   ├── apiClient.ts       # fetch wrapper (all server API calls)
     │   └── fetchWithProgress.ts  # streamed fetch with byte-level progress tracking
+    ├── utils/
+    │   ├── experimentStatus.ts   # terminal/running helpers + summarizeExperimentRuns()
+    │   └── experimentDbStats.ts  # db-stats response normalizers
     └── types/index.ts         # hand-mirrored TypeScript types from Python models
 ```
 
@@ -219,6 +227,8 @@ See `docs/adr/` for Architecture Decision Records:
 | Dual loading indicators (panel + polling badge) | Initial load → full progress panel; background polls → subtle "Syncing..." badge; clear state transitions |
 | Two progress patterns (network vs experiment) | `LoadingFeedbackPanel` for network/API loads (byte-level); `ExperimentProgressCard` for experiment execution (run completion); distinct concerns, reusable components |
 | Cascade delete with confirmation | DELETE endpoint scrubs all collections (experiments, run_status, chunks, results); `ConfirmDeleteModal` shows experiment details + deletion statistics; prevents deletion of running experiments |
+| Boot orphan reconciliation | `BackgroundTasks` sweeps die on process exit; startup marks in-flight runs `interrupted` and sets terminal experiment status — separate from Slice 10 retry |
+| Vector DB stats API + dashboard | `GET /experiments/vector-db-stats` and `/{id}/db-stats`; estimated storage from chunk counts + model dimensions; optional Atlas quota bar |
 
 ---
 
@@ -226,7 +236,7 @@ See `docs/adr/` for Architecture Decision Records:
 
 | Enhancement | Notes |
 |---|---|
-| Run recovery (failed / interrupted runs) | Planned as [Slice 10 — Run Recovery](../slices/SLICE-10-RUN-RECOVERY.md): `recover` CLI + API; per-`run_id` artifact scrub; **`RECOVER_ON_BOOT`** = **INTERRUPTED** only |
+| Run recovery (retry failed / interrupted runs) | **Reconciliation on boot** ✅ — status fix only. **Retry** planned as [Slice 10](../slices/SLICE-10-RUN-RECOVERY.md): `recover` CLI + API; **`RECOVER_ON_BOOT`** = retry **INTERRUPTED** only |
 | SSE live updates | Replace 2-second polling with Server-Sent Events |
 | Parallel sweep (`execution.parallelism` > 1) | Planned as [Slice 16 — Parallel Sweep Runs](../slices/SLICE-16-PARALLEL-SWEEP-RUNS.md); bounded in-process pool first; **Celery + Redis** when multi-process fairness or isolation is needed |
 | Dashboard-triggered runs | Submit experiments from the React UI, not just CLI |

--- a/docs/contributor-guide/architecture.md
+++ b/docs/contributor-guide/architecture.md
@@ -19,9 +19,9 @@ System design, data flow, module structure, and design decisions for `rag-params
 
 1. **Python CLI** (thin client) — submits experiment configs to the server
 2. **FastAPI Server** (engine) — orchestrates the full pipeline end-to-end
-3. **React Dashboard** (observer) — read-only visualization of experiments and results
+3. **React Dashboard** — visualization, sweep controls (pause/resume/cancel/delete), and results exploration
 
-The CLI and Dashboard are intentionally thin. All business logic lives in the server.
+The CLI submits configs; the Dashboard observes progress and controls active sweeps. All pipeline business logic lives in the server.
 
 ---
 
@@ -98,17 +98,17 @@ rag-params-finder/
 │   ├── main.py              # FastAPI app entry; lifespan: indexes + orphan reconciliation
 │   ├── settings.py          # Centralized pydantic-settings config
 │   ├── api/
-│   │   ├── experiments.py   # CRUD, explore, db-stats, cancel, delete
+│   │   ├── experiments.py   # CRUD, explore, db-stats, pause, resume, cancel, delete
 │   │   ├── experiments_shared.py  # Mongo helpers incl. db-stats aggregation
 │   │   └── runs.py          # GET /runs/{id}/status
 │   ├── core/
-│   │   ├── orchestrator.py  # run_sweep() + run_single() pipeline
+│   │   ├── orchestrator.py  # run_sweep(), resume_sweep(), run_single() pipeline
 │   │   ├── startup_reconciliation.py  # fix stale running experiments on boot
 │   │   ├── atlas_storage.py # Atlas Admin API quota + dbStats footprint
 │   │   ├── pdf_parser.py    # pypdf text extraction
 │   │   ├── query_loader.py  # persona JSON → Query dataclass list
 │   │   ├── model_registry.py  # embedding + reranking model catalog
-│   │   ├── embedder.py      # Voyage embedding client
+│   │   ├── embedder.py      # Voyage embed(); voyage-context-3 → contextualized_embed + segment split
 │   │   ├── local_embedder.py  # sentence-transformers embedding (lazy-load, cached)
 │   │   ├── reranker.py      # Voyage reranking client
 │   │   ├── local_reranker.py  # CrossEncoder reranking (lazy-load, cached)
@@ -129,7 +129,7 @@ rag-params-finder/
 │       ├── atlas.py         # MongoDB connection singleton
 │       └── indexes.py       # collection + index creation helpers
 ├── cli/
-│   ├── main.py              # Typer app (run, cancel, version)
+│   ├── main.py              # Typer app (run, cancel, pause, resume, delete, version)
 │   ├── config_loader.py     # YAML parser + model registry validation
 │   └── api_client.py        # HTTP client to server
 └── frontend/src/
@@ -141,6 +141,7 @@ rag-params-finder/
     │   ├── ExperimentProgressCard.tsx  # experiment progress card (circular indicator, reusable)
     │   ├── PollingIndicator.tsx        # subtle "Syncing..." indicator during polls
     │   ├── ConfirmDeleteModal.tsx      # delete confirmation modal with experiment details
+    │   ├── ExperimentControlButtons.tsx  # pause / resume / cancel on detail screen
     │   ├── CollapsibleCard.tsx         # reusable collapsible section (localStorage state)
     │   ├── VectorDbStatsPanel.tsx      # cluster-grouped storage stats (experiments list)
     │   ├── ExperimentVectorDbStatsCard.tsx  # per-experiment db-stats on detail screen
@@ -181,7 +182,7 @@ Two independent provider settings in each experiment config:
 
 **Embedding provider** (`embedding.provider`):
 - `local` → `server/core/local_embedder.py` → sentence-transformers `all-MiniLM-L6-v2` (384-dim)
-- `voyage` → `server/core/embedder.py` → Voyage AI API (1024-dim)
+- `voyage` → `server/core/embedder.py` → Voyage AI API (1024-dim); `voyage-context-3` uses `contextualized_embed()` with per-document segment splitting (32K-token window)
 
 **Reranking provider** (`retrieval.rerank_provider`):
 - `local` → `server/core/local_reranker.py` → CrossEncoder `cross-encoder/ms-marco-MiniLM-L-6-v2`
@@ -228,6 +229,7 @@ See `docs/adr/` for Architecture Decision Records:
 | Two progress patterns (network vs experiment) | `LoadingFeedbackPanel` for network/API loads (byte-level); `ExperimentProgressCard` for experiment execution (run completion); distinct concerns, reusable components |
 | Cascade delete with confirmation | DELETE endpoint scrubs all collections (experiments, run_status, chunks, results); `ConfirmDeleteModal` shows experiment details + deletion statistics; prevents deletion of running experiments |
 | Boot orphan reconciliation | `BackgroundTasks` sweeps die on process exit; startup marks in-flight runs `interrupted` and sets terminal experiment status — separate from Slice 10 retry |
+| Pause / resume sweeps | Cooperative halt via `_SweepControl` threading events; `resume_sweep()` skips completed parameter signatures; status `paused` is non-terminal |
 | Vector DB stats API + dashboard | `GET /experiments/vector-db-stats` and `/{id}/db-stats`; estimated storage from chunk counts + model dimensions; optional Atlas quota bar |
 
 ---

--- a/docs/contributor-guide/development.md
+++ b/docs/contributor-guide/development.md
@@ -122,7 +122,7 @@ rag-params-finder/
 │   ├── models/          # Pydantic schemas and enums
 │   └── db/              # Atlas connection singleton + index helpers
 ├── cli/                 # Python CLI client (thin — delegates to server)
-├── frontend/            # React dashboard (read-only observer)
+├── frontend/            # React dashboard (observe + pause/resume/cancel/delete)
 │   └── src/
 │       ├── components/  # ExperimentsScreen, ExperimentDetailScreen, SearchExplorerScreen
 │       ├── services/    # apiClient.ts — all fetch calls

--- a/docs/contributor-guide/extending.md
+++ b/docs/contributor-guide/extending.md
@@ -36,6 +36,13 @@ If the model uses a provider not yet supported, update `server/models/config.py`
 
 In `server/core/embedder.py` (Voyage) or `server/core/local_embedder.py` (sentence-transformers): verify the model name routes correctly through the existing dispatch logic. For most new models of an existing provider type, no changes are needed.
 
+**Contextualized models** (`contextualized: True`, e.g. `voyage-context-3`):
+
+- Route through `_embed_documents_voyage_context()` → `client.contextualized_embed()`
+- Respect Voyage's 32K-token per-segment window — long documents are split in `_split_context_segments()`
+- Set `"contextualized": True` in `EMBEDDING_MODELS`; `is_contextualized_embedding()` drives dispatch in `embed_documents()`
+- Standard Voyage models (`contextualized: False`) are unaffected — they use `client.embed()` only
+
 ### 4. Create an Atlas vector index
 
 A new dimension size requires a new Atlas vector index. See [getting-started.md](../user-guide/getting-started.md#2-create-the-atlas-vector-index) for the index JSON format.
@@ -178,6 +185,7 @@ export async function fetchMyData(experimentId: string): Promise<MyType> {
 | Queries file URL caching | URL-sourced query files are downloaded to `configs/` and cached by hash. Delete the cached file to force re-download. |
 | Server must be running | The CLI requires the server at `SERVER_URL` (default: `http://localhost:8001`). All commands fail if the server is down. |
 | Rate limits on Voyage | Free tier: 3 RPM / 10k TPM (defaults). Tier 1: 2,000 RPM + model TPM — set `VOYAGE_RPM_LIMIT` / `VOYAGE_TPM_LIMIT` in `.env`. |
+| `voyage-context-3` token window | Contextualized API: 32K tokens per document segment, no truncation. Server splits long docs automatically; single chunks must stay under 32K. Other Voyage models use standard `embed()`. |
 | Score normalization | Rerank scores (cross-encoder logits) can be negative. The system uses min-max normalization to map all scores to 0–100. |
 | TypeScript types are hand-mirrored | When changing Python models (`server/models/`), manually update `frontend/src/types/index.ts`. There is no codegen. |
 

--- a/docs/contributor-guide/extending.md
+++ b/docs/contributor-guide/extending.md
@@ -17,11 +17,13 @@ In `server/core/model_registry.py`, add to `EMBEDDING_MODELS`:
 
 ```python
 EMBEDDING_MODELS = {
-    "my-new-model": ModelEntry(
-        provider="local",          # or "voyage"
-        dimensions=768,
-        huggingface_id="org/my-new-model",  # for local models
-    ),
+    "my-new-model": {
+        "provider": "local",          # or "voyage"
+        "dimensions": 768,
+        "huggingface_id": "org/my-new-model",  # for local models; None for Voyage
+        "description": "Short label for docs",
+        "contextualized": False,      # True only for voyage-context-* (contextualized_embed API)
+    },
     ...
 }
 ```
@@ -175,7 +177,7 @@ export async function fetchMyData(experimentId: string): Promise<MyType> {
 | Missing embeddings filter | Always filter Atlas vector search by `embedding_model` — different models produce incompatible vectors that must not be compared. |
 | Queries file URL caching | URL-sourced query files are downloaded to `configs/` and cached by hash. Delete the cached file to force re-download. |
 | Server must be running | The CLI requires the server at `SERVER_URL` (default: `http://localhost:8001`). All commands fail if the server is down. |
-| Rate limits on Voyage | Free tier: 300 RPM / 1M TPM. Set `VOYAGE_RPM_LIMIT` and `VOYAGE_TPM_LIMIT` in `.env` to throttle. |
+| Rate limits on Voyage | Free tier: 3 RPM / 10k TPM (defaults). Tier 1: 2,000 RPM + model TPM — set `VOYAGE_RPM_LIMIT` / `VOYAGE_TPM_LIMIT` in `.env`. |
 | Score normalization | Rerank scores (cross-encoder logits) can be negative. The system uses min-max normalization to map all scores to 0–100. |
 | TypeScript types are hand-mirrored | When changing Python models (`server/models/`), manually update `frontend/src/types/index.ts`. There is no codegen. |
 

--- a/docs/contributor-guide/local-environment.md
+++ b/docs/contributor-guide/local-environment.md
@@ -77,9 +77,8 @@ VOYAGE_API_KEY=vo-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # Server URL (used by CLI, default is localhost:8001)
 SERVER_URL=http://localhost:8001
 
-# Rate limits (Voyage only — set based on your tier)
-VOYAGE_RPM_LIMIT=3
-VOYAGE_TPM_LIMIT=10000
+# Rate limits (Voyage only — set based on your tier; see .env.example)
+# Tier 1 example: VOYAGE_RPM_LIMIT=2000  VOYAGE_TPM_LIMIT=16000000  # voyage-4-lite / voyage-3.5-lite
 
 # Optional — Atlas Admin API for dashboard storage quota bar
 # ATLAS_PUBLIC_KEY=
@@ -170,7 +169,7 @@ db.results.deleteMany({experiment_id: exp_id})
 | Provider | Speed | Notes |
 |---|---|---|
 | Local (`all-MiniLM-L6-v2`) | ~50 chunks/sec on M1 CPU | No API latency; first run downloads model |
-| Voyage (`voyage-3.5-lite`) | ~1000 chunks/min | API rate-limited; free tier is 1M TPM |
+| Voyage (`voyage-4-lite`, `voyage-3.5-lite`) | varies by tier | Tier 1: up to 16M TPM / 2000 RPM when `.env` limits match |
 
 ### MongoDB Atlas free tier limits
 

--- a/docs/contributor-guide/local-environment.md
+++ b/docs/contributor-guide/local-environment.md
@@ -10,22 +10,17 @@ Internal notes for local setup, debugging, and maintenance. Not required for bas
 
 ## 🗄️ MongoDB Atlas — Full Setup Details
 
+**User-facing guide:** [Cloud Account Setup](../user-guide/cloud-setup.md#mongodb-atlas-required) — account, cluster, connection string, and search indexes with official MongoDB doc links.
+
+The sections below are contributor/debugging notes. Prefer the cloud-setup guide for onboarding.
+
 ### Connection String Format
 
 ```
 mongodb+srv://<username>:<password>@<cluster>.mongodb.net/<database>?retryWrites=true&w=majority&appName=<app-name>
 ```
 
-### Atlas UI Steps (one-time)
-
-1. [cloud.mongodb.com](https://cloud.mongodb.com/) → create a free cluster (M0)
-2. **Database Access** → create user with read/write permissions
-3. **Network Access** → add your IP or `0.0.0.0/0` for local dev
-4. **Connect → Compass** → copy the SRV URI into `MONGODB_URI` in `.env`
-
-### Vector Index Creation
-
-See [getting-started.md](../user-guide/getting-started.md#2-create-the-atlas-vector-index) for the full JSON index definitions. Index creation takes ~1–2 minutes in the Atlas UI. The server will fail vector queries until the index is ready.
+Index JSON definitions: [Cloud Account Setup → Search indexes](../user-guide/cloud-setup.md#6-create-search-indexes-m0--manual).
 
 ### Checking Index Status
 
@@ -57,11 +52,7 @@ The `text_search_index`, `vector_index_384`, and `vector_index_1024` all coexist
 
 ## 🤖 Voyage AI Setup
 
-1. Sign up at [dash.voyageai.com](https://dash.voyageai.com)
-2. Navigate to **API Keys** → create new key
-3. Copy the `vo-...` key into `.env` as `VOYAGE_API_KEY`
-
-Check usage and rate limits at [dash.voyageai.com/usage](https://dash.voyageai.com/usage).
+**User-facing guide:** [Cloud Account Setup → Voyage AI](../user-guide/cloud-setup.md#voyage-ai-optional) — account, API key, $5 credit for Tier 1 rate limits.
 
 **`voyage-context-3`**: uses the contextualized embedding API (not standard `embed()`). The server splits long documents into segments that fit the 32K-token window. See [configuration.md](../user-guide/configuration.md#voyage-context-3-contextualized-api) and [troubleshooting.md](../user-guide/troubleshooting.md#-voyage-context-3-token-limit-exceeded).
 

--- a/docs/contributor-guide/local-environment.md
+++ b/docs/contributor-guide/local-environment.md
@@ -63,6 +63,8 @@ The `text_search_index`, `vector_index_384`, and `vector_index_1024` all coexist
 
 Check usage and rate limits at [dash.voyageai.com/usage](https://dash.voyageai.com/usage).
 
+**`voyage-context-3`**: uses the contextualized embedding API (not standard `embed()`). The server splits long documents into segments that fit the 32K-token window. See [configuration.md](../user-guide/configuration.md#voyage-context-3-contextualized-api) and [troubleshooting.md](../user-guide/troubleshooting.md#-voyage-context-3-token-limit-exceeded).
+
 ---
 
 ## 🔑 Full .env Reference

--- a/docs/contributor-guide/local-environment.md
+++ b/docs/contributor-guide/local-environment.md
@@ -78,17 +78,26 @@ VOYAGE_API_KEY=vo-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 SERVER_URL=http://localhost:8001
 
 # Rate limits (Voyage only — set based on your tier)
-VOYAGE_RPM_LIMIT=300
-VOYAGE_TPM_LIMIT=1000000
+VOYAGE_RPM_LIMIT=3
+VOYAGE_TPM_LIMIT=10000
 
-# Optional — stored in experiment metadata / dashboard (“Recover on Boot”); no runtime retry on boot yet (planned: docs/slices/SLICE-10-RUN-RECOVERY.md — boot = INTERRUPTED only).
+# Optional — Atlas Admin API for dashboard storage quota bar
+# ATLAS_PUBLIC_KEY=
+# ATLAS_PRIVATE_KEY=
+# ATLAS_GROUP_ID=                         # 24-char project ID from Atlas URL
+# ATLAS_CLUSTER_NAME=                     # omit to parse from MONGODB_URI host
+# MONGODB_STORAGE_LIMIT_MB=512            # manual override (MB); 0 = try API
+
+# Optional — stored in experiment metadata / dashboard (“Recover on Boot”).
+# Status reconciliation on boot always runs (marks stale running → partial).
+# Automatic retry of interrupted runs is not implemented yet (Slice 10).
 RECOVER_ON_BOOT=false
 
 # Logging
 LOG_LEVEL=INFO   # DEBUG for verbose output
 ```
 
-Slice 10 *(planned)* documents CLI/API recovery and boot semantics: [`SLICE-10-RUN-RECOVERY.md`](../slices/SLICE-10-RUN-RECOVERY.md).
+Slice 10 *(planned)* documents CLI/API **retry** of failed/interrupted runs: [`SLICE-10-RUN-RECOVERY.md`](../slices/SLICE-10-RUN-RECOVERY.md). **Boot status reconciliation** (fix stale `running` experiments) is already implemented in `server/core/startup_reconciliation.py`.
 
 **Never commit `.env` to git** — it is in `.gitignore`.
 

--- a/docs/slices/SLICE-10-RUN-RECOVERY.md
+++ b/docs/slices/SLICE-10-RUN-RECOVERY.md
@@ -2,7 +2,7 @@
 
 **MoSCoW:** COULD *(ops ergonomics; workarounds today are manual YAML subsets or Mongo cleanup + resubmit)*
 **Target time:** ~1–2 h *(CLI + API + orchestration hooks; boot path is a small add-on if scoped narrowly)*
-**Status:** 📋 PLANNED
+**Status:** 🔨 PARTIAL — boot **status reconciliation** shipped; **retry** CLI/API still planned
 
 ---
 
@@ -15,7 +15,8 @@ Today:
 - `rag-params-finder run` always creates a **new** `experiment_id` and `run_sweep` assigns a **fresh** `run_id` per sweep row.
 - Partial sweeps (`on_error: continue`) yield experiment status **PARTIAL** with a mix of **COMPLETE** and **FAILED** runs.
 - Cancellation marks in-flight runs **INTERRUPTED**.
-- **`RECOVER_ON_BOOT`** is stored in metadata for the dashboard only — **no** server startup retry is implemented.
+- **Boot reconciliation** *(implemented)*: on server start, experiments still `running` get in-flight runs marked **INTERRUPTED** and status recomputed (`partial` / `complete` / `failed`). See `server/core/startup_reconciliation.py`.
+- **`RECOVER_ON_BOOT`** retry of interrupted runs is **not** implemented yet — flag is metadata-only until Slice 10 ships.
 - The only supported workflow for “redo the bad ones” is trimming YAML (or multiple YAMLs) and submitting a **new** experiment.
 
 ---
@@ -51,12 +52,9 @@ Recovery should **reuse the same `run_id`** for a retried run so dashboards, URL
 
 ## `RECOVER_ON_BOOT` Semantics *(narrow scope)*
 
-To avoid endlessly retrying **FAILED** runs caused by bad configs:
+**Already shipped (status only):** `server/main.py` lifespan calls `reconcile_orphaned_experiments()` on **every** boot — not gated by `RECOVER_ON_BOOT`. This fixes MongoDB status when the process died mid-sweep; it does **not** re-execute runs.
 
-- **Boot path** *(when implemented)* should target **INTERRUPTED** runs only *(process died mid-sweep)*, **not** all historical **FAILED** rows.
-- Optional future: allow opt-in `--also-failed` for advanced operators *(YAGNI until asked)*.
-
-Wire `settings.recover_on_boot` in `server/main.py` lifespan (or a small startup task) to enqueue the same recovery engine as the CLI — **same code path**.
+**Still planned (retry):** When `RECOVER_ON_BOOT=true`, enqueue the same recovery engine as the CLI to **retry INTERRUPTED** runs only *(process died mid-sweep)* — **not** all historical **FAILED** rows.
 
 ---
 
@@ -68,6 +66,7 @@ Wire `settings.recover_on_boot` in `server/main.py` lifespan (or a small startup
 | `cli/api_client.py` | POST recover endpoint |
 | `server/api/experiments.py` | `POST /experiments/{id}/recover`; BackgroundTask for recovery sweep |
 | `server/core/orchestrator.py` | `recover_failed_runs(...)` or extend `run_sweep` with a “recovery mode”; shared cleanup helper |
+| `server/core/startup_reconciliation.py` | ✅ Boot status fix *(shipped)* — mark orphans `interrupted`, recompute experiment status |
 | `server/api/experiments_shared.py` *(or new db helper)* | Bulk delete chunks/results by `run_id`; experiment status recomputation |
 | `docs/user-guide/cli-reference.md` | Document `recover` |
 | `docs/_internal/PROGRESS.md` | Mark slice complete; decision log |

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -58,6 +58,30 @@ Posts `POST /experiments/{experiment_id}/cancel`. A running experiment stops aft
 
 ---
 
+### `pause` — Pause a running sweep
+
+```bash
+rag-params-finder pause <experiment-id>
+```
+
+Posts `POST /experiments/{experiment_id}/pause`. The sweep stops after the **current run's current phase** completes — in-flight work is not discarded. Status becomes `paused`. Completed runs and their chunks/results are kept.
+
+Use this to temporarily free API quota or stop a long sweep without losing progress. Resume later with `resume`.
+
+---
+
+### `resume` — Continue a paused sweep
+
+```bash
+rag-params-finder resume <experiment-id>
+```
+
+Posts `POST /experiments/{experiment_id}/resume`. Re-queues the experiment in a background task and executes **only parameter combinations that have not yet reached `COMPLETE`**. Skips are determined from stored `run_status` records — no YAML trimming required.
+
+Only works when experiment status is `paused`.
+
+---
+
 ### `delete` — Delete experiment and all associated data
 
 ```bash
@@ -75,7 +99,7 @@ Deletes an experiment and **all** its associated data:
 |---|---|---|
 | `--force` / `-f` | off | Skip confirmation prompt |
 
-⚠️ **Warning:** This is a **permanent** operation that cannot be undone. Running experiments cannot be deleted — cancel them first.
+⚠️ **Warning:** This is a **permanent** operation that cannot be undone. **Running** experiments cannot be deleted — pause or cancel first. **Paused** experiments can be deleted.
 
 **Examples**:
 ```bash
@@ -131,6 +155,8 @@ The server exposes a REST API at `http://localhost:8001`. Full interactive docs 
 | GET | `/experiments/{id}/results` | Get query results for an experiment |
 | GET | `/experiments/{id}/explore` | Get data for the Search Explorer screen |
 | POST | `/experiments/{id}/cancel` | Request cancellation while status is running |
+| POST | `/experiments/{id}/pause` | Pause after current phase; status → `paused` |
+| POST | `/experiments/{id}/resume` | Resume a paused sweep; skips completed parameter combos |
 | DELETE | `/experiments/{id}` | Delete experiment and all associated data (chunks, results, run statuses) |
 | POST | `/experiments/{id}/recover` | Retry failed / interrupted runs only *(planned — Slice 10)* |
 | GET | `/runs/{id}/status` | Get a single run's current phase |

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -125,7 +125,9 @@ The server exposes a REST API at `http://localhost:8001`. Full interactive docs 
 | GET | `/healthz` | Health check — returns `{"ok": true}` |
 | POST | `/experiments` | Submit an experiment sweep |
 | GET | `/experiments` | List all experiments |
+| GET | `/experiments/vector-db-stats` | Cluster-grouped vector DB / storage stats for all experiments |
 | GET | `/experiments/{id}` | Get experiment details + run statuses |
+| GET | `/experiments/{id}/db-stats` | Per-experiment chunk counts, storage estimates, index names |
 | GET | `/experiments/{id}/results` | Get query results for an experiment |
 | GET | `/experiments/{id}/explore` | Get data for the Search Explorer screen |
 | POST | `/experiments/{id}/cancel` | Request cancellation while status is running |

--- a/docs/user-guide/cloud-setup.md
+++ b/docs/user-guide/cloud-setup.md
@@ -1,0 +1,205 @@
+# Cloud Account Setup
+
+![MongoDB](https://img.shields.io/badge/MongoDB_Atlas-47A248?logo=mongodb&logoColor=white)
+![Voyage AI](https://img.shields.io/badge/Voyage_AI-FF6B6B)
+
+**Essential, minimal steps** to run the example sweep commands. Official vendor docs are linked; details you can skip are marked *optional*.
+
+---
+
+## Before you run a sweep
+
+Both example configs use **dense + sparse + hybrid** retrieval — you need **two** Atlas search indexes (vector + text), not just one.
+
+### Local sweep — `example-mongodb-local.yaml`
+
+```bash
+rag-params-finder run --config configs/example-mongodb-local.yaml
+```
+
+| # | Step | Where |
+|---|---|---|
+| 1 | Atlas account + M0 cluster | [MongoDB → steps 1–2](#mongodb-atlas-required-for-all-sweeps) |
+| 2 | Database user + network access | [MongoDB → steps 3–4](#mongodb-atlas-required-for-all-sweeps) |
+| 3 | `MONGODB_URI` in `.env` | [MongoDB → step 5](#mongodb-atlas-required-for-all-sweeps) |
+| 4 | `vector_index_384` + `text_search_index` on `chunks` | [MongoDB → step 6](#6-create-search-indexes-m0--required-before-sweep) |
+| 5 | Server running | `uvicorn server.main:app --reload --port 8001` |
+
+No Voyage account needed.
+
+### Voyage sweep — `example-mongodb-voyage.yaml`
+
+```bash
+rag-params-finder run --config configs/example-mongodb-voyage.yaml
+```
+
+Complete the **local sweep checklist** above, then add:
+
+| # | Step | Where |
+|---|---|---|
+| 6 | Voyage account + API key → `VOYAGE_API_KEY` | [Voyage → steps 1–2](#voyage-ai-required-for-voyage-sweep) |
+| 7 | Payment method + **≥ $5** usage credits (Tier 1) | [Voyage → step 3](#voyage-ai-required-for-voyage-sweep) |
+| 8 | `VOYAGE_RPM_LIMIT=2000` and `VOYAGE_TPM_LIMIT=16000000` in `.env` | [Voyage → step 3](#voyage-ai-required-for-voyage-sweep) |
+| 9 | `vector_index_1024` instead of `vector_index_384` | [MongoDB → step 6](#6-create-search-indexes-m0--required-before-sweep) |
+
+Steps 1–5 use `vector_index_384`; step 9 swaps in `vector_index_1024` for Voyage embeddings. You need **both** vector indexes if you run local and Voyage sweeps on the same cluster.
+
+---
+
+## MongoDB Atlas (required for all sweeps)
+
+Atlas stores chunks, embeddings, and experiment results. Free **M0** is enough.
+
+### 1. Create an account
+
+Register at [cloud.mongodb.com](https://cloud.mongodb.com/) (email, Google, or GitHub).
+
+→ [Create an Atlas Account](https://www.mongodb.com/docs/atlas/tutorial/create-atlas-account/)
+
+### 2. Deploy a free cluster
+
+Atlas UI → **Create** → **M0 (Free)** → pick region → **Create**.
+
+→ [Deploy a Free Tier Cluster](https://www.mongodb.com/docs/atlas/tutorial/deploy-free-tier-cluster/)
+
+### 3. Create a database user
+
+**Database Access** → **Add New Database User** → password auth → **Read and write to any database**. Save username and password.
+
+→ [Create a Database User](https://www.mongodb.com/docs/atlas/security-add-mongodb-users/)
+
+### 4. Allow network access
+
+**Network Access** → **Add IP Address** → **Add Current IP Address** (or `0.0.0.0/0` for local dev only).
+
+→ [Configure IP Access List](https://www.mongodb.com/docs/atlas/security/ip-access-list/)
+
+### 5. Set `MONGODB_URI`
+
+**Database** → **Connect** → **Drivers** → copy SRV string → replace `<password>` → set database to `rag_params_finder`:
+
+```
+mongodb+srv://<user>:<password>@<cluster>.mongodb.net/rag_params_finder?retryWrites=true&w=majority
+```
+
+Paste into `.env`:
+
+```bash
+MONGODB_URI=mongodb+srv://...
+```
+
+→ [Connect to Your Cluster](https://www.mongodb.com/docs/atlas/driver-connection/)
+
+### 6. Create search indexes (M0 — required before sweep)
+
+On **M0/M2/M5**, indexes must be created in the Atlas UI **before** the sweep reaches the QUERYING phase. Both example configs need **vector + text** indexes.
+
+**6a. Create the `chunks` collection** (if it does not exist):
+
+Atlas UI → **Browse Collections** → database `rag_params_finder` → **Create Collection** → name: `chunks`.
+
+**6b. Create indexes** on `chunks` → **Search Indexes** → **Create Search Index** → **JSON Editor**:
+
+| Sweep | Vector index name | `numDimensions` |
+|---|---|---|
+| `example-mongodb-local.yaml` | `vector_index_384` | `384` |
+| `example-mongodb-voyage.yaml` | `vector_index_1024` | `1024` |
+| Both (same cluster) | create **both** | `384` and `1024` |
+
+**Vector index JSON** (set `numDimensions` and name as above):
+
+```json
+{
+  "fields": [
+    { "type": "vector", "path": "embedding", "numDimensions": 384, "similarity": "cosine" },
+    { "type": "filter", "path": "experiment_id" },
+    { "type": "filter", "path": "embedding_model" },
+    { "type": "filter", "path": "chunking_method" },
+    { "type": "filter", "path": "chunk_size" },
+    { "type": "filter", "path": "overlap" }
+  ]
+}
+```
+
+**Text index** (required — both sweeps use sparse/hybrid), name: `text_search_index`:
+
+```json
+{
+  "mappings": {
+    "dynamic": false,
+    "fields": {
+      "text": [{ "type": "string" }],
+      "experiment_id": [{ "type": "token" }],
+      "embedding_model": [{ "type": "token" }]
+    }
+  }
+}
+```
+
+Wait until each index shows **ACTIVE** (~1–2 min).
+
+→ [How to Index Fields for Vector Search](https://www.mongodb.com/docs/atlas/atlas-vector-search/create-index/)
+
+**M10+ paid clusters:** skip manual creation — the server creates indexes on startup (check uvicorn logs).
+
+---
+
+## Voyage AI (required for Voyage sweep)
+
+Skip entirely for `example-mongodb-local.yaml`.
+
+### 1. Create an account
+
+Sign up at [dash.voyageai.com](https://dash.voyageai.com).
+
+→ [API Key and Python Client](https://docs.voyageai.com/docs/api-key-and-installation)
+
+### 2. Create an API key
+
+Dashboard → **API Keys** → **Create new secret key** → add to `.env`:
+
+```bash
+VOYAGE_API_KEY=vo-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+### 3. Unlock Tier 1 rate limits (required for 90-run sweep)
+
+Without billing, Voyage caps you at **3 RPM / 10,000 TPM** — a full sweep will hit rate limits and fail.
+
+1. Add payment method: [Billing → Payment methods](https://dashboard.voyageai.com/organization/billing/payment-methods)
+2. Add **≥ $5 USD** credits: [Billing → Add to credit balance](https://dashboard.voyageai.com/organization/billing)
+3. Confirm Tier 1 at [Organization → Rate Limits](https://dashboard.voyageai.com/organization/rate-limits)
+4. Set in `.env` and **restart uvicorn**:
+
+```bash
+VOYAGE_RPM_LIMIT=2000
+VOYAGE_TPM_LIMIT=16000000
+```
+
+→ [Voyage Rate Limits](https://docs.voyageai.com/docs/rate-limits) · [Prepaid billing FAQ](https://docs.voyageai.com/docs/faq#how-can-i-set-up-prepaid-billing) · [Pricing](https://docs.voyageai.com/docs/pricing)
+
+*Optional:* monitor usage at [dash.voyageai.com/usage](https://dash.voyageai.com/usage).
+
+---
+
+## Run the sweep
+
+```bash
+cp .env.example .env          # once — then fill MONGODB_URI (+ Voyage vars if needed)
+uvicorn server.main:app --reload --port 8001
+
+# Local — 90 runs, no API key
+rag-params-finder run --config configs/example-mongodb-local.yaml
+
+# Voyage — 90 runs, requires steps above
+rag-params-finder run --config configs/example-mongodb-voyage.yaml
+```
+
+Dashboard (optional): `cd frontend && npm run dev` → `http://localhost:5173`
+
+---
+
+## 👉 If something fails
+
+- [Troubleshooting](troubleshooting.md) — index not found, rate limits, dimension mismatch
+- [Getting Started](getting-started.md) — install, documents, pause/resume

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -134,6 +134,24 @@ Canonical list: `server/core/model_registry.py` (`EMBEDDING_MODELS`, `RERANKER_M
 
 **Atlas vector index** selection is automatic: local models (384-dim) use `vector_index_384`; Voyage models (1024-dim) use `vector_index_1024`. Both can coexist on the same `chunks` collection.
 
+### `voyage-context-3` (contextualized API)
+
+Unlike other Voyage models, `voyage-context-3` uses Voyage's **`contextualized_embed`** API — all chunks from a document segment share embedding context for better retrieval quality.
+
+| Limit | Value | Server behavior |
+|---|---|---|
+| Per-segment context window | 32,000 tokens | Long documents are split into multiple segments automatically (`server/core/embedder.py`) |
+| Per-request total tokens | 120,000 tokens | Multiple segments batched into one API call when under cap |
+| Single chunk max | 32,000 tokens | Validated before embed; fails with clear error if `chunk_size` is too large |
+
+**Implications for sweeps**:
+
+- **Other Voyage models are unaffected** — they use standard `client.embed()` with per-chunk batching.
+- **Segment boundaries**: chunks in different segments lose cross-segment document context (within-segment context is preserved).
+- **Chunk size**: keep `chunk_sizes` well below 32K tokens (the example configs use `[256, 512]` characters/tokens). A single oversized chunk cannot be truncated by Voyage.
+
+See [Troubleshooting — voyage-context-3 token limit](troubleshooting.md#-voyage-context-3-token-limit-exceeded) if embedding fails with a 32K window error.
+
 ---
 
 ## ✂️ Chunking Methods
@@ -204,7 +222,9 @@ rag-params-finder run --config configs/example-mongodb-local.yaml
 
 For a targeted subset, copy the file and trim the `methods` or `chunk_sizes` lists before running.
 
-To **re-run only failed combinations inside an existing experiment** *(same `experiment_id`, keep successful runs)*, see the planned workflow in [`../slices/SLICE-10-RUN-RECOVERY.md`](../slices/SLICE-10-RUN-RECOVERY.md) — today this still requires manual YAML reshaping or a new submit.
+To **continue an incomplete sweep** without re-submitting YAML, pause and resume the same experiment (CLI or dashboard) — completed parameter combinations are skipped automatically.
+
+To **re-run only failed combinations inside an existing experiment** *(same `experiment_id`, keep successful runs)*, see the planned workflow in [`../slices/SLICE-10-RUN-RECOVERY.md`](../slices/SLICE-10-RUN-RECOVERY.md) — today this requires manual YAML reshaping, pause/resume for not-yet-started combos, or a new submit.
 
 ---
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -95,15 +95,40 @@ Each run is tracked independently through the pipeline phases and has its own re
 
 ## 🤖 Models
 
-| Model | Type | Dimensions | Provider | Notes |
-|---|---|---|---|---|
-| `all-MiniLM-L6-v2` | Embedding | 384 | `local` | ~23 MB, no API key, HuggingFace cached |
-| `voyage-3.5-lite` | Embedding | 1024 | `voyage` | Cheapest Voyage embedding |
-| `voyage-3.5` | Embedding | 1024 | `voyage` | Higher accuracy |
-| `voyage-context-3` | Embedding | 1024 | `voyage` | Long-context optimized |
-| `cross-encoder/ms-marco-MiniLM-L-6-v2` | Reranker | — | `local` | ~23 MB, no API key |
-| `rerank-2.5-lite` | Reranker | — | `voyage` | Fastest Voyage reranker |
-| `rerank-2.5` | Reranker | — | `voyage` | Higher accuracy reranker |
+Canonical list: `server/core/model_registry.py` (`EMBEDDING_MODELS`, `RERANKER_MODELS`).
+
+### Embedding models
+
+| Model | Dimensions | Provider | Notes |
+|---|---|---|---|
+| `all-MiniLM-L6-v2` | 384 | `local` | ~23 MB, no API key |
+| **Voyage 4** | | | |
+| `voyage-4-large` | 1024 | `voyage` | Flagship; shared 4-series embedding space |
+| `voyage-4` | 1024 | `voyage` | General-purpose |
+| `voyage-4-lite` | 1024 | `voyage` | Latency/cost optimized |
+| **Domain** | | | |
+| `voyage-code-3` | 1024 | `voyage` | Code retrieval |
+| `voyage-finance-2` | 1024 | `voyage` | Finance domain |
+| `voyage-law-2` | 1024 | `voyage` | Legal domain |
+| `voyage-context-3` | 1024 | `voyage` | Contextualized chunk API |
+| **Voyage 3 (legacy API)** | | | |
+| `voyage-3-large` | 1024 | `voyage` | Previous-gen large |
+| `voyage-3.5-lite` | 1024 | `voyage` | Previous-gen lite |
+| `voyage-3.5` | 1024 | `voyage` | Previous-gen standard |
+| `voyage-3` | 1024 | `voyage` | Voyage 3 general |
+| `voyage-multilingual-2` | 1024 | `voyage` | Multilingual |
+
+### Reranker models
+
+| Model | Provider | Notes |
+|---|---|---|
+| `cross-encoder/ms-marco-MiniLM-L-6-v2` | `local` | ~23 MB, no API key |
+| `rerank-2.5-lite` | `voyage` | Recommended — fastest |
+| `rerank-2.5` | `voyage` | Recommended — higher quality |
+| `rerank-2-lite` | `voyage` | Legacy |
+| `rerank-2` | `voyage` | Legacy |
+| `rerank-lite-1` | `voyage` | Legacy |
+| `rerank-1` | `voyage` | Legacy |
 
 **Provider/model must match.** The system validates at config load time — a `provider: local` config with a Voyage model name will fail immediately with a clear error.
 
@@ -189,11 +214,14 @@ To **re-run only failed combinations inside an existing experiment** *(same `exp
 
 | Model | Cost | Notes |
 |---|---|---|
-| `voyage-3.5-lite` | $0.06 / 1M tokens | Cheapest embedding |
-| `voyage-3.5` | $0.12 / 1M tokens | Higher accuracy |
-| `rerank-2.5-lite` | $0.02 / 1K queries | Cheapest reranker |
+| `voyage-4-lite` | $0.02 / 1M tokens | Cheapest current-gen embedding |
+| `voyage-4` | $0.06 / 1M tokens | Balanced |
+| `voyage-4-large` | $0.12 / 1M tokens | Highest quality |
+| `voyage-context-3` | $0.18 / 1M tokens | Contextualized chunks |
+| `voyage-3.5-lite` | $0.02 / 1M tokens | Legacy lite |
+| `rerank-2.5-lite` | $0.02 / 1M tokens | Cheapest reranker |
 
-**Free tier limits**: 300 RPM, 1M TPM. Set `VOYAGE_RPM_LIMIT` and `VOYAGE_TPM_LIMIT` in `.env` to throttle requests to match your tier.
+**Rate limits**: Server defaults to free tier (3 RPM, 10,000 TPM). Tier 1 (payment method) is typically 2,000 RPM with model-specific TPM — set `VOYAGE_RPM_LIMIT` and `VOYAGE_TPM_LIMIT` in `.env` (see `.env.example` and [Voyage rate limits](https://docs.voyageai.com/docs/rate-limits)).
 
 **Example cost** for a 36-run sweep (3 models × 2 methods × 3 chunk sizes × 2 overlaps):
 - 1 PDF × ~200 pages × 5 chunks/page = 1,000 chunks/run

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -241,7 +241,7 @@ To **re-run only failed combinations inside an existing experiment** *(same `exp
 | `voyage-3.5-lite` | $0.02 / 1M tokens | Legacy lite |
 | `rerank-2.5-lite` | $0.02 / 1M tokens | Cheapest reranker |
 
-**Rate limits**: Server defaults to free tier (3 RPM, 10,000 TPM). Tier 1 (payment method) is typically 2,000 RPM with model-specific TPM — set `VOYAGE_RPM_LIMIT` and `VOYAGE_TPM_LIMIT` in `.env` (see `.env.example` and [Voyage rate limits](https://docs.voyageai.com/docs/rate-limits)).
+**Rate limits**: Required for Voyage sweep — add payment method + ≥$5 credits, then set Tier 1 limits in `.env`. See [Cloud Account Setup → Voyage step 3](cloud-setup.md#3-unlock-tier-1-rate-limits-required-for-90-run-sweep).
 
 **Example cost** for a 36-run sweep (3 models × 2 methods × 3 chunk sizes × 2 overlaps):
 - 1 PDF × ~200 pages × 5 chunks/page = 1,000 chunks/run
@@ -252,7 +252,8 @@ To **re-run only failed combinations inside an existing experiment** *(same `exp
 
 ## 👉 See Also
 
-- [Getting Started](getting-started.md) — environment setup and Atlas vector index creation
+- [Getting Started](getting-started.md) — environment setup and first experiment
+- [Cloud Account Setup](cloud-setup.md) — Atlas and Voyage account setup
 - [CLI Reference](cli-reference.md) — how to submit a config and monitor runs
 - [Dashboard Guide](dashboard-guide.md) — interpreting results and scores
 - [Extending the System](../contributor-guide/extending.md) — adding new models or chunking methods

--- a/docs/user-guide/dashboard-guide.md
+++ b/docs/user-guide/dashboard-guide.md
@@ -29,6 +29,10 @@ The landing screen shows all submitted experiments, newest first.
 
 **Pagination**: Shows 10 experiments per page. Navigate using Previous/Next buttons at the bottom.
 
+**Collapsible rows**: Click the chevron on a row to expand inline details without leaving the list. Expansion state is remembered per experiment (`localStorage`).
+
+**Vector DB stats panel** (top of list): Aggregated storage footprint for your Atlas cluster — total chunks, estimated embedding storage, active index names, and per-experiment breakdown. Polls `GET /experiments/vector-db-stats` on refresh. Cluster quota bar appears when Atlas Admin API credentials or `MONGODB_STORAGE_LIMIT_MB` is configured.
+
 **Actions**:
 - **View details**: Click any row to open the Experiment Detail screen
 - **Delete**: Click the trash icon button in the Actions column to delete an experiment (confirmation required)
@@ -39,9 +43,9 @@ The landing screen shows all submitted experiments, newest first.
 
 | Badge | Color | Meaning |
 |---|---|---|
-| `complete` | Green | All runs finished successfully |
+| `complete` | Green | All planned runs finished successfully |
 | `running` | Blue | One or more runs still active |
-| `partial` | Yellow | Some runs completed, some failed |
+| `partial` | Yellow | Sweep stopped early — some runs complete, some failed/interrupted, and/or some parameter combos never started |
 | `failed` | Red | All runs failed |
 | `cancelled` | Gray | Experiment was cancelled |
 
@@ -49,13 +53,33 @@ The landing screen shows all submitted experiments, newest first.
 
 ### 🔬 Experiment Detail
 
-Opened by clicking a row in the Experiments List. Polls every 2 seconds while status is non-terminal.
+Opened by clicking a row in the Experiments List. Polls every 2 seconds while status is non-terminal. List→detail navigation reuses cached experiment payloads when available to reduce duplicate fetches.
 
-**Metric cards** (top row):
-- Total Runs — number of config combinations in the sweep
-- Successful — runs that reached COMPLETE
-- Failed — runs that hit an error
-- Avg Duration — mean elapsed time across completed runs
+**Overview panel** (top): Status badge, action buttons, and compact run-outcome metrics in one card:
+
+| Metric | Meaning |
+|---|---|
+| Total | Planned sweep size (`run_count` from config) |
+| Successful | Runs that reached `COMPLETE` |
+| Failed | Runs that ended in `FAILED` |
+| Interrupted | Runs stopped mid-pipeline (cancel or server restart) |
+| Not Started | Parameter combos never queued — sweep stopped before reaching them |
+| In Progress | Runs currently executing *(running experiments only)* |
+| Duration | Wall time from `started_at` to `completed_at` |
+
+These buckets always sum to **Total** on terminal experiments.
+
+**Outcome banners** (below runs table):
+
+| Status | Banner |
+|---|---|
+| `complete` | Green — all planned runs succeeded |
+| `partial` | Amber — “Sweep Incomplete” with breakdown (e.g. 41/90 complete, 48 never started) |
+| `cancelled` | Gray — runs completed before cancellation |
+| Failed runs | Red panel listing `error_message` per run |
+| Interrupted runs | Amber panel listing interruption reason |
+
+**Vector DB stats card**: Collapsible panel with per-experiment chunk counts, embedding model breakdown, estimated storage, and index names. Loaded from `GET /experiments/{id}/db-stats`.
 
 **Phase indicator dots**: one row of colored dots per run, representing each pipeline phase in order:
 
@@ -68,7 +92,7 @@ QUEUED → PARSING → CHUNKING → EMBEDDING → STORING → QUERYING → RERAN
 | Green | Phase completed |
 | Blue pulsing | Phase currently active |
 | Gray | Phase not yet started |
-| Red | Phase failed |
+| Red | Phase failed or run interrupted |
 
 **Runs table**: each row is one config combination (model + chunking method + chunk size + overlap + retrieval method). Expand a row to see per-query results with dense scores and rerank scores.
 
@@ -151,7 +175,7 @@ For **running experiments**, the Experiment Detail screen shows an **Experiment 
 - Completion status (e.g., "1 of 2 runs completed")
 - Visual feedback: blue gradient background, green progress ring
 
-This card appears **only when status is "running"** and updates every 2 seconds via background polling. Once the experiment completes, the card is replaced with a success/failure summary.
+This card appears **only when status is "running"** and updates every 2 seconds via background polling. Progress is measured against **planned** run count (`run_count`), not just runs already in `run_status`. Once the experiment reaches a terminal status, the card is replaced with the outcome banner described above.
 
 **Note**: This is distinct from network loading — the Loading Feedback Panel tracks API data transfer, while the Experiment Progress Card tracks pipeline execution (runs completing).
 

--- a/docs/user-guide/dashboard-guide.md
+++ b/docs/user-guide/dashboard-guide.md
@@ -5,7 +5,7 @@
 ![Vite](https://img.shields.io/badge/Vite-6-646CFF?logo=vite&logoColor=white)
 ![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-3-06B6D4?logo=tailwindcss&logoColor=white)
 
-The React dashboard at `http://localhost:5173` provides a read-only view of experiments and results. It polls the server every 2 seconds while any experiment is running.
+The React dashboard at `http://localhost:5173` visualizes experiments and results. Experiments are **submitted from the CLI**; the dashboard can **pause, resume, cancel, and delete** active sweeps. It polls the server every 2 seconds while any experiment is `running` or `paused`.
 
 All screens feature:
 - **Loading feedback panels** with progress bars during initial data loads
@@ -36,7 +36,7 @@ The landing screen shows all submitted experiments, newest first.
 **Actions**:
 - **View details**: Click any row to open the Experiment Detail screen
 - **Delete**: Click the trash icon button in the Actions column to delete an experiment (confirmation required)
-  - Cannot delete running experiments — cancel them first
+  - Cannot delete **running** experiments — pause or cancel first (**paused** experiments can be deleted)
   - Deletion is permanent and removes all associated data (chunks, results, run statuses)
 
 **Status badges**:
@@ -45,6 +45,7 @@ The landing screen shows all submitted experiments, newest first.
 |---|---|---|
 | `complete` | Green | All planned runs finished successfully |
 | `running` | Blue | One or more runs still active |
+| `paused` | Violet | Sweep paused — completed runs kept; resume to continue remaining combos |
 | `partial` | Yellow | Sweep stopped early — some runs complete, some failed/interrupted, and/or some parameter combos never started |
 | `failed` | Red | All runs failed |
 | `cancelled` | Gray | Experiment was cancelled |
@@ -55,7 +56,17 @@ The landing screen shows all submitted experiments, newest first.
 
 Opened by clicking a row in the Experiments List. Polls every 2 seconds while status is non-terminal. List→detail navigation reuses cached experiment payloads when available to reduce duplicate fetches.
 
-**Overview panel** (top): Status badge, action buttons, and compact run-outcome metrics in one card:
+**Overview panel** (top): Status badge, control buttons, and compact run-outcome metrics in one card:
+
+**Control buttons** (header, via `ExperimentControlButtons`):
+
+| Button | When shown | Effect |
+|---|---|---|
+| **Pause** | Status is `running` | Stops after current phase; status → `paused` |
+| **Resume** | Status is `paused` | Continues from next incomplete parameter combo |
+| **Cancel** | Status is `running` | Stops sweep; status → `cancelled` or `partial` |
+
+Pause and cancel are cooperative — the current pipeline phase finishes before the sweep halts. Delete is blocked only for `running` experiments (paused experiments can be deleted).
 
 | Metric | Meaning |
 |---|---|
@@ -75,6 +86,7 @@ These buckets always sum to **Total** on terminal experiments.
 |---|---|
 | `complete` | Green — all planned runs succeeded |
 | `partial` | Amber — “Sweep Incomplete” with breakdown (e.g. 41/90 complete, 48 never started) |
+| `paused` | Violet — “Experiment is paused” with prompt to resume remaining combos |
 | `cancelled` | Gray — runs completed before cancellation |
 | Failed runs | Red panel listing `error_message` per run |
 | Interrupted runs | Amber panel listing interruption reason |
@@ -101,7 +113,7 @@ QUEUED → PARSING → CHUNKING → EMBEDDING → STORING → QUERYING → RERAN
 **Actions** (top-right header):
 - **Delete experiment**: Click the trash icon button to delete the entire experiment
   - Opens a confirmation modal showing experiment details and deletion statistics
-  - Cannot delete running experiments — cancel them first
+  - Cannot delete **running** experiments — pause or cancel first (**paused** experiments can be deleted)
   - Deletion is permanent and removes all associated data
 
 ---
@@ -136,10 +148,10 @@ This allows direct comparison of configs that used different models or retrieval
 | Screen | Polls | Interval | Stops When |
 |---|---|---|---|
 | Experiments List | Yes | Every 2 s | Never (always refreshes) |
-| Experiment Detail | Yes | Every 2 s | Status reaches terminal state |
+| Experiment Detail | Yes | Every 2 s | Status reaches terminal state (`paused` is non-terminal — polling continues) |
 | Search Explorer | No | — | Loads once |
 
-Terminal statuses: `complete`, `failed`, `partial`, `cancelled`
+Terminal statuses: `complete`, `failed`, `partial`, `cancelled` (non-terminal: `running`, `paused`)
 
 ---
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -184,6 +184,15 @@ The CLI will:
 
 Open `http://localhost:5173` to watch live progress and explore results.
 
+**Long sweeps**: pause and resume without losing completed runs:
+
+```bash
+rag-params-finder pause <experiment-id>    # stop after current phase
+rag-params-finder resume <experiment-id>   # continue remaining combos
+```
+
+Or use the Pause / Resume buttons on the experiment detail screen in the dashboard.
+
 ---
 
 ## 🤖 Pre-downloading Local Models (Optional)

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -16,8 +16,10 @@ Everything you need to run your first RAG parameter sweep experiment.
 |---|---|---|
 | Python | 3.12+ | Install via [python.org](https://www.python.org/downloads/) or `pyenv install 3.12.2` |
 | Node.js | 22+ | Install via [nodejs.org](https://nodejs.org/) or `nvm install 22` |
-| MongoDB Atlas | Free tier (M0) | [cloud.mongodb.com](https://cloud.mongodb.com/) — free tier fully supports vector search |
-| Voyage AI API key | Optional | [dash.voyageai.com](https://dash.voyageai.com) — only needed for Voyage models; local models need no key |
+| MongoDB Atlas | Free tier (M0) | **Required** — see [Cloud Account Setup](cloud-setup.md#mongodb-atlas-required) |
+| Voyage AI | Optional | Only for Voyage models — see [Cloud Account Setup](cloud-setup.md#voyage-ai-optional) |
+
+**New to Atlas or Voyage?** Start with **[Cloud Account Setup](cloud-setup.md)** — account creation, connection string, search indexes, API key, and Tier 1 billing (~15 min).
 
 ---
 
@@ -46,86 +48,29 @@ cd frontend && npm install && cd ..
 cp .env.example .env
 ```
 
-Edit `.env`:
+Edit `.env` — minimum for sweeps:
 
 ```bash
-# Required
+# Required (both sweeps)
 MONGODB_URI=mongodb+srv://<user>:<pass>@<cluster>.mongodb.net/rag_params_finder?retryWrites=true&w=majority
 
-# Optional — only needed for Voyage models
+# Required for Voyage sweep only — see cloud-setup.md checklist
 VOYAGE_API_KEY=vo-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+VOYAGE_RPM_LIMIT=2000
+VOYAGE_TPM_LIMIT=16000000
 
-# Optional — Voyage rate limits (must match your org tier on the Voyage dashboard)
-# Without a payment method: 3 RPM / 10_000 TPM (server default; sweeps are slow)
-# Tier 1: add payment at https://dashboard.voyageai.com/organization/billing/payment-methods
-#         then set e.g. VOYAGE_RPM_LIMIT=2000 and VOYAGE_TPM_LIMIT=16000000 (see .env.example)
 SERVER_URL=http://localhost:8001
-LOG_LEVEL=INFO
-
-# Optional — dashboard cluster storage quota bar (Atlas Admin API)
-# ATLAS_PUBLIC_KEY= / ATLAS_PRIVATE_KEY= / ATLAS_GROUP_ID=
-# Or set MONGODB_STORAGE_LIMIT_MB=512 for a manual quota override
 ```
 
-**MongoDB Atlas setup** (one-time):
-1. [cloud.mongodb.com](https://cloud.mongodb.com/) → create a free cluster
-2. **Database Access** → add a user with read/write permissions
-3. **Network Access** → add your IP (or `0.0.0.0/0` for local dev)
-4. **Connect → Compass** → copy the SRV connection string into `MONGODB_URI`
+Full variable reference: [Troubleshooting → Environment Variables](troubleshooting.md#-environment-variables-reference). Optional Atlas Admin API keys for dashboard quota bar — see `.env.example`.
 
-### 2. Indexes are created automatically
+### 2. Search indexes (required before sweep)
 
-The server **automatically creates all required indexes** on startup:
-- `vector_index_1024` (Voyage models, 1024-dim)
-- `vector_index_384` (local models, 384-dim)
-- `text_search_index` (sparse/hybrid retrieval)
+Both example configs use dense + sparse + hybrid — create **`vector_index_384`** (local) or **`vector_index_1024`** (Voyage) **and** **`text_search_index`** on the `chunks` collection.
 
-**On paid clusters (M10+)**: Indexes are created programmatically. Check server logs to confirm creation.
+**M0 free tier:** do this manually in Atlas UI before running a sweep — see [Cloud Account Setup → step 6](cloud-setup.md#6-create-search-indexes-m0--required-before-sweep).
 
-**On free-tier clusters (M0/M2/M5)**: Programmatic index creation is not supported. You'll see a warning in server logs. Create indexes manually:
-
-#### Manual index creation (M0/M2/M5 only)
-
-1. Atlas UI → your cluster → **Browse Collections** → `chunks` collection → **Search Indexes** tab
-2. **Create Search Index** → JSON Editor
-
-For **Voyage AI models** (1024-dim), name: `vector_index_1024`:
-```json
-{
-  "fields": [
-    { "type": "vector", "path": "embedding", "numDimensions": 1024, "similarity": "cosine" },
-    { "type": "filter", "path": "experiment_id" },
-    { "type": "filter", "path": "embedding_model" }
-  ]
-}
-```
-
-For **local models** (384-dim), name: `vector_index_384`:
-```json
-{
-  "fields": [
-    { "type": "vector", "path": "embedding", "numDimensions": 384, "similarity": "cosine" },
-    { "type": "filter", "path": "experiment_id" },
-    { "type": "filter", "path": "embedding_model" }
-  ]
-}
-```
-
-For **sparse/hybrid retrieval**, name: `text_search_index`:
-```json
-{
-  "mappings": {
-    "dynamic": false,
-    "fields": {
-      "text": [{ "type": "string" }],
-      "experiment_id": [{ "type": "token" }],
-      "embedding_model": [{ "type": "token" }]
-    }
-  }
-}
-```
-
-Wait ~1–2 minutes for indexes to become active. All three indexes coexist on the same `chunks` collection.
+**M10+ paid tier:** server creates indexes on startup — check uvicorn logs.
 
 ---
 
@@ -166,11 +111,13 @@ cd frontend && npm run dev
 
 ## ▶️ Run Your First Experiment
 
+Complete the checklist for your sweep path in **[Cloud Account Setup → Before you run a sweep](cloud-setup.md#before-you-run-a-sweep)** first.
+
 ```bash
-# Local models — no API key needed (90 runs: all chunkers × all retrieval methods)
+# Local sweep — checklist items 1–5 (no Voyage)
 rag-params-finder run --config configs/example-mongodb-local.yaml
 
-# Voyage AI models — requires VOYAGE_API_KEY in .env
+# Voyage sweep — checklist items 1–9
 rag-params-finder run --config configs/example-mongodb-voyage.yaml
 
 # Submit and detach (check dashboard for status instead)
@@ -210,6 +157,7 @@ Models are cached in `~/.cache/huggingface/hub/` after the first download.
 
 ## 👉 Next Steps
 
+- [Cloud Account Setup](cloud-setup.md) — Atlas account, Voyage billing, search indexes
 - [Configuration reference](configuration.md) — all YAML fields, sweep expansion, queries format
 - [CLI reference](cli-reference.md) — all commands and flags
 - [Dashboard guide](dashboard-guide.md) — reading the experiments list, detail screen, and search explorer

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -55,10 +55,11 @@ MONGODB_URI=mongodb+srv://<user>:<pass>@<cluster>.mongodb.net/rag_params_finder?
 # Optional — only needed for Voyage models
 VOYAGE_API_KEY=vo-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
-# Optional — defaults shown (free-tier Voyage limits)
+# Optional — Voyage rate limits (must match your org tier on the Voyage dashboard)
+# Without a payment method: 3 RPM / 10_000 TPM (server default; sweeps are slow)
+# Tier 1: add payment at https://dashboard.voyageai.com/organization/billing/payment-methods
+#         then set e.g. VOYAGE_RPM_LIMIT=2000 and VOYAGE_TPM_LIMIT=16000000 (see .env.example)
 SERVER_URL=http://localhost:8001
-VOYAGE_RPM_LIMIT=3
-VOYAGE_TPM_LIMIT=10000
 LOG_LEVEL=INFO
 
 # Optional — dashboard cluster storage quota bar (Atlas Admin API)

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -55,11 +55,15 @@ MONGODB_URI=mongodb+srv://<user>:<pass>@<cluster>.mongodb.net/rag_params_finder?
 # Optional — only needed for Voyage models
 VOYAGE_API_KEY=vo-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
-# Optional — defaults shown
+# Optional — defaults shown (free-tier Voyage limits)
 SERVER_URL=http://localhost:8001
-VOYAGE_RPM_LIMIT=300
-VOYAGE_TPM_LIMIT=1000000
+VOYAGE_RPM_LIMIT=3
+VOYAGE_TPM_LIMIT=10000
 LOG_LEVEL=INFO
+
+# Optional — dashboard cluster storage quota bar (Atlas Admin API)
+# ATLAS_PUBLIC_KEY= / ATLAS_PRIVATE_KEY= / ATLAS_GROUP_ID=
+# Or set MONGODB_STORAGE_LIMIT_MB=512 for a manual quota override
 ```
 
 **MongoDB Atlas setup** (one-time):

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -12,15 +12,9 @@ Common errors and how to fix them.
 
 **Symptom**: server logs show `Search index 'vector_index' not found` or queries return no results.
 
-**Cause**: The Atlas vector index must be created manually — the server cannot create it automatically.
+**Cause**: Search indexes are missing or not yet **ACTIVE**. On M0 free tier they must be created manually; on M10+ check server logs for auto-creation failures.
 
-**Fix**:
-
-1. Atlas UI → your cluster → **Browse Collections** → `chunks` collection → **Search Indexes** tab
-2. **Create Search Index** → JSON Editor
-3. Paste the correct index definition for your model type
-
-**Voyage models** (1024-dim) — name: `vector_index_1024`:
+**Fix**: Full steps → [Cloud Account Setup → step 6](cloud-setup.md#6-create-search-indexes-m0--required-before-sweep). Quick reference — **Voyage models** (1024-dim), name: `vector_index_1024`:
 ```json
 {
   "fields": [
@@ -134,9 +128,10 @@ embedding:
 **Symptom**: `voyageai.error.RateLimitError: Rate limit exceeded` in server logs; run status shows `failed`.
 
 **Fix**:
+- Complete [Cloud Account Setup → Voyage step 3](cloud-setup.md#3-unlock-tier-1-rate-limits-required-for-90-run-sweep) (payment method + ≥$5 credits + `.env` limits)
 - Check usage and org limits at [dash.voyageai.com/usage](https://dash.voyageai.com/usage) and [organization rate limits](https://dashboard.voyageai.com/organization/rate-limits)
 - **Free tier** (no payment method): 3 RPM / 10,000 TPM — server defaults match this
-- **Tier 1** (payment method): 2,000 RPM; TPM per model (e.g. `voyage-4-lite` / `voyage-3.5-lite` → 16M, `voyage-4` / `voyage-3.5` → 8M, `rerank-2.5-lite` → 4M). See [Voyage rate limits](https://docs.voyageai.com/docs/rate-limits) and `.env.example`
+- **Tier 1** (payment method + credits): 2,000 RPM; TPM per model (e.g. `voyage-4-lite` / `voyage-3.5-lite` → 16M, `voyage-4` / `voyage-3.5` → 8M, `rerank-2.5-lite` → 4M). See [Voyage rate limits](https://docs.voyageai.com/docs/rate-limits) and `.env.example`
 - Set `VOYAGE_RPM_LIMIT` and `VOYAGE_TPM_LIMIT` in `.env` to **match or stay slightly below** your tier (restart uvicorn after changing)
 - If limits are too **low**, sweeps are slow but safe; if too **high**, you get 429s (retry/backoff applies)
 - Switch to `provider: local` for testing (no API key, no rate limits)
@@ -295,7 +290,8 @@ db.results.deleteMany({experiment_id: exp_id})
 
 ## 👉 See Also
 
-- [Getting Started](getting-started.md) — Atlas setup, vector index creation, and first run
+- [Cloud Account Setup](cloud-setup.md) — Atlas account, Voyage billing, search indexes
+- [Getting Started](getting-started.md) — install, configure, first run
 - [Configuration Reference](configuration.md) — fix provider/model mismatch errors
 - [Dashboard Guide](dashboard-guide.md) — understand what the UI is showing
 - [Local Environment](../contributor-guide/local-environment.md) — deeper debugging and MongoDB shell patterns

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -143,6 +143,30 @@ embedding:
 
 ---
 
+## 📄 voyage-context-3 token limit exceeded
+
+**Symptom**: server logs or Voyage API error:
+
+```
+Request to model 'voyage-context-3' failed. The example at index 0 in your batch has too many tokens
+and does not fit into the model's context window of 32000 tokens.
+```
+
+**Cause**: `voyage-context-3` embeds document chunks via the **contextualized** API, which shares context across chunks in each segment. Voyage does **not** truncate contextualized inputs. Either:
+
+1. The **combined tokens** of all chunks in one segment exceeded 32K (common on long PDFs), or
+2. A **single chunk** exceeded 32K tokens (oversized `chunk_size`).
+
+**Fix**:
+
+- **Server ≥ 2026-05-19**: the embedder automatically splits long documents into ~30K-token segments. Restart uvicorn and re-run. Check logs for `Split N chunks into M contextualized segments`.
+- If a **single chunk** is too large, reduce `chunk_sizes` in your YAML (e.g. `[256, 512]` not `[8192, 16384]`).
+- For documents that still fail, temporarily disable `voyage-context-3` and use `voyage-3.5-lite` or `voyage-4-lite` (standard per-chunk embedding, no shared context).
+
+**Note**: only `voyage-context-3` uses this API. All other registered Voyage models route through `client.embed()` and are not subject to the 32K per-segment limit.
+
+---
+
 ## 🔁 Experiment stuck `running` or shows `partial` after server restart
 
 **Symptom**: Dashboard shows an experiment as `running` for hours/days, or `partial` with many “Not Started” runs after you restarted uvicorn (`--reload`) or the server crashed mid-sweep.
@@ -159,7 +183,7 @@ embedding:
 
 1. Restart the server once — reconciliation runs at startup (check logs for `Reconciled N orphaned experiment(s)`)
 2. On the detail screen, verify outcome metrics: **Successful + Failed + Interrupted + Not Started = Total**
-3. To finish remaining parameter combos, either submit a trimmed YAML for the missing combos, or wait for Slice 10 `recover` (retry in-place)
+3. To finish remaining parameter combos: **`rag-params-finder resume <experiment-id>`** if status is `paused`, or pause a running sweep first then resume later. Alternatively submit a trimmed YAML for missing combos, or wait for Slice 10 `recover` (retry failed/interrupted runs in-place)
 
 **Prevention during long sweeps**:
 
@@ -221,7 +245,7 @@ rag-params-finder delete <experiment-id> --force
 
 Both methods:
 - Show a confirmation modal with experiment details
-- Prevent deletion of running experiments (cancel them first)
+- Prevent deletion of **running** experiments (pause or cancel first; **paused** experiments can be deleted)
 - Cascade delete across all collections (experiments, run_status, chunks, results)
 - Display deletion statistics after completion
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -189,13 +189,16 @@ and does not fit into the model's context window of 32000 tokens.
 
 ---
 
-## 🌀 Dashboard stuck on "Loading…"
+## 🌀 Dashboard stuck on "Loading…" or "Checking for experiments"
 
-**Symptom**: browser shows a loading spinner indefinitely or a "Failed to fetch" error.
+**Symptom**: browser shows a loading spinner indefinitely, "Waiting for the server to finish this refresh cycle", or a "Failed to fetch" error — often while a CLI sweep is embedding/chunking on the server.
 
 | Cause | Fix |
 |---|---|
 | Server not running | Start with `uvicorn server.main:app --reload --port 8001`; verify at `http://localhost:8001/healthz` |
+| API starved during heavy sweep *(older builds)* | Restart uvicorn after upgrading — sweeps now run on a dedicated thread pool so `GET /experiments` stays responsive |
+| Vector DB stats still loading | Stats load separately and may lag; the experiment **list** should appear within a few seconds even during a sweep |
+| Request timed out (30s) | Normal under extreme Atlas load; wait for the next 2s poll or open `http://127.0.0.1:8001/healthz` to confirm the process is alive |
 | Wrong server port | Check `SERVER_URL` in `.env` matches the port uvicorn is using |
 | CORS error | Hard-refresh the browser (`Cmd+Shift+R`); restart server |
 | Frontend pointing at wrong URL | Check `frontend/src/services/apiClient.ts` base URL matches server port |

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -134,9 +134,11 @@ embedding:
 **Symptom**: `voyageai.error.RateLimitError: Rate limit exceeded` in server logs; run status shows `failed`.
 
 **Fix**:
-- Check usage at [dash.voyageai.com/usage](https://dash.voyageai.com/usage)
-- Free tier: 300 RPM / 1M TPM
-- Set `VOYAGE_RPM_LIMIT` and `VOYAGE_TPM_LIMIT` in `.env` to throttle requests to match your tier
+- Check usage and org limits at [dash.voyageai.com/usage](https://dash.voyageai.com/usage) and [organization rate limits](https://dashboard.voyageai.com/organization/rate-limits)
+- **Free tier** (no payment method): 3 RPM / 10,000 TPM — server defaults match this
+- **Tier 1** (payment method): 2,000 RPM; TPM per model (e.g. `voyage-4-lite` / `voyage-3.5-lite` → 16M, `voyage-4` / `voyage-3.5` → 8M, `rerank-2.5-lite` → 4M). See [Voyage rate limits](https://docs.voyageai.com/docs/rate-limits) and `.env.example`
+- Set `VOYAGE_RPM_LIMIT` and `VOYAGE_TPM_LIMIT` in `.env` to **match or stay slightly below** your tier (restart uvicorn after changing)
+- If limits are too **low**, sweeps are slow but safe; if too **high**, you get 429s (retry/backoff applies)
 - Switch to `provider: local` for testing (no API key, no rate limits)
 
 ---

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -141,6 +141,33 @@ embedding:
 
 ---
 
+## 🔁 Experiment stuck `running` or shows `partial` after server restart
+
+**Symptom**: Dashboard shows an experiment as `running` for hours/days, or `partial` with many “Not Started” runs after you restarted uvicorn (`--reload`) or the server crashed mid-sweep.
+
+**Cause**: Sweep execution runs in FastAPI `BackgroundTasks` (in-memory only). When the process dies, MongoDB may still show `status: running` and in-flight runs mid-phase — even though nothing is executing.
+
+**Automatic fix (server ≥ 2026-05-19)**: On every server start, `reconcile_orphaned_experiments()` in `server/core/startup_reconciliation.py`:
+
+1. Finds experiments still marked `running`
+2. Marks in-flight runs as `interrupted` with error *“Interrupted — server restarted while run was in progress”*
+3. Recomputes experiment status → usually `partial` when some runs completed and others never started
+
+**What to do**:
+
+1. Restart the server once — reconciliation runs at startup (check logs for `Reconciled N orphaned experiment(s)`)
+2. On the detail screen, verify outcome metrics: **Successful + Failed + Interrupted + Not Started = Total**
+3. To finish remaining parameter combos, either submit a trimmed YAML for the missing combos, or wait for Slice 10 `recover` (retry in-place)
+
+**Prevention during long sweeps**:
+
+- Avoid editing server code (triggers `--reload`) while a large sweep is running
+- Run uvicorn **without** `--reload` for production-length sweeps: `uvicorn server.main:app --port 8001`
+
+**Note**: `RECOVER_ON_BOOT=true` does **not** yet retry interrupted runs — it only logs a reminder. Status reconciliation always runs regardless of that flag.
+
+---
+
 ## 🌀 Dashboard stuck on "Loading…"
 
 **Symptom**: browser shows a loading spinner indefinitely or a "Failed to fetch" error.
@@ -217,9 +244,14 @@ db.results.deleteMany({experiment_id: exp_id})
 | `MONGODB_URI` | Yes | — | MongoDB Atlas connection string |
 | `VOYAGE_API_KEY` | No | — | Voyage AI API key (only if using Voyage models) |
 | `SERVER_URL` | No | `http://localhost:8001` | FastAPI server URL (used by CLI) |
-| `VOYAGE_RPM_LIMIT` | No | `300` | Voyage requests-per-minute limit (throttle guard) |
-| `VOYAGE_TPM_LIMIT` | No | `1000000` | Voyage tokens-per-minute limit |
-| `RECOVER_ON_BOOT` | No | `false` | Persisted into experiment metadata for the dashboard only; **does not** start or retry runs on server boot yet. When implemented ([Slice 10](../slices/SLICE-10-RUN-RECOVERY.md)), boot recovery will target **INTERRUPTED** runs only — not every **FAILED** run. |
+| `VOYAGE_RPM_LIMIT` | No | `3` | Voyage requests-per-minute limit (throttle guard; free-tier default) |
+| `VOYAGE_TPM_LIMIT` | No | `10000` | Voyage tokens-per-minute limit (free-tier default) |
+| `ATLAS_PUBLIC_KEY` | No | — | Atlas Admin API public key — enables cluster storage quota in dashboard |
+| `ATLAS_PRIVATE_KEY` | No | — | Atlas Admin API private key |
+| `ATLAS_GROUP_ID` | No | — | 24-char Atlas **project** ID (from cloud.mongodb.com URL) |
+| `ATLAS_CLUSTER_NAME` | No | *(from URI)* | Cluster name for quota lookup; parsed from `MONGODB_URI` host if omitted |
+| `MONGODB_STORAGE_LIMIT_MB` | No | `0` | Manual cluster quota override (MB). `0` = try Atlas API; omit quota bar if unavailable |
+| `RECOVER_ON_BOOT` | No | `false` | Stored in experiment metadata for the dashboard. **Status reconciliation on boot always runs.** Automatic **retry** of interrupted runs is not implemented yet ([Slice 10](../slices/SLICE-10-RUN-RECOVERY.md)). |
 | `LOG_LEVEL` | No | `INFO` | Logging verbosity (`DEBUG` for verbose output) |
 
 ---

--- a/frontend/src/components/ExperimentControlButtons.tsx
+++ b/frontend/src/components/ExperimentControlButtons.tsx
@@ -1,0 +1,145 @@
+import { useState, type MouseEvent } from 'react';
+import {
+  cancelExperiment,
+  pauseExperiment,
+  resumeExperiment,
+} from '../services/apiClient';
+import type { ExperimentStatus } from '../types';
+import {
+  isPausedExperimentStatus,
+  isRunningExperimentStatus,
+} from '../utils/experimentStatus';
+
+type ControlTone = 'light' | 'dark';
+type ControlSize = 'sm' | 'md';
+
+interface ExperimentControlButtonsProps {
+  experimentId: string;
+  status: ExperimentStatus;
+  tone?: ControlTone;
+  size?: ControlSize;
+  onStatusChange?: () => void | Promise<void>;
+  onError?: (message: string) => void;
+}
+
+function stopRowNavigation(event: MouseEvent<HTMLDivElement>) {
+  event.stopPropagation();
+}
+
+export default function ExperimentControlButtons({
+  experimentId,
+  status,
+  tone = 'light',
+  size = 'md',
+  onStatusChange,
+  onError,
+}: ExperimentControlButtonsProps) {
+  const [pausing, setPausing] = useState(false);
+  const [resuming, setResuming] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
+
+  const isRunning = isRunningExperimentStatus(status);
+  const isPaused = isPausedExperimentStatus(status);
+
+  if (!isRunning && !isPaused) {
+    return null;
+  }
+
+  const pad = size === 'sm' ? 'px-2.5 py-1 text-xs' : 'px-4 py-2 text-sm';
+  const pauseClass =
+    tone === 'dark'
+      ? 'border border-violet-400/50 bg-violet-500/20 text-violet-100 hover:bg-violet-500/30'
+      : 'border border-violet-300 bg-violet-50 text-violet-800 hover:bg-violet-100';
+  const resumeClass =
+    tone === 'dark'
+      ? 'bg-emerald-600 text-white hover:bg-emerald-500'
+      : 'bg-emerald-600 text-white hover:bg-emerald-700';
+  const cancelClass =
+    tone === 'dark'
+      ? 'bg-red-600/90 text-white hover:bg-red-500'
+      : 'bg-red-600 text-white hover:bg-red-700';
+
+  async function runAction(
+    action: () => Promise<unknown>,
+    setBusy: (busy: boolean) => void,
+  ) {
+    setBusy(true);
+    try {
+      await action();
+      await onStatusChange?.();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Action failed';
+      onError?.(message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handlePause() {
+    if (
+      !confirm(
+        'Pause this experiment? The current run will finish its phase, then execution stops.',
+      )
+    ) {
+      return;
+    }
+    await runAction(() => pauseExperiment(experimentId), setPausing);
+  }
+
+  async function handleResume() {
+    await runAction(() => resumeExperiment(experimentId), setResuming);
+  }
+
+  async function handleCancel() {
+    if (
+      !confirm(
+        'Cancel this experiment? Runs in progress will stop after the current phase.',
+      )
+    ) {
+      return;
+    }
+    await runAction(() => cancelExperiment(experimentId), setCancelling);
+  }
+
+  const disabled = pausing || resuming || cancelling;
+
+  return (
+    <div
+      role="group"
+      aria-label="Experiment controls"
+      className="flex flex-wrap items-center justify-end gap-2"
+      onClick={stopRowNavigation}
+    >
+      {isRunning && (
+        <>
+          <button
+            type="button"
+            onClick={handlePause}
+            disabled={disabled}
+            className={`rounded-lg font-semibold shadow-sm transition-colors disabled:opacity-50 ${pad} ${pauseClass}`}
+          >
+            {pausing ? 'Pausing…' : '⏸ Pause'}
+          </button>
+          <button
+            type="button"
+            onClick={handleCancel}
+            disabled={disabled}
+            className={`rounded-lg font-semibold shadow-sm transition-colors disabled:opacity-50 ${pad} ${cancelClass}`}
+          >
+            {cancelling ? 'Cancelling…' : '⏹ Cancel'}
+          </button>
+        </>
+      )}
+      {isPaused && (
+        <button
+          type="button"
+          onClick={handleResume}
+          disabled={disabled}
+          className={`rounded-lg font-semibold shadow-sm transition-colors disabled:opacity-50 ${pad} ${resumeClass}`}
+        >
+          {resuming ? 'Resuming…' : '▶ Resume'}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ExperimentDetailScreen.tsx
+++ b/frontend/src/components/ExperimentDetailScreen.tsx
@@ -22,20 +22,25 @@ import ExperimentProgressCard from './ExperimentProgressCard';
 import ExperimentVectorDbStatsCard from './ExperimentVectorDbStatsCard';
 import type { FeedEntry } from './LoadingFeedbackPanel';
 import {
-  cancelExperiment,
   deleteExperiment,
   getExperiment,
   getExperimentDbStats,
   getExperimentWithProgress,
   type ExperimentProgressCallback,
 } from '../services/apiClient';
+import ExperimentControlButtons from './ExperimentControlButtons';
 import ConfirmDeleteModal from './ConfirmDeleteModal';
 import CollapsibleCard from './CollapsibleCard';
 import { RunStatus, Phase, EnvParams, SweepSummary, ExperimentStatus, Experiment, ExperimentDbStatsSummary } from '../types';
 import { createStallWatcher, type FetchProgressUpdate } from '../services/fetchWithProgress';
 import { devDebugThrottled, devWarn } from '../utils/devLog';
 import { toExperimentDbStatsSummary } from '../utils/experimentDbStats';
-import { isRunningExperimentStatus, isTerminalExperimentStatus, summarizeExperimentRuns } from '../utils/experimentStatus';
+import {
+  isPausedExperimentStatus,
+  isRunningExperimentStatus,
+  isTerminalExperimentStatus,
+  summarizeExperimentRuns,
+} from '../utils/experimentStatus';
 
 let detailFeedSeq = 0;
 
@@ -279,6 +284,7 @@ function StatusBadge({ status }: { status: string }) {
     failed: { bg: 'bg-red-100', text: 'text-red-800', icon: icons.x, ring: 'ring-red-600' },
     partial: { bg: 'bg-yellow-100', text: 'text-yellow-800', icon: icons.x, ring: 'ring-yellow-600' },
     cancelled: { bg: 'bg-gray-100', text: 'text-gray-800', icon: icons.x, ring: 'ring-gray-600' },
+    paused: { bg: 'bg-violet-100', text: 'text-violet-800', icon: icons.clock, ring: 'ring-violet-600' },
   }[status] || { bg: 'bg-slate-100', text: 'text-slate-800', icon: icons.clock, ring: 'ring-slate-600' };
 
   return (
@@ -391,7 +397,6 @@ export default function ExperimentDetailScreen({
   const [detail, setDetail] = useState<ExperimentDetail | null>(seededDetail);
   const [error, setError] = useState<string | null>(null);
   const [hydrating, setHydrating] = useState(seededDetail === null);
-  const [cancelling, setCancelling] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
@@ -598,22 +603,16 @@ export default function ExperimentDetailScreen({
     };
   }, [experimentId, initialExperiment, startDetailPollIfRunning, stopDetailPoll]);
 
-  async function handleCancel() {
-    if (!confirm('Cancel this experiment? Runs in progress will stop after the current phase.')) {
-      return;
+  const refreshDetailAfterControl = useCallback(async () => {
+    const refreshed = await getExperiment(experimentId);
+    setDetail(refreshed as unknown as ExperimentDetail);
+    if (isRunningExperimentStatus(refreshed.status)) {
+      startDetailPollIfRunning(refreshed.status);
+    } else {
+      stopDetailPoll();
     }
-    setCancelling(true);
-    try {
-      await cancelExperiment(experimentId);
-      const refreshed = await getExperiment(experimentId);
-      setDetail(refreshed as unknown as ExperimentDetail);
-      setError(null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to cancel');
-    } finally {
-      setCancelling(false);
-    }
-  }
+    setError(null);
+  }, [experimentId, startDetailPollIfRunning, stopDetailPoll]);
 
   async function handleDelete() {
     setDeleting(true);
@@ -631,7 +630,10 @@ export default function ExperimentDetailScreen({
 
   const TERMINAL_STATUSES: ExperimentStatus[] = ['complete', 'failed', 'partial', 'cancelled'];
   const isTerminal = detail && TERMINAL_STATUSES.includes(detail.status);
-  const isRunning = detail?.status === 'running';
+  const isRunning = isRunningExperimentStatus(detail?.status);
+  const isPaused = isPausedExperimentStatus(detail?.status);
+  const canExplore = Boolean(onExplore && (isTerminal || isRunning || isPaused));
+  const canDelete = isTerminal || isPaused;
 
   const backToList = (
     <button
@@ -744,15 +746,28 @@ export default function ExperimentDetailScreen({
           pageMeta={<span className="font-mono">{experimentId}</span>}
           pageHint={
             isRunning
-              ? `Live updates every ${DETAIL_POLL_MS / 1000}s until this batch reaches a terminal status.`
-              : 'Runs, sweep metadata, and stored results appear in the sections below.'
+              ? `Live updates every ${DETAIL_POLL_MS / 1000}s. Pause or cancel from the controls above.`
+              : isPaused
+                ? 'Experiment is paused — resume to continue remaining parameter combinations.'
+                : 'Runs, sweep metadata, and stored results appear in the sections below.'
+          }
+          topRight={
+            <ExperimentControlButtons
+              experimentId={experimentId}
+              status={detail.status}
+              tone="dark"
+              onStatusChange={refreshDetailAfterControl}
+              onError={(message) => setError(message)}
+            />
           }
           showDashboardFootnote={false}
         />
       }
       sidebar={experimentRailBlurb(
         isRunning
-          ? 'Cancel stays available until every run leaves the running phases.'
+          ? 'Pause or cancel from the header while runs are in flight.'
+          : isPaused
+            ? 'Resume from the header to continue the sweep.'
           : isTerminal && onExplore
           ? 'Open Explore results when you want aggregated rankings for this sweep.'
           : 'Status, configs, failures, and the run table populate the pane on the right.',
@@ -769,31 +784,29 @@ export default function ExperimentDetailScreen({
               </p>
             </div>
             <div className="flex shrink-0 flex-wrap items-center gap-2">
-              {(isTerminal || isRunning) && onExplore && (
+              {canExplore && (
                 <button
                   type="button"
                   onClick={onExplore}
                   title={
                     isRunning
                       ? 'Opens Search Explorer with data stored so far; more results appear as runs finish.'
-                      : undefined
+                      : isPaused
+                        ? 'Explore results from completed runs; resume to continue the sweep.'
+                        : undefined
                   }
                   className="rounded-lg bg-gradient-to-r from-blue-600 to-blue-700 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:from-blue-700 hover:to-blue-800"
                 >
                   {isRunning ? '🔍 Explore live' : '🔍 Explore'}
                 </button>
               )}
-              {isRunning && (
-                <button
-                  type="button"
-                  onClick={handleCancel}
-                  disabled={cancelling}
-                  className="rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-red-700 disabled:bg-red-300"
-                >
-                  {cancelling ? 'Cancelling…' : '⏹ Cancel'}
-                </button>
-              )}
-              {isTerminal && (
+              <ExperimentControlButtons
+                experimentId={experimentId}
+                status={detail.status}
+                onStatusChange={refreshDetailAfterControl}
+                onError={(message) => setError(message)}
+              />
+              {canDelete && (
                 <button
                   type="button"
                   onClick={() => setShowDeleteModal(true)}
@@ -826,13 +839,21 @@ export default function ExperimentDetailScreen({
 
         {/* Progress visualization for running experiments */}
         {detail && isRunning && detail.runs && detail.runs.length > 0 && (
-          <ExperimentProgressCard
-            title="Experiment Progress"
-            subtitle={`${runSummary.complete} of ${runSummary.expected} runs completed`}
-            percent={runSummary.expected > 0 ? (runSummary.complete / runSummary.expected) * 100 : 0}
-            variant="default"
-            className="mb-6"
-          />
+          <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <ExperimentProgressCard
+              title="Experiment Progress"
+              subtitle={`${runSummary.complete} of ${runSummary.expected} runs completed`}
+              percent={runSummary.expected > 0 ? (runSummary.complete / runSummary.expected) * 100 : 0}
+              variant="default"
+              className="min-w-0 flex-1"
+            />
+            <ExperimentControlButtons
+              experimentId={experimentId}
+              status={detail.status}
+              onStatusChange={refreshDetailAfterControl}
+              onError={(message) => setError(message)}
+            />
+          </div>
         )}
 
         <div className="mb-6">
@@ -1250,7 +1271,35 @@ export default function ExperimentDetailScreen({
           </div>
         )}
 
-        {!isTerminal && (
+        {isPaused && (
+          <div className="mt-6 bg-gradient-to-br from-violet-50 to-purple-50 border-2 border-violet-300 rounded-2xl p-6 shadow-lg">
+            <div className="flex items-center justify-between gap-4 flex-wrap">
+              <div className="flex items-center gap-4">
+                <div className="w-12 h-12 rounded-full bg-violet-500 flex items-center justify-center text-white">
+                  {icons.clock}
+                </div>
+                <div>
+                  <h3 className="text-lg font-bold text-violet-900">Experiment Paused</h3>
+                  <p className="text-sm text-violet-800 mt-1">
+                    {runSummary.complete} of {runSummary.expected} run(s) completed.
+                    {runSummary.neverStarted > 0 && ` ${runSummary.neverStarted} not started yet.`}
+                  </p>
+                  <p className="text-xs text-violet-700 mt-2">
+                    Resume to continue from the next parameter combination. Completed runs are kept.
+                  </p>
+                </div>
+              </div>
+              <ExperimentControlButtons
+                experimentId={experimentId}
+                status={detail.status}
+                onStatusChange={refreshDetailAfterControl}
+                onError={(message) => setError(message)}
+              />
+            </div>
+          </div>
+        )}
+
+        {isRunning && (
           <div className="mt-4 text-center text-xs text-slate-500">
             Polling every {DETAIL_POLL_MS / 1000}s <span className="animate-pulse">●</span>
           </div>

--- a/frontend/src/components/ExperimentsScreen.tsx
+++ b/frontend/src/components/ExperimentsScreen.tsx
@@ -11,12 +11,14 @@ import DashboardShell from './DashboardShell';
 import LoadingFeedbackPanel, { type FeedEntry } from './LoadingFeedbackPanel';
 import PollingIndicator from './PollingIndicator';
 import ConfirmDeleteModal from './ConfirmDeleteModal';
+import ExperimentControlButtons from './ExperimentControlButtons';
 import VectorDbStatsPanel from './VectorDbStatsPanel';
 import ExperimentVectorDbStatsCard from './ExperimentVectorDbStatsCard';
 import { createStallWatcher, type FetchProgressUpdate } from '../services/fetchWithProgress';
 import { deleteExperiment, getExperiments, getExperimentsWithProgress, getVectorDbStatsGrouped } from '../services/apiClient';
 import { Experiment, ExperimentDbStatsSummary, VectorDbStatsGroup } from '../types';
 import { devDebugThrottled, devWarn } from '../utils/devLog';
+import { isPausedExperimentStatus, isRunningExperimentStatus } from '../utils/experimentStatus';
 
 let feedSeq = 0;
 
@@ -99,7 +101,7 @@ function experimentsRailHelp() {
         <div className="mt-0.5 text-[11px] uppercase tracking-wider text-slate-500">Experiment list</div>
       </div>
       <div className="rounded-lg border border-slate-600/50 bg-slate-700/40 px-3 py-3 text-xs leading-relaxed text-slate-300 ring-1 ring-slate-600/35">
-        This table polls the experiments API continuously so you never miss a sweep finishing.
+        Running sweeps show Pause and Cancel on each row. Paused sweeps show Resume. Open an experiment for the same controls in the page header.
       </div>
     </>
   );
@@ -111,6 +113,7 @@ function statusBadgeClass(status: Experiment['status']): string {
   if (status === 'partial') return 'bg-yellow-100 text-yellow-700';
   if (status === 'failed') return 'bg-red-100 text-red-700';
   if (status === 'cancelled') return 'bg-orange-100 text-orange-700';
+  if (status === 'paused') return 'bg-violet-100 text-violet-700';
   return 'bg-slate-100 text-slate-700';
 }
 
@@ -201,6 +204,13 @@ export default function ExperimentsScreen({
       setSelectedExperiments(new Set());
     }
   }, [experiments]);
+
+  const refreshExperimentList = useCallback(async () => {
+    const refreshed = await getExperiments();
+    setExperiments(refreshed);
+    onCacheUpdate?.({ experiments: refreshed, vectorDbGroups });
+    setError(null);
+  }, [onCacheUpdate, vectorDbGroups]);
 
   const handleBulkDelete = useCallback(async () => {
     setDeleting(true);
@@ -530,9 +540,11 @@ export default function ExperimentsScreen({
               <div className="space-y-3">
                 {paginatedExperiments.map((exp) => {
                   const isSelected = selectedExperiments.has(exp.experiment_id);
-                  const isRunning = exp.status === 'running';
+                  const isRunning = isRunningExperimentStatus(exp.status);
+                  const isPaused = isPausedExperimentStatus(exp.status);
                   const isCollapsed = collapsedExperiments.has(exp.experiment_id);
                   const dbStats = statsByExperimentId.get(exp.experiment_id);
+                  const showRowControls = isRunning || isPaused;
                   return (
                     <div
                       key={exp.experiment_id}
@@ -588,9 +600,22 @@ export default function ExperimentsScreen({
                             </div>
                           )}
                         </button>
-                        <span className={`hidden sm:inline-flex rounded px-2 py-1 text-xs font-bold ${statusBadgeClass(exp.status)}`}>
-                          {exp.status}
-                        </span>
+                        <div className="flex shrink-0 flex-col items-end gap-2 sm:flex-row sm:items-center">
+                          {showRowControls && (
+                            <ExperimentControlButtons
+                              experimentId={exp.experiment_id}
+                              status={exp.status}
+                              size="sm"
+                              onStatusChange={refreshExperimentList}
+                              onError={(message) => setError(message)}
+                            />
+                          )}
+                          <span
+                            className={`inline-flex rounded px-2 py-1 text-xs font-bold ${statusBadgeClass(exp.status)}`}
+                          >
+                            {exp.status}
+                          </span>
+                        </div>
                       </div>
                       {!isCollapsed && (
                         <div className="space-y-4 border-t border-slate-100 bg-slate-50/60 px-4 py-4">

--- a/frontend/src/components/ExperimentsScreen.tsx
+++ b/frontend/src/components/ExperimentsScreen.tsx
@@ -127,18 +127,14 @@ function experimentStatsMap(groups: VectorDbStatsGroup[]): Map<string, Experimen
   return map;
 }
 
-/** True when we should show the full-page loading overlay (experiment list fetch only). */
+/** True only for the first experiment-list load — not for background polls. */
 function shouldShowLoadingPanel(
   initialLoadDone: boolean,
   loading: boolean,
-  isPolling: boolean,
-  experimentsCount: number,
   error: string | null,
 ): boolean {
   if (error !== null) return false;
-  if (!initialLoadDone || loading) return true;
-  if (experimentsCount === 0 && isPolling) return true;
-  return false;
+  return !initialLoadDone || loading;
 }
 
 export default function ExperimentsScreen({
@@ -257,7 +253,8 @@ export default function ExperimentsScreen({
     }
 
     const request = (async () => {
-      if (!options?.silent) setVectorDbLoading(true);
+      const showSpinner = !options?.silent && vectorDbGroups.length === 0;
+      if (showSpinner) setVectorDbLoading(true);
       try {
         const payload = await getVectorDbStatsGrouped();
         if (!aliveRef.current) return;
@@ -268,13 +265,13 @@ export default function ExperimentsScreen({
         setVectorDbError(err instanceof Error ? err.message : 'Failed to load vector DB stats');
       } finally {
         vectorDbStatsInFlightRef.current = null;
-        if (aliveRef.current && !options?.silent) setVectorDbLoading(false);
+        if (aliveRef.current && showSpinner) setVectorDbLoading(false);
       }
     })();
 
     vectorDbStatsInFlightRef.current = request;
     return request;
-  }, []);
+  }, [vectorDbGroups.length]);
 
   useEffect(() => {
     if (!initialLoadDone) return;
@@ -414,13 +411,7 @@ export default function ExperimentsScreen({
     };
   }, [cacheReady, loadVectorDbStats]);
 
-  const showLoadingPanel = shouldShowLoadingPanel(
-    initialLoadDone,
-    loading,
-    isPolling,
-    experiments.length,
-    error,
-  );
+  const showLoadingPanel = shouldShowLoadingPanel(initialLoadDone, loading, error);
   const showEmptyConfirmed =
     initialLoadDone &&
     !loading &&

--- a/frontend/src/components/VectorDbStatsPanel.tsx
+++ b/frontend/src/components/VectorDbStatsPanel.tsx
@@ -39,7 +39,11 @@ export default function VectorDbStatsPanel({
   if (loading && groups.length === 0) {
     return (
       <div className="mb-6 rounded-2xl border border-indigo-200 bg-gradient-to-br from-indigo-50 to-blue-50 p-6 text-sm text-slate-600">
-        Loading vector database stats…
+        <p className="font-medium text-slate-800">Loading vector database stats…</p>
+        <p className="mt-2 text-slate-600">
+          Counting chunks and storage across experiments. This is separate from the experiment list
+          and may take longer while a sweep is writing to Atlas.
+        </p>
       </div>
     );
   }
@@ -65,6 +69,9 @@ export default function VectorDbStatsPanel({
 
   return (
     <div className="mb-6 space-y-4">
+      {loading && (
+        <p className="text-xs font-medium text-indigo-700">Refreshing vector database stats…</p>
+      )}
       {groups.map((group) => (
         <div
           key={group.vector_db_id}

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -3,7 +3,7 @@ export const APP_NAME = 'RAG Params Finder';
 export const APP_TAGLINE =
   'Sweep chunking, embeddings, retrieval, and reranking—then inspect what worked on your evaluation queries.';
 export const APP_READ_ONLY_NOTE =
-  'Experiments start from the CLI; this UI reads your FastAPI backend (cancel is the only write when a run is active).';
+  'Experiments start from the CLI; this UI reads your FastAPI backend (pause, resume, and cancel are available while a sweep is active).';
 export const APP_FOOTNOTE_SUMMARY = 'How this dashboard relates to CLI runs';
 
 /** Polling intervals (ms). */

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -20,5 +20,11 @@ export const LOADING_STALL_AFTER_MS = 1800;
 /** Repeat stalled warnings while awaiting response (ms). */
 export const LOADING_STALL_REPEAT_MS = 2400;
 
+/** Abort hung API calls so polling does not leave the UI stuck forever. */
+export const API_FETCH_TIMEOUT_MS = 30_000;
+
+/** Vector DB stats aggregation can take longer than the experiment list. */
+export const VECTOR_DB_STATS_FETCH_TIMEOUT_MS = 90_000;
+
 /** Dev-console poll breadcrumbs — match backend info_throttled interval. */
 export const DEV_POLL_LOG_INTERVAL_MS = 60_000;

--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -1,5 +1,6 @@
 import { DeleteExperimentResponse, Experiment, ExperimentDbStatsResponse, ExploreResponse, VectorDbStatsGroupedResponse } from '../types';
-import { fetchJsonWithProgress, type FetchProgressUpdate } from './fetchWithProgress';
+import { API_FETCH_TIMEOUT_MS, VECTOR_DB_STATS_FETCH_TIMEOUT_MS } from '../constants';
+import { fetchJsonWithProgress, fetchWithTimeout, type FetchProgressUpdate } from './fetchWithProgress';
 import { devWarn } from '../utils/devLog';
 
 export { formatBytes } from './fetchWithProgress';
@@ -57,7 +58,7 @@ function emit(cb: ExperimentProgressCallback | undefined, u: FetchProgressUpdate
 export async function getExperiments(signal?: AbortSignal): Promise<Experiment[]> {
   let response: Response;
   try {
-    response = await fetch(EXPERIMENTS_URL, { signal });
+    response = await fetchWithTimeout(EXPERIMENTS_URL, { signal }, API_FETCH_TIMEOUT_MS);
   } catch (err) {
     rethrowWithFetchHint(EXPERIMENTS_URL, err);
   }
@@ -200,7 +201,7 @@ export async function getVectorDbStatsGrouped(
   const url = `${API_BASE_URL}/experiments/vector-db-stats`;
   let response: Response;
   try {
-    response = await fetch(url, { signal });
+    response = await fetchWithTimeout(url, { signal }, VECTOR_DB_STATS_FETCH_TIMEOUT_MS);
   } catch (err) {
     rethrowWithFetchHint(url, err);
   }

--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -228,6 +228,42 @@ export async function cancelExperiment(
   return response.json();
 }
 
+export async function pauseExperiment(
+  experimentId: string,
+): Promise<{ status: string; message: string }> {
+  const url = `${API_BASE_URL}/experiments/${experimentId}/pause`;
+  let response: Response;
+  try {
+    response = await fetch(url, { method: 'POST' });
+  } catch (err) {
+    rethrowWithFetchHint(url, err);
+  }
+  if (!response.ok) {
+    const parsed = await response.json().catch(() => ({}));
+    const detail = typeof parsed.detail === 'string' ? parsed.detail : undefined;
+    throw new Error(detail || 'Failed to pause experiment');
+  }
+  return response.json();
+}
+
+export async function resumeExperiment(
+  experimentId: string,
+): Promise<{ status: string; message: string; run_count?: number }> {
+  const url = `${API_BASE_URL}/experiments/${experimentId}/resume`;
+  let response: Response;
+  try {
+    response = await fetch(url, { method: 'POST' });
+  } catch (err) {
+    rethrowWithFetchHint(url, err);
+  }
+  if (!response.ok) {
+    const parsed = await response.json().catch(() => ({}));
+    const detail = typeof parsed.detail === 'string' ? parsed.detail : undefined;
+    throw new Error(detail || 'Failed to resume experiment');
+  }
+  return response.json();
+}
+
 export async function deleteExperiment(experimentId: string): Promise<DeleteExperimentResponse> {
   const url = `${API_BASE_URL}/experiments/${experimentId}`;
   let response: Response;

--- a/frontend/src/services/fetchWithProgress.ts
+++ b/frontend/src/services/fetchWithProgress.ts
@@ -2,7 +2,50 @@
  * Streaming fetch progress for GET JSON bodies — byte counts when Content-Length exists.
  */
 
+import { API_FETCH_TIMEOUT_MS } from '../constants';
+
 const BYTE_PROGRESS_INTERVAL_MS = 200;
+
+export function abortSignalWithTimeout(
+  userSignal: AbortSignal | undefined,
+  timeoutMs: number = API_FETCH_TIMEOUT_MS,
+): { signal: AbortSignal; dispose: () => void } {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  const forwardAbort = () => controller.abort();
+  if (userSignal?.aborted) {
+    controller.abort();
+  } else if (userSignal) {
+    userSignal.addEventListener('abort', forwardAbort, { once: true });
+  }
+  return {
+    signal: controller.signal,
+    dispose: () => {
+      clearTimeout(timeoutId);
+      userSignal?.removeEventListener('abort', forwardAbort);
+    },
+  };
+}
+
+export async function fetchWithTimeout(
+  url: string,
+  init?: RequestInit,
+  timeoutMs: number = API_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const { signal, dispose } = abortSignalWithTimeout(init?.signal ?? undefined, timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      throw new Error(
+        `Request timed out after ${Math.round(timeoutMs / 1000)}s — the server may be busy running a sweep.`,
+      );
+    }
+    throw err;
+  } finally {
+    dispose();
+  }
+}
 
 export type FetchProgressUpdate =
   | { type: 'message'; text: string; variant?: 'default' | 'warning' }
@@ -87,7 +130,13 @@ export async function fetchJsonWithProgress<T>(
   const abortSignal =
     rawSignal === null || rawSignal === undefined ? undefined : rawSignal;
 
-  const response = await fetch(url, init);
+  const { signal, dispose } = abortSignalWithTimeout(abortSignal);
+  let response: Response;
+  try {
+    response = await fetch(url, { ...init, signal });
+  } finally {
+    dispose();
+  }
 
   if (!response.ok) {
     const errText = await response.text().catch(() => '');

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,5 +1,11 @@
 // Experiment-level status (mirrored from server/models/enums.py ExperimentStatus)
-export type ExperimentStatus = 'running' | 'complete' | 'partial' | 'failed' | 'cancelled';
+export type ExperimentStatus =
+  | 'running'
+  | 'paused'
+  | 'complete'
+  | 'partial'
+  | 'failed'
+  | 'cancelled';
 
 // Enums (mirrored from server/models/enums.py)
 

--- a/frontend/src/utils/experimentStatus.ts
+++ b/frontend/src/utils/experimentStatus.ts
@@ -36,3 +36,11 @@ export function isTerminalExperimentStatus(status: ExperimentStatus | undefined)
 export function isRunningExperimentStatus(status: ExperimentStatus | undefined): boolean {
   return status === 'running';
 }
+
+export function isPausedExperimentStatus(status: ExperimentStatus | undefined): boolean {
+  return status === 'paused';
+}
+
+export function isActiveExperimentStatus(status: ExperimentStatus | undefined): boolean {
+  return status === 'running' || status === 'paused';
+}

--- a/server/api/experiments.py
+++ b/server/api/experiments.py
@@ -1,8 +1,9 @@
 import asyncio
 import uuid
+from collections.abc import Callable
 from datetime import datetime
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException
+from fastapi import APIRouter, HTTPException
 
 from server.api.experiments_shared import (
     mongo_delete_experiment_data,
@@ -18,6 +19,7 @@ from server.api.experiments_shared import (
     mongo_mark_experiment_paused_now,
     mongo_mark_experiment_running,
 )
+from server.core.executors import HEAVY_READ_EXECUTOR, schedule_sweep
 from server.core.orchestrator import (
     is_sweep_in_flight,
     request_cancel,
@@ -36,8 +38,14 @@ logger = get_logger(__name__)
 router = APIRouter()
 
 
+async def _run_heavy_read[R](fn: Callable[[], R]) -> R:
+    """Run expensive read-only Mongo aggregations off the default API thread pool."""
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(HEAVY_READ_EXECUTOR, fn)
+
+
 @router.post("")
-async def create_experiment(config: ExperimentConfig, background_tasks: BackgroundTasks):
+async def create_experiment(config: ExperimentConfig):
     """Submit a new experiment sweep configuration."""
     experiment_id = str(uuid.uuid4())
     timestamp_suffix = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
@@ -79,7 +87,7 @@ async def create_experiment(config: ExperimentConfig, background_tasks: Backgrou
     await asyncio.to_thread(mongo_insert_experiment_doc, experiment_doc)
 
     logger.info(f"Experiment '{stamped_name}' ({experiment_id}): {len(runs)} runs")
-    background_tasks.add_task(run_sweep, experiment_id, config)
+    schedule_sweep(run_sweep, experiment_id, config)
 
     return {
         "status": "submitted",
@@ -103,7 +111,7 @@ async def list_experiments():
 async def get_vector_db_stats_grouped():
     """Vector DB stats for all experiments, grouped by cluster."""
     logger.debug("GET /experiments/vector-db-stats")
-    payload = await asyncio.to_thread(mongo_get_vector_db_stats_grouped)
+    payload = await _run_heavy_read(mongo_get_vector_db_stats_grouped)
     info_throttled(
         logger,
         "poll:vector-db-stats",
@@ -150,7 +158,7 @@ async def get_experiment_db_stats(experiment_id: str):
     if not experiment:
         raise HTTPException(status_code=404, detail="Experiment not found")
 
-    stats = await asyncio.to_thread(mongo_get_experiment_db_stats, experiment_id)
+    stats = await _run_heavy_read(lambda: mongo_get_experiment_db_stats(experiment_id))
     info_throttled(
         logger,
         f"poll:db-stats:{experiment_id}",
@@ -169,8 +177,8 @@ async def explore_experiment(experiment_id: str, query: str | None = None):
 
     logger.debug(f"GET /experiments/{experiment_id}/explore (query={query!r})")
 
-    experiment_doc, query_results, run_statuses = await asyncio.to_thread(
-        mongo_load_explore_source, experiment_id
+    experiment_doc, query_results, run_statuses = await _run_heavy_read(
+        lambda: mongo_load_explore_source(experiment_id)
     )
     if not experiment_doc:
         raise HTTPException(status_code=404, detail="Experiment not found")
@@ -248,7 +256,7 @@ async def pause_experiment(experiment_id: str):
 
 
 @router.post("/{experiment_id}/resume")
-async def resume_experiment(experiment_id: str, background_tasks: BackgroundTasks):
+async def resume_experiment(experiment_id: str):
     """Resume a paused experiment from the next incomplete parameter combination."""
     logger.info(f"POST /experiments/{experiment_id}/resume")
 
@@ -278,7 +286,7 @@ async def resume_experiment(experiment_id: str, background_tasks: BackgroundTask
 
     config = ExperimentConfig.model_validate(config_payload)
     await asyncio.to_thread(mongo_mark_experiment_running, experiment_id)
-    background_tasks.add_task(resume_sweep, experiment_id, config)
+    schedule_sweep(resume_sweep, experiment_id, config)
 
     runs = expand_sweep(config)
     return {

--- a/server/api/experiments.py
+++ b/server/api/experiments.py
@@ -15,8 +15,16 @@ from server.api.experiments_shared import (
     mongo_list_results_for_experiment,
     mongo_load_explore_source,
     mongo_mark_experiment_cancelled_now,
+    mongo_mark_experiment_paused_now,
+    mongo_mark_experiment_running,
 )
-from server.core.orchestrator import request_cancel, run_sweep
+from server.core.orchestrator import (
+    is_sweep_in_flight,
+    request_cancel,
+    request_pause,
+    resume_sweep,
+    run_sweep,
+)
 from server.models.config import ExperimentConfig, expand_sweep
 from server.models.enums import ExperimentStatus
 from server.utils.log_throttle import info_throttled
@@ -208,6 +216,76 @@ async def cancel_experiment(experiment_id: str):
         "status": "cancel_requested",
         "experiment_id": experiment_id,
         "message": "Experiment will stop after the current phase completes",
+    }
+
+
+@router.post("/{experiment_id}/pause")
+async def pause_experiment(experiment_id: str):
+    """Pause a running experiment after the current phase completes."""
+    logger.info(f"POST /experiments/{experiment_id}/pause")
+
+    experiment = await asyncio.to_thread(mongo_find_experiment_by_id, experiment_id)
+    if not experiment:
+        raise HTTPException(status_code=404, detail="Experiment not found")
+
+    if experiment.get("status") != ExperimentStatus.RUNNING:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Experiment is not running (status: {experiment.get('status')})",
+        )
+
+    signalled = request_pause(experiment_id)
+
+    if not signalled:
+        await asyncio.to_thread(mongo_mark_experiment_paused_now, experiment_id)
+
+    logger.info(f"Experiment {experiment_id} pause requested (in-flight={signalled})")
+    return {
+        "status": "pause_requested",
+        "experiment_id": experiment_id,
+        "message": "Experiment will pause after the current phase completes",
+    }
+
+
+@router.post("/{experiment_id}/resume")
+async def resume_experiment(experiment_id: str, background_tasks: BackgroundTasks):
+    """Resume a paused experiment from the next incomplete parameter combination."""
+    logger.info(f"POST /experiments/{experiment_id}/resume")
+
+    experiment = await asyncio.to_thread(mongo_find_experiment_by_id, experiment_id)
+    if not experiment:
+        raise HTTPException(status_code=404, detail="Experiment not found")
+
+    status = experiment.get("status")
+    if status == ExperimentStatus.RUNNING:
+        if is_sweep_in_flight(experiment_id):
+            raise HTTPException(status_code=409, detail="Experiment is already running")
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Experiment is marked running but not executing — restart the server or reconcile"
+            ),
+        )
+    if status != ExperimentStatus.PAUSED:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Experiment cannot be resumed (status: {status})",
+        )
+
+    config_payload = experiment.get("config")
+    if not config_payload:
+        raise HTTPException(status_code=400, detail="Experiment config is missing")
+
+    config = ExperimentConfig.model_validate(config_payload)
+    await asyncio.to_thread(mongo_mark_experiment_running, experiment_id)
+    background_tasks.add_task(resume_sweep, experiment_id, config)
+
+    runs = expand_sweep(config)
+    return {
+        "status": "resume_requested",
+        "experiment_id": experiment_id,
+        "run_count": len(runs),
+        "message": "Experiment resumed — remaining parameter combinations will execute",
     }
 
 

--- a/server/api/experiments_shared.py
+++ b/server/api/experiments_shared.py
@@ -69,6 +69,20 @@ def mongo_mark_experiment_cancelled_now(experiment_id: str):
     )
 
 
+def mongo_mark_experiment_paused_now(experiment_id: str):
+    get_collection(EXPERIMENTS_COLLECTION).update_one(
+        {"_id": experiment_id},
+        {"$set": {"status": ExperimentStatus.PAUSED, "completed_at": datetime.utcnow()}},
+    )
+
+
+def mongo_mark_experiment_running(experiment_id: str):
+    get_collection(EXPERIMENTS_COLLECTION).update_one(
+        {"_id": experiment_id},
+        {"$set": {"status": ExperimentStatus.RUNNING, "completed_at": None}},
+    )
+
+
 def mongo_delete_experiment_data(experiment_id: str) -> dict[str, int]:
     """Delete all data for an experiment across all collections.
 

--- a/server/api/experiments_shared.py
+++ b/server/api/experiments_shared.py
@@ -7,6 +7,7 @@ Keeping I/O here isolates blocking work into threadpool tasks.
 from datetime import datetime
 
 from server.db.atlas import (
+    CHUNKS_COLLECTION,
     EXPERIMENTS_COLLECTION,
     RESULTS_COLLECTION,
     RUN_STATUS_COLLECTION,
@@ -244,32 +245,24 @@ def _run_breakdown_for_experiment(chunks_coll, results_coll, experiment_id: str)
     return breakdown
 
 
-def mongo_get_experiment_db_stats(experiment_id: str) -> dict:
-    """Get vector database statistics for an experiment."""
+def _assemble_experiment_db_stats(
+    experiment: dict | None,
+    *,
+    total_chunks: int,
+    embedding_models: list[str],
+    chunking_breakdown: dict[str, int],
+    total_results: int,
+    unique_queries: int,
+    runs_with_data: int,
+    run_breakdown: list[dict],
+) -> dict:
     from server.core.model_registry import EMBEDDING_MODELS, get_dimensions, get_index_name
-    from server.db.atlas import CHUNKS_COLLECTION
     from server.db.indexes import TEXT_SEARCH_INDEX_NAME
-
-    experiment = get_collection(EXPERIMENTS_COLLECTION).find_one(
-        {"experiment_id": experiment_id},
-        {"data_paths": 1, "sweep_summary": 1, "config": 1},
-    )
-    chunks_coll = get_collection(CHUNKS_COLLECTION)
-    results_coll = get_collection(RESULTS_COLLECTION)
-
-    total_chunks = chunks_coll.count_documents({"experiment_id": experiment_id})
-    embedding_models = chunks_coll.distinct("embedding_model", {"experiment_id": experiment_id})
 
     embedding_dimensions = sorted(
         {get_dimensions(model) for model in embedding_models if model in EMBEDDING_MODELS}
     )
-
     unique_documents = len((experiment or {}).get("data_paths") or [])
-    total_results = results_coll.count_documents({"experiment_id": experiment_id})
-    unique_queries = len(results_coll.distinct("query_id", {"experiment_id": experiment_id}))
-
-    run_breakdown = _run_breakdown_for_experiment(chunks_coll, results_coll, experiment_id)
-
     index_names = sorted(
         {get_index_name(model) for model in embedding_models if model in EMBEDDING_MODELS}
     )
@@ -278,10 +271,8 @@ def mongo_get_experiment_db_stats(experiment_id: str) -> dict:
         index_names.append(TEXT_SEARCH_INDEX_NAME)
         index_names = sorted(set(index_names))
 
-    runs_with_data = len(run_breakdown)
     avg_chunks_per_run = round(total_chunks / runs_with_data, 1) if runs_with_data else 0.0
     embedding_mb, metadata_mb, total_mb = _storage_breakdown_mb(total_chunks, embedding_models)
-    chunking_breakdown = _chunking_breakdown(chunks_coll, experiment_id)
     sweep = (experiment or {}).get("sweep_summary") or {}
 
     return {
@@ -305,6 +296,137 @@ def mongo_get_experiment_db_stats(experiment_id: str) -> dict:
         "unique_queries": unique_queries,
         "run_breakdown": run_breakdown,
     }
+
+
+def _bulk_chunk_aggregates() -> dict[str, dict]:
+    """Per-experiment chunk counts and models in one aggregation (dashboard list)."""
+    chunks_coll = get_collection(CHUNKS_COLLECTION)
+    pipeline = [
+        {
+            "$group": {
+                "_id": "$experiment_id",
+                "total_chunks": {"$sum": 1},
+                "embedding_models": {"$addToSet": "$embedding_model"},
+                "run_ids": {"$addToSet": "$run_id"},
+            }
+        }
+    ]
+    out: dict[str, dict] = {}
+    for row in chunks_coll.aggregate(pipeline, allowDiskUse=True):
+        exp_id = row.get("_id")
+        if not exp_id:
+            continue
+        models = [str(m) for m in row.get("embedding_models") or [] if m]
+        run_ids = [r for r in row.get("run_ids") or [] if r]
+        out[str(exp_id)] = {
+            "total_chunks": int(row["total_chunks"]),
+            "embedding_models": models,
+            "runs_with_data": len(run_ids),
+        }
+    return out
+
+
+def _bulk_result_aggregates() -> dict[str, dict]:
+    """Per-experiment result counts in one aggregation."""
+    results_coll = get_collection(RESULTS_COLLECTION)
+    pipeline = [
+        {
+            "$group": {
+                "_id": "$experiment_id",
+                "total_results": {"$sum": 1},
+                "query_ids": {"$addToSet": "$query_id"},
+            }
+        }
+    ]
+    out: dict[str, dict] = {}
+    for row in results_coll.aggregate(pipeline, allowDiskUse=True):
+        exp_id = row.get("_id")
+        if not exp_id:
+            continue
+        query_ids = [q for q in row.get("query_ids") or [] if q]
+        out[str(exp_id)] = {
+            "total_results": int(row["total_results"]),
+            "unique_queries": len(query_ids),
+        }
+    return out
+
+
+def _bulk_chunking_breakdown() -> dict[str, dict[str, int]]:
+    """Per-experiment chunking method counts in one aggregation."""
+    chunks_coll = get_collection(CHUNKS_COLLECTION)
+    pipeline = [
+        {
+            "$group": {
+                "_id": {
+                    "experiment_id": "$experiment_id",
+                    "chunk_method": "$chunk_method",
+                },
+                "count": {"$sum": 1},
+            }
+        }
+    ]
+    out: dict[str, dict[str, int]] = {}
+    for row in chunks_coll.aggregate(pipeline, allowDiskUse=True):
+        key = row.get("_id") or {}
+        exp_id = key.get("experiment_id")
+        method = key.get("chunk_method")
+        if not exp_id or not method:
+            continue
+        bucket = out.setdefault(str(exp_id), {})
+        bucket[str(method)] = int(row["count"])
+    return out
+
+
+def _summary_db_stats_for_experiment(
+    experiment: dict,
+    chunk_row: dict | None,
+    result_row: dict | None,
+    chunking_breakdown: dict[str, int],
+) -> dict:
+    """Lightweight stats for grouped dashboard (no per-run breakdown queries)."""
+    total_chunks = int((chunk_row or {}).get("total_chunks") or 0)
+    embedding_models = list((chunk_row or {}).get("embedding_models") or [])
+    runs_with_data = int((chunk_row or {}).get("runs_with_data") or 0)
+    total_results = int((result_row or {}).get("total_results") or 0)
+    unique_queries = int((result_row or {}).get("unique_queries") or 0)
+    return _assemble_experiment_db_stats(
+        experiment,
+        total_chunks=total_chunks,
+        embedding_models=embedding_models,
+        chunking_breakdown=chunking_breakdown,
+        total_results=total_results,
+        unique_queries=unique_queries,
+        runs_with_data=runs_with_data,
+        run_breakdown=[],
+    )
+
+
+def mongo_get_experiment_db_stats(experiment_id: str) -> dict:
+    """Vector DB stats for one experiment (full detail, including per-run breakdown)."""
+    experiment = get_collection(EXPERIMENTS_COLLECTION).find_one(
+        {"experiment_id": experiment_id},
+        {"data_paths": 1, "sweep_summary": 1, "config": 1},
+    )
+    chunks_coll = get_collection(CHUNKS_COLLECTION)
+    results_coll = get_collection(RESULTS_COLLECTION)
+
+    total_chunks = chunks_coll.count_documents({"experiment_id": experiment_id})
+    embedding_models = chunks_coll.distinct("embedding_model", {"experiment_id": experiment_id})
+    total_results = results_coll.count_documents({"experiment_id": experiment_id})
+    unique_queries = len(results_coll.distinct("query_id", {"experiment_id": experiment_id}))
+    run_breakdown = _run_breakdown_for_experiment(chunks_coll, results_coll, experiment_id)
+    chunking_breakdown = _chunking_breakdown(chunks_coll, experiment_id)
+
+    return _assemble_experiment_db_stats(
+        experiment,
+        total_chunks=total_chunks,
+        embedding_models=embedding_models,
+        chunking_breakdown=chunking_breakdown,
+        total_results=total_results,
+        unique_queries=unique_queries,
+        runs_with_data=len(run_breakdown),
+        run_breakdown=run_breakdown,
+    )
 
 
 def _vector_db_group_key(database_provider: str, cluster_host: str | None) -> str:
@@ -334,11 +456,20 @@ def _merge_group_totals(group: dict, stats: dict) -> None:
 def mongo_get_vector_db_stats_grouped() -> dict:
     """Aggregate DB stats for all experiments, grouped by vector database cluster."""
     experiments = mongo_list_all_experiment_docs()
+    chunk_by_exp = _bulk_chunk_aggregates()
+    result_by_exp = _bulk_result_aggregates()
+    chunking_by_exp = _bulk_chunking_breakdown()
+    cluster_storage = _mongodb_cluster_storage_mb()
     groups: dict[str, dict] = {}
 
     for experiment in experiments:
         experiment_id = str(experiment["experiment_id"])
-        stats = mongo_get_experiment_db_stats(experiment_id)
+        stats = _summary_db_stats_for_experiment(
+            experiment,
+            chunk_by_exp.get(experiment_id),
+            result_by_exp.get(experiment_id),
+            chunking_by_exp.get(experiment_id, {}),
+        )
         group_key = _vector_db_group_key(stats["database_provider"], stats["cluster_host"])
 
         if group_key not in groups:
@@ -377,7 +508,6 @@ def mongo_get_vector_db_stats_grouped() -> dict:
         )
 
     grouped = list(groups.values())
-    cluster_storage = _mongodb_cluster_storage_mb()
     for group in grouped:
         group["totals"].update(cluster_storage)
         group["experiments"].sort(

--- a/server/core/embedder.py
+++ b/server/core/embedder.py
@@ -1,13 +1,27 @@
+from collections.abc import Callable
 from typing import cast
 
+import tiktoken
 import voyageai
+from tiktoken.core import Encoding
 from voyageai.object import EmbeddingsObject
+from voyageai.object.contextualized_embeddings import ContextualizedEmbeddingsObject
 
+from server.core.model_registry import is_contextualized_embedding
 from server.core.rate_limiter import RateLimiter, call_with_retry, estimate_tokens
 from server.settings import settings
 from server.utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+# voyage-context-3 limits (https://docs.voyageai.com/docs/contextualized-chunk-embeddings)
+VOYAGE_CONTEXT_WINDOW_TOKENS = 32_000
+VOYAGE_CONTEXT_REQUEST_TOKEN_CAP = 120_000
+VOYAGE_CONTEXT_MAX_INPUTS = 1_000
+# Per-segment cap (tiktoken cl100k_base); leaves headroom vs Voyage's 32K window.
+VOYAGE_CONTEXT_SEGMENT_BUDGET = 30_000
+
+_tiktoken_encoding: Encoding | None = None
 
 _client: voyageai.Client | None = None
 _limiter: RateLimiter | None = None
@@ -51,6 +65,8 @@ def embed_documents(texts: list[str], model: str, provider: str = "local") -> li
         from server.core.local_embedder import embed_documents_local
 
         return embed_documents_local(texts, model)
+    if is_contextualized_embedding(model):
+        return _embed_documents_voyage_context(texts, model)
     return _embed_documents_voyage(texts, model)
 
 
@@ -60,6 +76,8 @@ def embed_query(text: str, model: str, provider: str = "local") -> list[float]:
         from server.core.local_embedder import embed_query_local
 
         return embed_query_local(text, model)
+    if is_contextualized_embedding(model):
+        return _embed_query_voyage_context(text, model)
     return _embed_query_voyage(text, model)
 
 
@@ -89,6 +107,58 @@ def _embed_documents_voyage(texts: list[str], model: str) -> list[list[float]]:
     return all_embeddings
 
 
+def _embed_documents_voyage_context(texts: list[str], model: str) -> list[list[float]]:
+    """Embed document chunks with voyage-context-3 (shared document context)."""
+    if not texts:
+        return []
+
+    _validate_context_chunk_sizes(texts)
+    logger.info(f"Contextualized embedding {len(texts)} chunks with model={model}")
+    client = get_client()
+    segments = _split_context_segments(texts)
+    if len(segments) > 1:
+        logger.info(
+            f"Split {len(texts)} chunks into {len(segments)} contextualized segments "
+            f"({VOYAGE_CONTEXT_WINDOW_TOKENS}-token window per segment)"
+        )
+
+    all_embeddings: list[list[float]] = []
+    for req_idx, request_segments in enumerate(_split_context_requests(segments)):
+        flat = [chunk for segment in request_segments for chunk in segment]
+        tokens = _count_context_tokens(flat)
+        logger.debug(
+            f"Contextualized request {req_idx + 1}: "
+            f"{len(request_segments)} segment(s), ~{tokens} tokens"
+        )
+
+        def _embed(batch: list[list[str]] = request_segments) -> ContextualizedEmbeddingsObject:
+            return client.contextualized_embed(batch, model=model, input_type="document")
+
+        result = call_with_retry(_embed, limiter=get_limiter(), estimated_tokens=tokens)
+        for segment_result in result.results:
+            all_embeddings.extend(cast(list[list[float]], segment_result.embeddings))
+
+    logger.info(
+        f"Generated {len(all_embeddings)} contextualized embeddings, dim={len(all_embeddings[0])}"
+    )
+    return all_embeddings
+
+
+def _embed_query_voyage_context(text: str, model: str) -> list[float]:
+    """Embed a query with voyage-context-3."""
+    logger.debug(f"Contextualized query embedding with model={model}")
+    client = get_client()
+    tokens = estimate_tokens([text])
+
+    def _embed() -> ContextualizedEmbeddingsObject:
+        return client.contextualized_embed([[text]], model=model, input_type="query")
+
+    result = call_with_retry(_embed, limiter=get_limiter(), estimated_tokens=tokens)
+    embedding = cast(list[float], result.results[0].embeddings[0])
+    logger.debug(f"Generated contextualized query embedding, dim={len(embedding)}")
+    return embedding
+
+
 def _embed_query_voyage(text: str, model: str) -> list[float]:
     """Embed a single query using Voyage AI."""
     logger.debug(f"Embedding query with model={model}")
@@ -106,14 +176,44 @@ def _embed_query_voyage(text: str, model: str) -> list[float]:
     return embedding
 
 
-def _split_into_batches(texts: list[str], token_budget: int) -> list[list[str]]:
+def _get_tiktoken_encoding() -> Encoding:
+    global _tiktoken_encoding
+    if _tiktoken_encoding is None:
+        _tiktoken_encoding = tiktoken.get_encoding("cl100k_base")
+    return _tiktoken_encoding
+
+
+def _count_context_tokens(texts: list[str]) -> int:
+    """Count tokens with tiktoken (cl100k_base) for voyage-context-3 segment sizing."""
+    encoding = _get_tiktoken_encoding()
+    return max(1, sum(len(encoding.encode(text)) for text in texts))
+
+
+def _validate_context_chunk_sizes(texts: list[str]) -> None:
+    for index, text in enumerate(texts):
+        tokens = _count_context_tokens([text])
+        if tokens <= VOYAGE_CONTEXT_WINDOW_TOKENS:
+            continue
+        raise ValueError(
+            f"Chunk {index} has ~{tokens} tokens, exceeding voyage-context-3's "
+            f"{VOYAGE_CONTEXT_WINDOW_TOKENS}-token window (no truncation). "
+            "Use a smaller chunk_size."
+        )
+
+
+def _split_into_batches(
+    texts: list[str],
+    token_budget: int,
+    token_counter: Callable[[list[str]], int] | None = None,
+) -> list[list[str]]:
     """Split texts into batches that each fit within the token budget."""
+    count_tokens = token_counter or estimate_tokens
     batches: list[list[str]] = []
     current_batch: list[str] = []
     current_tokens = 0
 
     for text in texts:
-        text_tokens = estimate_tokens([text])
+        text_tokens = count_tokens([text])
         if current_batch and current_tokens + text_tokens > token_budget:
             batches.append(current_batch)
             current_batch = []
@@ -124,3 +224,35 @@ def _split_into_batches(texts: list[str], token_budget: int) -> list[list[str]]:
     if current_batch:
         batches.append(current_batch)
     return batches
+
+
+def _split_context_segments(texts: list[str]) -> list[list[str]]:
+    """Split document chunks into segments for voyage-context-3's per-input window."""
+    return _split_into_batches(
+        texts,
+        VOYAGE_CONTEXT_SEGMENT_BUDGET,
+        token_counter=_count_context_tokens,
+    )
+
+
+def _split_context_requests(segments: list[list[str]]) -> list[list[list[str]]]:
+    """Group segments into API requests within total token and input limits."""
+    requests: list[list[list[str]]] = []
+    current_segments: list[list[str]] = []
+    current_tokens = 0
+
+    for segment in segments:
+        segment_tokens = _count_context_tokens(segment)
+        if current_segments and (
+            current_tokens + segment_tokens > VOYAGE_CONTEXT_REQUEST_TOKEN_CAP
+            or len(current_segments) >= VOYAGE_CONTEXT_MAX_INPUTS
+        ):
+            requests.append(current_segments)
+            current_segments = []
+            current_tokens = 0
+        current_segments.append(segment)
+        current_tokens += segment_tokens
+
+    if current_segments:
+        requests.append(current_segments)
+    return requests

--- a/server/core/executors.py
+++ b/server/core/executors.py
@@ -1,0 +1,35 @@
+"""Dedicated thread pools so sweep work does not starve API handlers.
+
+FastAPI BackgroundTasks and ``asyncio.to_thread`` both use the default
+ThreadPoolExecutor. Long-running sweeps and expensive vector-db aggregations
+were competing with lightweight list/detail reads, so the dashboard could hang
+on GET /experiments while a sweep was active.
+"""
+
+from __future__ import annotations
+
+import atexit
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from typing import ParamSpec
+
+P = ParamSpec("P")
+
+# One sweep per process — matches current parallelism: 1 semantics.
+SWEEP_EXECUTOR = ThreadPoolExecutor(max_workers=1, thread_name_prefix="rag-sweep")
+
+# Expensive read-only aggregations (vector-db-stats, per-experiment db-stats).
+HEAVY_READ_EXECUTOR = ThreadPoolExecutor(max_workers=1, thread_name_prefix="rag-heavy-read")
+
+
+def schedule_sweep[R, **P](fn: Callable[P, R], /, *args: P.args, **kwargs: P.kwargs) -> None:
+    """Fire-and-forget sweep execution on the isolated sweep pool."""
+    SWEEP_EXECUTOR.submit(fn, *args, **kwargs)
+
+
+def shutdown_executors() -> None:
+    SWEEP_EXECUTOR.shutdown(wait=False, cancel_futures=True)
+    HEAVY_READ_EXECUTOR.shutdown(wait=False, cancel_futures=True)
+
+
+atexit.register(shutdown_executors)

--- a/server/core/model_registry.py
+++ b/server/core/model_registry.py
@@ -19,6 +19,7 @@ class EmbeddingModelInfo(TypedDict):
     dimensions: int
     huggingface_id: str | None
     description: str
+    contextualized: bool  # uses contextualized_embed() API (e.g. voyage-context-3)
 
 
 class RerankerModelInfo(TypedDict):
@@ -28,29 +29,100 @@ class RerankerModelInfo(TypedDict):
 
 
 EMBEDDING_MODELS: dict[str, EmbeddingModelInfo] = {
-    "voyage-3.5-lite": {
+    # Voyage 4 series (1024-dim default; shared embedding space)
+    "voyage-4-large": {
         "provider": "voyage",
         "dimensions": 1024,
         "huggingface_id": None,
-        "description": "Voyage AI lightweight embedding (1024-dim)",
+        "description": "Voyage 4 flagship embedding (1024-dim)",
+        "contextualized": False,
     },
-    "voyage-3.5": {
+    "voyage-4": {
         "provider": "voyage",
         "dimensions": 1024,
         "huggingface_id": None,
-        "description": "Voyage AI standard embedding (1024-dim)",
+        "description": "Voyage 4 general-purpose embedding (1024-dim)",
+        "contextualized": False,
+    },
+    "voyage-4-lite": {
+        "provider": "voyage",
+        "dimensions": 1024,
+        "huggingface_id": None,
+        "description": "Voyage 4 latency/cost-optimized embedding (1024-dim)",
+        "contextualized": False,
+    },
+    # Domain-specific (1024-dim)
+    "voyage-code-3": {
+        "provider": "voyage",
+        "dimensions": 1024,
+        "huggingface_id": None,
+        "description": "Voyage code retrieval embedding (1024-dim)",
+        "contextualized": False,
+    },
+    "voyage-finance-2": {
+        "provider": "voyage",
+        "dimensions": 1024,
+        "huggingface_id": None,
+        "description": "Voyage finance domain embedding (1024-dim)",
+        "contextualized": False,
+    },
+    "voyage-law-2": {
+        "provider": "voyage",
+        "dimensions": 1024,
+        "huggingface_id": None,
+        "description": "Voyage legal domain embedding (1024-dim)",
+        "contextualized": False,
     },
     "voyage-context-3": {
         "provider": "voyage",
         "dimensions": 1024,
         "huggingface_id": None,
-        "description": "Voyage AI context-optimized embedding (1024-dim)",
+        "description": "Voyage contextualized chunk embedding (1024-dim)",
+        "contextualized": True,
     },
+    # Voyage 3 series (legacy API; 1024-dim default)
+    "voyage-3-large": {
+        "provider": "voyage",
+        "dimensions": 1024,
+        "huggingface_id": None,
+        "description": "Voyage 3 large embedding (1024-dim, legacy)",
+        "contextualized": False,
+    },
+    "voyage-3.5-lite": {
+        "provider": "voyage",
+        "dimensions": 1024,
+        "huggingface_id": None,
+        "description": "Voyage 3.5 lightweight embedding (1024-dim, legacy)",
+        "contextualized": False,
+    },
+    "voyage-3.5": {
+        "provider": "voyage",
+        "dimensions": 1024,
+        "huggingface_id": None,
+        "description": "Voyage 3.5 standard embedding (1024-dim, legacy)",
+        "contextualized": False,
+    },
+    "voyage-3": {
+        "provider": "voyage",
+        "dimensions": 1024,
+        "huggingface_id": None,
+        "description": "Voyage 3 general-purpose embedding (1024-dim, legacy)",
+        "contextualized": False,
+    },
+    "voyage-multilingual-2": {
+        "provider": "voyage",
+        "dimensions": 1024,
+        "huggingface_id": None,
+        "description": "Voyage multilingual retrieval embedding (1024-dim, legacy)",
+        "contextualized": False,
+    },
+    # Local
     "all-MiniLM-L6-v2": {
         "provider": "local",
         "dimensions": 384,
         "huggingface_id": "sentence-transformers/all-MiniLM-L6-v2",
         "description": "Fast general-purpose sentence embeddings (384-dim, ~23MB)",
+        "contextualized": False,
     },
 }
 
@@ -58,12 +130,32 @@ RERANKER_MODELS: dict[str, RerankerModelInfo] = {
     "rerank-2.5-lite": {
         "provider": "voyage",
         "huggingface_id": None,
-        "description": "Voyage AI lightweight reranker",
+        "description": "Voyage 2.5 lightweight reranker (recommended)",
     },
     "rerank-2.5": {
         "provider": "voyage",
         "huggingface_id": None,
-        "description": "Voyage AI standard reranker",
+        "description": "Voyage 2.5 standard reranker (recommended)",
+    },
+    "rerank-2-lite": {
+        "provider": "voyage",
+        "huggingface_id": None,
+        "description": "Voyage 2 lightweight reranker (legacy)",
+    },
+    "rerank-2": {
+        "provider": "voyage",
+        "huggingface_id": None,
+        "description": "Voyage 2 standard reranker (legacy)",
+    },
+    "rerank-lite-1": {
+        "provider": "voyage",
+        "huggingface_id": None,
+        "description": "Voyage 1 lightweight reranker (legacy)",
+    },
+    "rerank-1": {
+        "provider": "voyage",
+        "huggingface_id": None,
+        "description": "Voyage 1 standard reranker (legacy)",
     },
     "cross-encoder/ms-marco-MiniLM-L-6-v2": {
         "provider": "local",
@@ -87,6 +179,16 @@ def get_provider(model_id: str) -> str:
 
 def get_dimensions(model_id: str) -> int:
     return get_model_info(model_id)["dimensions"]
+
+
+def is_contextualized_embedding(model_id: str) -> bool:
+    return get_model_info(model_id)["contextualized"]
+
+
+def list_embedding_models(*, provider: str | None = None) -> list[str]:
+    if provider is None:
+        return list(EMBEDDING_MODELS)
+    return [mid for mid, info in EMBEDDING_MODELS.items() if info["provider"] == provider]
 
 
 def get_index_name(model_id: str) -> str:

--- a/server/core/orchestrator.py
+++ b/server/core/orchestrator.py
@@ -1,6 +1,7 @@
 import threading
 import time
 import uuid
+from dataclasses import dataclass, field
 from datetime import datetime
 
 from server.core.chunkers import chunk_text
@@ -24,58 +25,176 @@ from server.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-_cancel_events: dict[str, threading.Event] = {}
+ParamSignature = tuple[
+    str,
+    str,
+    str,
+    str,
+    int,
+    int,
+    str,
+    str,
+    str | None,
+]
+
+
+@dataclass
+class _SweepControl:
+    cancel: threading.Event = field(default_factory=threading.Event)
+    pause: threading.Event = field(default_factory=threading.Event)
+
+
+_sweep_controls: dict[str, _SweepControl] = {}
 
 
 class ExperimentCancelledError(Exception):
     pass
 
 
+class ExperimentPausedError(Exception):
+    pass
+
+
 def request_cancel(experiment_id: str) -> bool:
     """Signal a running experiment to stop. Returns True if it was in-flight."""
-    event = _cancel_events.get(experiment_id)
-    if event is None:
+    control = _sweep_controls.get(experiment_id)
+    if control is None:
         return False
-    event.set()
+    control.cancel.set()
     return True
 
 
-def _check_cancelled(experiment_id: str) -> None:
-    """Raise ExperimentCancelled if this experiment has been cancelled."""
-    event = _cancel_events.get(experiment_id)
-    if event and event.is_set():
+def request_pause(experiment_id: str) -> bool:
+    """Signal a running experiment to pause. Returns True if it was in-flight."""
+    control = _sweep_controls.get(experiment_id)
+    if control is None:
+        return False
+    control.pause.set()
+    return True
+
+
+def is_sweep_in_flight(experiment_id: str) -> bool:
+    return experiment_id in _sweep_controls
+
+
+def _params_signature(params: RunParams) -> ParamSignature:
+    return (
+        params.database_provider,
+        params.embedding_provider,
+        params.embedding_model,
+        params.chunking_method.value,
+        params.chunk_size,
+        params.overlap,
+        params.retrieval_method.value,
+        params.rerank_provider,
+        params.rerank_model,
+    )
+
+
+def _stored_enum_value(value: object | None) -> str:
+    if value is None:
+        return ""
+    if hasattr(value, "value"):
+        return str(getattr(value, "value"))
+    return str(value)
+
+
+def _run_doc_signature(run: dict) -> ParamSignature:
+    return (
+        str(run.get("database_provider") or "mongodb"),
+        str(run.get("embedding_provider") or ""),
+        str(run.get("embedding_model") or ""),
+        _stored_enum_value(run.get("chunking_method")),
+        int(run.get("chunk_size") or 0),
+        int(run.get("overlap") or 0),
+        _stored_enum_value(run.get("retrieval_method")),
+        str(run.get("rerank_provider") or ""),
+        run.get("rerank_model"),
+    )
+
+
+def _completed_param_signatures(experiment_id: str) -> set[ParamSignature]:
+    cursor = get_collection(RUN_STATUS_COLLECTION).find(
+        {"experiment_id": experiment_id, "phase": Phase.COMPLETE.value},
+        {
+            "database_provider": 1,
+            "embedding_provider": 1,
+            "embedding_model": 1,
+            "chunking_method": 1,
+            "chunk_size": 1,
+            "overlap": 1,
+            "retrieval_method": 1,
+            "rerank_provider": 1,
+            "rerank_model": 1,
+        },
+    )
+    return {_run_doc_signature(run) for run in cursor}
+
+
+def _check_control(experiment_id: str) -> None:
+    """Raise if this experiment was cancelled or paused."""
+    control = _sweep_controls.get(experiment_id)
+    if control is None:
+        return
+    if control.cancel.is_set():
         raise ExperimentCancelledError(f"Experiment {experiment_id} was cancelled")
+    if control.pause.is_set():
+        raise ExperimentPausedError(f"Experiment {experiment_id} was paused")
 
 
 def run_sweep(experiment_id: str, config: ExperimentConfig) -> dict:
-    """Execute all sweep runs for a pre-created experiment.
+    """Execute all sweep runs for a pre-created experiment."""
+    return _execute_sweep(experiment_id, config, skip_signatures=set())
 
-    Declared as a sync function so FastAPI's BackgroundTasks runs it in a
-    threadpool instead of on the event loop (all callees are blocking I/O).
-    """
-    _cancel_events[experiment_id] = threading.Event()
 
+def resume_sweep(experiment_id: str, config: ExperimentConfig) -> dict:
+    """Continue a paused experiment, skipping parameter sets that already completed."""
+    completed = _completed_param_signatures(experiment_id)
+    logger.info(
+        "Experiment %s resume: skipping %s completed parameter combination(s)",
+        experiment_id,
+        len(completed),
+    )
+    return _execute_sweep(experiment_id, config, skip_signatures=completed)
+
+
+def _execute_sweep(
+    experiment_id: str,
+    config: ExperimentConfig,
+    skip_signatures: set[ParamSignature],
+) -> dict:
+    """Declared sync so FastAPI BackgroundTasks runs it in a threadpool."""
+    _sweep_controls[experiment_id] = _SweepControl()
     try:
-        return _run_sweep_inner(experiment_id, config)
+        return _run_sweep_inner(experiment_id, config, skip_signatures)
     finally:
-        _cancel_events.pop(experiment_id, None)
+        _sweep_controls.pop(experiment_id, None)
 
 
-def _run_sweep_inner(experiment_id: str, config: ExperimentConfig) -> dict:
-    # execution.parallelism is stored on experiments but honored only after Slice 16
-    # (bounded concurrent runs). See docs/slices/SLICE-16-PARALLEL-SWEEP-RUNS.md
+def _run_sweep_inner(
+    experiment_id: str,
+    config: ExperimentConfig,
+    skip_signatures: set[ParamSignature],
+) -> dict:
     runs = expand_sweep(config)
     run_ids: list[str] = []
     logger.info(f"Experiment {experiment_id}: {len(runs)} runs to execute")
 
-    failed = 0
     cancelled = False
+    paused = False
     for params in runs:
+        if _params_signature(params) in skip_signatures:
+            continue
+
         try:
-            _check_cancelled(experiment_id)
+            _check_control(experiment_id)
         except ExperimentCancelledError:
             cancelled = True
             logger.info(f"Experiment {experiment_id} cancelled before run {len(run_ids) + 1}")
+            break
+        except ExperimentPausedError:
+            paused = True
+            logger.info(f"Experiment {experiment_id} paused before run {len(run_ids) + 1}")
             break
 
         run_id = str(uuid.uuid4())
@@ -86,20 +205,23 @@ def _run_sweep_inner(experiment_id: str, config: ExperimentConfig) -> dict:
             cancelled = True
             logger.info(f"Experiment {experiment_id} cancelled during run {run_id}")
             break
+        except ExperimentPausedError:
+            paused = True
+            logger.info(f"Experiment {experiment_id} paused during run {run_id}")
+            break
         except Exception as e:
-            failed += 1
             logger.error(f"Run {run_id} failed: {e}", exc_info=True)
             if config.execution.on_error == "stop":
                 break
 
     if cancelled:
         final_status = ExperimentStatus.CANCELLED
-    elif failed == 0:
-        final_status = ExperimentStatus.COMPLETE
-    elif failed < len(runs):
-        final_status = ExperimentStatus.PARTIAL
+        failed_count = _count_failed_runs(experiment_id)
+    elif paused:
+        final_status = ExperimentStatus.PAUSED
+        failed_count = _count_failed_runs(experiment_id)
     else:
-        final_status = ExperimentStatus.FAILED
+        final_status, failed_count = _compute_final_status(experiment_id, len(runs))
 
     completed_at = datetime.utcnow()
     get_collection(EXPERIMENTS_COLLECTION).update_one(
@@ -108,7 +230,7 @@ def _run_sweep_inner(experiment_id: str, config: ExperimentConfig) -> dict:
             "$set": {
                 "status": final_status,
                 "run_count": len(runs),
-                "failed_count": failed,
+                "failed_count": failed_count,
                 "completed_at": completed_at,
             }
         },
@@ -116,6 +238,29 @@ def _run_sweep_inner(experiment_id: str, config: ExperimentConfig) -> dict:
     logger.info(f"Experiment {experiment_id} finished: {final_status}")
 
     return {"experiment_id": experiment_id, "run_ids": run_ids, "status": final_status}
+
+
+def _count_failed_runs(experiment_id: str) -> int:
+    return int(
+        get_collection(RUN_STATUS_COLLECTION).count_documents(
+            {"experiment_id": experiment_id, "phase": Phase.FAILED.value}
+        )
+    )
+
+
+def _compute_final_status(
+    experiment_id: str,
+    expected_run_count: int,
+) -> tuple[ExperimentStatus, int]:
+    runs = list(get_collection(RUN_STATUS_COLLECTION).find({"experiment_id": experiment_id}))
+    complete = sum(1 for run in runs if run.get("phase") == Phase.COMPLETE.value)
+    failed = sum(1 for run in runs if run.get("phase") == Phase.FAILED.value)
+
+    if complete == expected_run_count and failed == 0:
+        return ExperimentStatus.COMPLETE, failed
+    if failed == expected_run_count or (failed > 0 and complete == 0):
+        return ExperimentStatus.FAILED, failed
+    return ExperimentStatus.PARTIAL, failed
 
 
 def _run_single(experiment_id: str, run_id: str, params: RunParams) -> None:
@@ -142,22 +287,22 @@ def _run_single(experiment_id: str, run_id: str, params: RunParams) -> None:
     get_collection(RUN_STATUS_COLLECTION).insert_one(run_status.model_dump())
 
     try:
-        _check_cancelled(experiment_id)
+        _check_control(experiment_id)
         _update_phase(run_id, Phase.PARSING)
         text = load_all_files(params.data_paths)
         logger.info(f"Run {run_id}: parsed {len(text)} chars from {len(params.data_paths)} path(s)")
 
-        _check_cancelled(experiment_id)
+        _check_control(experiment_id)
         _update_phase(run_id, Phase.CHUNKING)
         chunks = chunk_text(text, params.chunking_method, params.chunk_size, params.overlap)
         logger.info(f"Run {run_id}: chunked into {len(chunks)} chunks")
 
-        _check_cancelled(experiment_id)
+        _check_control(experiment_id)
         _update_phase(run_id, Phase.EMBEDDING)
         embeddings = embed_documents(chunks, params.embedding_model, params.embedding_provider)
         logger.info(f"Run {run_id}: generated {len(embeddings)} embeddings")
 
-        _check_cancelled(experiment_id)
+        _check_control(experiment_id)
         _update_phase(run_id, Phase.STORING)
         chunk_docs = [
             {
@@ -177,13 +322,13 @@ def _run_single(experiment_id: str, run_id: str, params: RunParams) -> None:
         get_collection(CHUNKS_COLLECTION).insert_many(chunk_docs)
         logger.info(f"Stored {len(chunk_docs)} chunks")
 
-        _check_cancelled(experiment_id)
+        _check_control(experiment_id)
         _update_phase(run_id, Phase.QUERYING)
         queries = load_queries(params.queries_file)
         logger.info(f"Run {run_id}: querying with {len(queries)} queries")
 
         for i, q in enumerate(queries, start=1):
-            _check_cancelled(experiment_id)
+            _check_control(experiment_id)
             query_id = str(uuid.uuid4())
             logger.debug(
                 f"Run {run_id} query {i}/{len(queries)}: "
@@ -245,6 +390,10 @@ def _run_single(experiment_id: str, run_id: str, params: RunParams) -> None:
     except ExperimentCancelledError:
         logger.info(f"Run {run_id} interrupted by cancellation")
         _update_phase(run_id, Phase.INTERRUPTED, error_message="Cancelled by user")
+        raise
+    except ExperimentPausedError:
+        logger.info(f"Run {run_id} interrupted by pause")
+        _update_phase(run_id, Phase.INTERRUPTED, error_message="Paused by user")
         raise
     except Exception as e:
         logger.error(f"Run {run_id} failed: {e}", exc_info=True)

--- a/server/core/orchestrator.py
+++ b/server/core/orchestrator.py
@@ -163,7 +163,7 @@ def _execute_sweep(
     config: ExperimentConfig,
     skip_signatures: set[ParamSignature],
 ) -> dict:
-    """Declared sync so FastAPI BackgroundTasks runs it in a threadpool."""
+    """Declared sync; scheduled on the dedicated sweep executor (see executors.py)."""
     _sweep_controls[experiment_id] = _SweepControl()
     try:
         return _run_sweep_inner(experiment_id, config, skip_signatures)

--- a/server/main.py
+++ b/server/main.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from server.api import experiments, runs
+from server.core.executors import shutdown_executors
 from server.core.startup_reconciliation import reconcile_orphaned_experiments
 from server.db.indexes import ensure_indexes
 from server.settings import LOCALHOST_CORS_ORIGIN_REGEX, settings
@@ -35,6 +36,7 @@ async def lifespan(app: FastAPI):
     logger.info("Server ready")
     yield
     logger.info("Server shutting down...")
+    shutdown_executors()
 
 
 app = FastAPI(

--- a/server/models/enums.py
+++ b/server/models/enums.py
@@ -3,6 +3,7 @@ from enum import StrEnum
 
 class ExperimentStatus(StrEnum):
     RUNNING = "running"
+    PAUSED = "paused"
     COMPLETE = "complete"
     PARTIAL = "partial"
     FAILED = "failed"


### PR DESCRIPTION
## Summary

- Add **experiment pause/resume** end-to-end: CLI commands (`pause`/`resume`), API endpoints, orchestrator cooperative stop between phases, and dashboard control buttons on the detail screen.
- Expand the **Voyage model catalog** (voyage-4 series, domain models, legacy rerankers) and fix **`voyage-context-3`** contextualized embedding with automatic segment splitting for long documents.
- Add **`docs/user-guide/cloud-setup.md`** — minimal checklists for MongoDB Atlas and Voyage AI setup required before running `example-mongodb-local.yaml` and `example-mongodb-voyage.yaml` sweeps (indexes, Tier 1 billing, official vendor doc links).
- Document vector DB stats, boot orphan reconciliation, partial sweep UI, and voyage-context-3 troubleshooting across user/contributor guides.

## Test plan

- [ ] `uv run ruff check . && uv run mypy server/ cli/ && uv run pytest`
- [ ] `cd frontend && npm run typecheck && npm run build`
- [ ] Start server, submit local sweep, **pause** mid-run, verify status → **resume** and remaining combos complete
- [ ] Submit Voyage sweep with Tier 1 `.env` limits; confirm `voyage-context-3` handles long PDF without 32K token error
- [ ] Follow [cloud-setup.md](docs/user-guide/cloud-setup.md) checklist on fresh M0 Atlas cluster; run both example sweep configs
- [ ] Dashboard: pause/resume/cancel buttons visible on detail screen for active/paused experiments


Made with [Cursor](https://cursor.com)