### PR TITLE
Tessl hackathon kimchi integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ VOYAGE_RPM_LIMIT=3          # Tier 1 Voyage sweep: 2000
 VOYAGE_TPM_LIMIT=10000      # Tier 1 Voyage sweep: 16000000
 
 # Kimchi embeddings — OpenAI-compatible endpoint (example-kimchi.yaml only)
-KIMCHI_BASE_URL=https://your-kimchi-host.example
+KIMCHI_BASE_URL=https://api.navy
 KIMCHI_API_KEY=your_kimchi_api_key_here
 KIMCHI_RPM_LIMIT=60
 KIMCHI_TPM_LIMIT=0          # 0 disables token throttling

--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,18 @@
 # ── Minimum for sweeps ────────────────────────────────────────────────────────
 # Local sweep (example-mongodb-local.yaml):  MONGODB_URI only
 # Voyage sweep (example-mongodb-voyage.yaml): MONGODB_URI + VOYAGE_API_KEY + Tier 1 limits below
+# Kimchi sweep (example-kimchi.yaml):        MONGODB_URI + KIMCHI_BASE_URL + KIMCHI_API_KEY
 # Full checklist: docs/user-guide/cloud-setup.md#before-you-run-a-sweep
 VOYAGE_API_KEY=your_voyage_api_key_here
 # Voyage rate limits — free tier defaults below; override for Tier 1 (Voyage sweep)
 VOYAGE_RPM_LIMIT=3          # Tier 1 Voyage sweep: 2000
 VOYAGE_TPM_LIMIT=10000      # Tier 1 Voyage sweep: 16000000
+
+# Kimchi embeddings — OpenAI-compatible endpoint (example-kimchi.yaml only)
+KIMCHI_BASE_URL=https://your-kimchi-host.example
+KIMCHI_API_KEY=your_kimchi_api_key_here
+KIMCHI_RPM_LIMIT=60
+KIMCHI_TPM_LIMIT=0          # 0 disables token throttling
 
 # MongoDB Atlas — required for all sweeps
 MONGODB_URI=your_mongodb_atlas_uri_here

--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ VOYAGE_RPM_LIMIT=3          # Tier 1 Voyage sweep: 2000
 VOYAGE_TPM_LIMIT=10000      # Tier 1 Voyage sweep: 16000000
 
 # Kimchi embeddings — OpenAI-compatible endpoint (example-kimchi.yaml only)
-KIMCHI_BASE_URL=https://api.navy
+KIMCHI_BASE_URL=https://llm.cast.ai/openai
 KIMCHI_API_KEY=your_kimchi_api_key_here
 KIMCHI_RPM_LIMIT=60
 KIMCHI_TPM_LIMIT=0          # 0 disables token throttling

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   backend:
@@ -45,7 +52,7 @@ jobs:
         run: mypy server/ cli/
 
       - name: Tests (pytest)
-        run: pytest --tb=short -q || [ "$?" = "5" ]
+        run: uv run pytest -m "not integration" --tb=short -q
 
   frontend:
     name: Frontend (Node.js)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
 
   # ── Python lint + format (one tool, replaces black+isort+pylint) ─
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.4
+    rev: v0.15.12
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ rag-params-finder run --config configs/example-mongodb-local.yaml  # submit expe
 rag-params-finder run --config configs/example-kimchi.yaml         # Kimchi-hosted sweep
 rag-params-finder pause <experiment-id>   # pause after current phase
 rag-params-finder resume <experiment-id>  # continue paused sweep
-uv pip install -e ".[dev]" && uv run ruff check . && uv run mypy server/ cli/ && uv run pytest
+uv pip install -e ".[dev]" && uv run ruff check . && uv run mypy server/ cli/ && rag-params-finder test
 
 # Frontend
 cd frontend && npm run dev                     # start dashboard → http://localhost:5173

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,8 @@ Agent session entry point for `rag-params-finder`.
 
 - Run quality gates before and after every change (see `CLAUDE.md` → Quality Gates Baseline).
 - Follow the slice execution playbook in `CLAUDE.md` → Slice Execution Playbook.
-- Secrets (`VOYAGE_API_KEY`, `MONGODB_URI`) stay server-side — never in CLI configs or committed files.
-- Provider/model must match: `provider: local` + Voyage model → Pydantic validation error.
+- Secrets (`VOYAGE_API_KEY`, `KIMCHI_API_KEY`, `MONGODB_URI`) stay server-side — never in CLI configs or committed files.
+- Provider/model must match: `provider: local` + Voyage/Kimchi model → Pydantic validation error.
 
 ## Quick commands
 
@@ -22,6 +22,7 @@ Agent session entry point for `rag-params-finder`.
 # Backend
 uvicorn server.main:app --reload --port 8001   # start server
 rag-params-finder run --config configs/example-mongodb-local.yaml  # submit experiment
+rag-params-finder run --config configs/example-kimchi.yaml         # Kimchi-hosted sweep
 rag-params-finder pause <experiment-id>   # pause after current phase
 rag-params-finder resume <experiment-id>  # continue paused sweep
 uv pip install -e ".[dev]" && uv run ruff check . && uv run mypy server/ cli/ && uv run pytest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,9 +99,10 @@ List/detail: dashboard or `GET /experiments` / `GET /experiments/{id}` (see `htt
 ## Provider System
 
 **Two independent provider settings**:
-- `embedding.provider`: "local" or "voyage"
+- `embedding.provider`: "local", "voyage", or "kimchi"
   - Local → `server/core/local_embedder.py` → `all-MiniLM-L6-v2` (384-dim)
   - Voyage → `server/core/embedder.py` → all models in `EMBEDDING_MODELS` with `provider: voyage` (1024-dim; `voyage-context-3` uses `contextualized_embed()` with automatic segment splitting for long documents)
+  - Kimchi → `server/core/kimchi_embedder.py` → OpenAI-compatible hosted embeddings (runtime-detected dim)
 - `retrieval.rerank_provider`: "local" or "voyage"
   - Local → `server/core/local_reranker.py` → `cross-encoder/ms-marco-MiniLM-L-6-v2`
   - Voyage → `server/core/reranker.py` → `rerank-2.5-lite|rerank-2.5` (+ legacy `rerank-2*`, `rerank-1*`)
@@ -112,7 +113,7 @@ Provider/model must match — registry in `model_registry.py` validates at confi
 
 | Collection | Purpose | Key Index |
 |---|---|---|
-| `chunks` | Text chunks + embeddings | Vector index on `embedding` (384 or 1024-dim cosine) + filters |
+| `chunks` | Text chunks + embeddings | Vector index on `embedding` (`vector_index_<dimension>` cosine) + filters |
 | `experiments` | Experiment metadata | `created_at`, `status` |
 | `run_status` | Per-run phase tracking | `experiment_id`, `phase` |
 | `results` | Query results (top-K chunks) | `experiment_id`, `query_id` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,9 @@ uvicorn server.main:app --reload --port 8001
 uv run ruff check .
 uv run mypy server/ cli/
 
-# Tests
-uv run pytest --tb=short -q
+# Tests (same suite as CI / PR checks)
+rag-params-finder test
+# or: uv run pytest -m "not integration" --tb=short -q
 ```
 
 ### Frontend (Node.js 22+)
@@ -143,7 +144,7 @@ Record every non-obvious choice in `docs/_internal/PROGRESS.md` → Decision Log
 # Backend
 uv run ruff check .
 uv run mypy server/ cli/
-uv run pytest --tb=short -q
+rag-params-finder test
 
 # Frontend
 cd frontend && npm run typecheck && npm run build
@@ -163,7 +164,7 @@ cd frontend && npm run typecheck && npm run build
 **Backend** (2026-05-20):
 - `ruff check .` → 0 errors
 - `mypy server/ cli/` → 0 errors
-- `pytest` → Kimchi provider tests in `tests/test_kimchi_provider.py` (run `uv run pytest --tb=short -q`)
+- `rag-params-finder test` → provider regression suite in `tests/` (CI on every PR to `main`)
 
 **Frontend** (2026-05-05):
 - `npm run typecheck` → 0 errors

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,8 @@ List/detail: dashboard or `GET /experiments` / `GET /experiments/{id}` (see `htt
 | `server/core/atlas_storage.py` | Atlas Admin API cluster quota + dbStats helpers |
 | `server/core/model_registry.py` | Embedding + reranking model catalog |
 | `server/core/embedder.py` | Voyage embedding client; `voyage-context-3` uses contextualized API with segment splitting |
+| `server/core/kimchi_embedder.py` | CAST OpenAI-compatible Kimchi embeddings (runtime-detected dim) |
+| `server/core/executors.py` | Dedicated thread pools for sweeps and heavy Mongo aggregations |
 | `server/core/local_embedder.py` | sentence-transformers embedding (lazy-load) |
 | `server/core/reranker.py` | Voyage reranking client |
 | `server/core/local_reranker.py` | CrossEncoder reranking (lazy-load) |
@@ -158,10 +160,10 @@ cd frontend && npm run typecheck && npm run build
 
 ## Quality Gates Baseline
 
-**Backend** (2026-05-05):
+**Backend** (2026-05-20):
 - `ruff check .` → 0 errors
 - `mypy server/ cli/` → 0 errors
-- `pytest` → 0 tests collected (test suite not yet written)
+- `pytest` → Kimchi provider tests in `tests/test_kimchi_provider.py` (run `uv run pytest --tb=short -q`)
 
 **Frontend** (2026-05-05):
 - `npm run typecheck` → 0 errors

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ One YAML. N experiments. Evidence-based decision. Ship the right config first.
 
 ## 🚀 Quick Start
 
-**Prerequisites:** Python 3.12+, Node.js 22+, [MongoDB Atlas account](docs/user-guide/cloud-setup.md#mongodb-atlas-required) (free tier). [Voyage AI](docs/user-guide/cloud-setup.md#voyage-ai-optional) optional for local-only sweeps.
+**Prerequisites:** Python 3.12+, Node.js 22+, [MongoDB Atlas account](docs/user-guide/cloud-setup.md#mongodb-atlas-required-for-all-sweeps) (free tier). [Voyage AI](docs/user-guide/cloud-setup.md#voyage-ai-required-for-voyage-sweep) or Kimchi credentials optional for local-only sweeps.
 
 ```bash
 # Clone and install

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Open `http://localhost:5173` to watch live progress and explore results.
 
 **AI/ML**: Voyage AI · Kimchi embeddings · sentence-transformers · MongoDB Atlas Vector Search
 
-**Dev tools**: uv · ruff · mypy · pytest · GitHub Actions
+**Dev tools**: uv · ruff · mypy · `rag-params-finder test` · GitHub Actions (runs on every PR to `main`)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 > Find your optimal RAG configuration — **before** you build your RAG application.
 
-**RAG parameter sweep experimentation tool** — systematically evaluate embedding models, chunking strategies, and retrieval methods using MongoDB Atlas Vector Search. Supports Voyage AI (hosted) and local sentence-transformers (no API key needed).
+**RAG parameter sweep experimentation tool** — systematically evaluate embedding models, chunking strategies, and retrieval methods using MongoDB Atlas Vector Search. Supports Voyage AI, Kimchi-hosted embedding models, and local sentence-transformers (no API key needed).
 
 Most RAG projects start with a guess: pick an embedding model, pick a chunking method, a retrieval method (or a re-ranker), realise it's wrong, refactor. That loop is
 slow and expensive.
@@ -40,7 +40,7 @@ shows you exactly which configuration performs best.
 
 ## What it sweeps
 
-- **Embedding models**: 12 Voyage models (voyage-4 series, domain, context, voyage-3 legacy) — see `server/core/model_registry.py`
+- **Embedding models**: local, Voyage AI (12 models — see `server/core/model_registry.py`), and Kimchi-hosted model sweeps
 - **Chunking methods**: Fixed · Recursive · Token · Sentence · Semantic
 - **Retrieval methods**: Dense · Sparse · Hybrid
 - **Questions**: Persona-organised — user provided or generated as part of golden master generation process
@@ -73,6 +73,8 @@ cd frontend && npm install && cd ..
 
 # Configure — see docs/user-guide/cloud-setup.md for minimal Atlas + Voyage checklist
 cp .env.example .env
+# Edit .env: add MONGODB_URI (required);
+# add VOYAGE_API_KEY or KIMCHI_BASE_URL/KIMCHI_API_KEY for hosted models
 
 # Start
 uvicorn server.main:app --reload --port 8001   # Terminal 1
@@ -81,6 +83,7 @@ cd frontend && npm run dev                      # Terminal 2 (optional)
 # Sweeps — complete cloud-setup.md checklist first
 rag-params-finder run --config configs/example-mongodb-local.yaml   # 90 runs, no API key
 rag-params-finder run --config configs/example-mongodb-voyage.yaml  # 90 runs, Voyage + Tier 1
+rag-params-finder run --config configs/example-kimchi.yaml          # Kimchi-hosted embeddings
 ```
 
 Open `http://localhost:5173` to watch live progress and explore results.
@@ -109,6 +112,7 @@ Open `http://localhost:5173` to watch live progress and explore results.
 - **5 chunking methods**: Fixed, Recursive, Token, Sentence, Semantic
 - **3 retrieval methods**: Dense (vector search), Sparse (BM25), Hybrid (Reciprocal Rank Fusion)
 - **Voyage AI models**: all registered embeddings in `model_registry.py` (voyage-4/3/domain/context) + rerankers `rerank-2.5-lite`, `rerank-2.5`, and legacy rerank APIs
+- **Kimchi embeddings**: OpenAI-compatible hosted embedding catalog via `configs/example-kimchi.yaml`
 - **Local models** (no API key): `all-MiniLM-L6-v2` + `cross-encoder/ms-marco-MiniLM-L-6-v2`
 - **Multi-format data loading**: PDF, TXT, Markdown, CSV — files or directories
 - **Cartesian sweep**: one YAML config → N models × M methods × P sizes × Q overlaps runs
@@ -126,7 +130,7 @@ Open `http://localhost:5173` to watch live progress and explore results.
 
 **Frontend**: React 19 · TypeScript 5.8 · Vite 6 · Tailwind CSS
 
-**AI/ML**: Voyage AI · sentence-transformers · MongoDB Atlas Vector Search
+**AI/ML**: Voyage AI · Kimchi embeddings · sentence-transformers · MongoDB Atlas Vector Search
 
 **Dev tools**: uv · ruff · mypy · pytest · GitHub Actions
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ cd frontend && npm run dev                      # Terminal 2 (optional)
 # Sweeps — complete cloud-setup.md checklist first
 rag-params-finder run --config configs/example-mongodb-local.yaml   # 90 runs, no API key
 rag-params-finder run --config configs/example-mongodb-voyage.yaml  # 90 runs, Voyage + Tier 1
-rag-params-finder run --config configs/example-kimchi.yaml          # Kimchi-hosted embeddings
+rag-params-finder run --config configs/example-kimchi.yaml          # 24 runs, Kimchi-hosted embeddings
 ```
 
 Open `http://localhost:5173` to watch live progress and explore results.

--- a/cli/config_loader.py
+++ b/cli/config_loader.py
@@ -45,8 +45,9 @@ def _validate_models(config: dict) -> None:
                 f"Embedding model '{model_id}' belongs to provider "
                 f"'{info['provider']}', but config declares provider '{declared_provider}'"
             )
+        dimensions = info["dimensions"] if info["dimensions"] is not None else "runtime"
         logger.info(
-            f"Embedding model '{model_id}' → provider={declared_provider}, dim={info['dimensions']}"
+            f"Embedding model '{model_id}' → provider={declared_provider}, dim={dimensions}"
         )
 
     retrieval_cfg = config.get("retrieval", {})

--- a/cli/main.py
+++ b/cli/main.py
@@ -425,6 +425,32 @@ def delete(
 
 
 @app.command()
+def test(
+    integration: bool = typer.Option(
+        False,
+        "--integration",
+        help="Include tests marked @pytest.mark.integration (live API keys)",
+    ),
+) -> None:
+    """Run the pytest suite (same gate as CI on pull requests to main)."""
+    try:
+        import pytest
+    except ImportError:
+        console.print('[red]pytest is not installed. Run: uv pip install -e ".[dev]"[/red]')
+        raise typer.Exit(1) from None
+
+    marker = "integration" if integration else "not integration"
+    args = ["-m", marker, "--tb=short", "-q"]
+    logger.info("Running quality gate: pytest %s", " ".join(args))
+    console.print("[cyan]Running pytest (CI quality gate)...[/cyan]")
+    exit_code = pytest.main(args)
+    if exit_code != 0:
+        console.print("[red]Tests failed — fix regressions before merging.[/red]")
+        raise typer.Exit(exit_code)
+    console.print("[green]All tests passed.[/green]")
+
+
+@app.command()
 def version():
     """Print the installed package version."""
     console.print(importlib.metadata.version("rag-params-finder"))

--- a/configs/example-kimchi.yaml
+++ b/configs/example-kimchi.yaml
@@ -1,0 +1,75 @@
+# Kimchi experiment — requires KIMCHI_BASE_URL and KIMCHI_API_KEY in .env.
+# Uses Kimchi-hosted embedding models through an OpenAI-compatible embeddings API.
+#
+# Supported embedding providers:
+#   Provider "local":   all-MiniLM-L6-v2 (384-dim)
+#   Provider "voyage":  voyage-3.5-lite, voyage-3.5, voyage-context-3
+#                       (1024-dim, requires VOYAGE_API_KEY)
+#   Provider "kimchi":  hosted models below
+#                       (runtime-detected dimensions, requires KIMCHI_API_KEY)
+
+experiment_name: kimchi-model-sweep
+
+data_paths:
+  - ./input_data/pdfs/The_Federal_Pell_Grant_Program.pdf
+
+queries_file: ./configs/questions.example.json
+
+database_provider: mongodb
+
+embedding:
+  provider: kimchi
+  models:
+    - mistral/codestral-embed
+    - mistral/mistral-embed
+    - mistral/codestral-embed-2505
+    - databricks/databricks-gte-large-en
+    - databricks/databricks-bge-large-en
+    - vertex_ai-language-models/gemini-flash-experimental
+    - gemini/gemini-embedding-2-preview
+    - gemini/gemini-embedding-001
+    - gemini/gemini-embedding-2
+    - perplexity/pplx-embed-v1-0.6b
+    - perplexity/pplx-embed-v1-4b
+    - azure/text-embedding-3-large
+    - azure/text-embedding-ada-002
+    - azure/ada
+    - bedrock/marengo-embed-2-7
+    - bedrock/titan-embed-text-v2
+    - bedrock/embed-v4:0
+    - bedrock/embed-english-v3
+    - bedrock/embed-multilingual-v3
+    - bedrock/titan-embed-image-v1
+    - bedrock/nova-2-multimodal-embeddings-v1:0
+    - bedrock/titan-embed-text-v1
+    - openai/text-embedding-3-large
+    - openai/text-embedding-ada-002
+    - openai/text-embedding-3-small
+    - openai/text-embedding-ada-002-v2
+    - hosted_vllm/gte-qwen2-7b-instruct
+    - hosted_vllm/multilingual-e5-large-instruct
+    - hosted_vllm/bge-base-en-v1.5
+    - hosted_vllm/multilingual-e5-large
+    - hosted_vllm/bge-m3
+    - azure_ai/Cohere-embed-v3-multilingual
+    - azure_ai/embed-v-4-0
+    - azure_ai/Cohere-embed-v3-english
+
+chunking:
+  methods:
+    - recursive
+  params:
+    chunk_sizes: [256, 512, 1024]
+    overlaps: [50, 100]
+
+retrieval:
+  methods:
+    - dense
+  top_k_initial: 20
+  top_k_final: 5
+  rerank_provider: local
+  rerank_model: null
+
+execution:
+  parallelism: 1
+  on_error: continue

--- a/configs/example-kimchi.yaml
+++ b/configs/example-kimchi.yaml
@@ -20,40 +20,47 @@ database_provider: mongodb
 embedding:
   provider: kimchi
   models:
-    - mistral/codestral-embed
-    - mistral/mistral-embed
-    - mistral/codestral-embed-2505
-    - databricks/databricks-gte-large-en
-    - databricks/databricks-bge-large-en
-    - vertex_ai-language-models/gemini-flash-experimental
-    - gemini/gemini-embedding-2-preview
-    - gemini/gemini-embedding-001
-    - gemini/gemini-embedding-2
-    - perplexity/pplx-embed-v1-0.6b
-    - perplexity/pplx-embed-v1-4b
-    - azure/text-embedding-3-large
-    - azure/text-embedding-ada-002
-    - azure/ada
-    - bedrock/marengo-embed-2-7
-    - bedrock/titan-embed-text-v2
-    - bedrock/embed-v4:0
-    - bedrock/embed-english-v3
-    - bedrock/embed-multilingual-v3
-    - bedrock/titan-embed-image-v1
-    - bedrock/nova-2-multimodal-embeddings-v1:0
-    - bedrock/titan-embed-text-v1
     - openai/text-embedding-3-large
     - openai/text-embedding-ada-002
     - openai/text-embedding-3-small
     - openai/text-embedding-ada-002-v2
-    - hosted_vllm/gte-qwen2-7b-instruct
-    - hosted_vllm/multilingual-e5-large-instruct
-    - hosted_vllm/bge-base-en-v1.5
-    - hosted_vllm/multilingual-e5-large
-    - hosted_vllm/bge-m3
-    - azure_ai/Cohere-embed-v3-multilingual
-    - azure_ai/embed-v-4-0
-    - azure_ai/Cohere-embed-v3-english
+
+# parked: models pending provider availability confirmation in this CAST.ai account.
+# Move entries back into embedding.models once the provider is verified via:
+#   curl -s https://api.cast.ai/v1/llm/openai/supported-providers \
+#     -H "X-API-Key: $KIMCHI_API_KEY" | python3 -m json.tool
+#
+# parked:
+#   - mistral/codestral-embed
+#   - mistral/mistral-embed
+#   - mistral/codestral-embed-2505
+#   - databricks/databricks-gte-large-en
+#   - databricks/databricks-bge-large-en
+#   - vertex_ai-language-models/gemini-flash-experimental
+#   - gemini/gemini-embedding-2-preview
+#   - gemini/gemini-embedding-001
+#   - gemini/gemini-embedding-2
+#   - perplexity/pplx-embed-v1-0.6b
+#   - perplexity/pplx-embed-v1-4b
+#   - azure/text-embedding-3-large
+#   - azure/text-embedding-ada-002
+#   - azure/ada
+#   - bedrock/marengo-embed-2-7
+#   - bedrock/titan-embed-text-v2
+#   - bedrock/embed-v4:0
+#   - bedrock/embed-english-v3
+#   - bedrock/embed-multilingual-v3
+#   - bedrock/titan-embed-image-v1
+#   - bedrock/nova-2-multimodal-embeddings-v1:0
+#   - bedrock/titan-embed-text-v1
+#   - hosted_vllm/gte-qwen2-7b-instruct
+#   - hosted_vllm/multilingual-e5-large-instruct
+#   - hosted_vllm/bge-base-en-v1.5
+#   - hosted_vllm/multilingual-e5-large
+#   - hosted_vllm/bge-m3
+#   - azure_ai/Cohere-embed-v3-multilingual
+#   - azure_ai/embed-v-4-0
+#   - azure_ai/Cohere-embed-v3-english
 
 chunking:
   methods:

--- a/docs/_internal/DOC-GAPS.md
+++ b/docs/_internal/DOC-GAPS.md
@@ -1,7 +1,7 @@
 # Documentation Gap Tracker
 
 **Created**: 2026-05-05
-**Last Updated**: 2026-05-05 (README rewritten for simplicity; ARCHITECTURE.md updated for local models)
+**Last Updated**: 2026-05-20 (Kimchi provider, dashboard responsiveness, PROGRESS slice sections)
 **Reference**: Gap analysis vs [pre-rag-explorer-dashboard](https://github.com/neomatrix369/pre-rag-explorer-dashboard)
 
 Each item below is a concrete, actionable doc gap. Check the box when done and record the date.
@@ -99,7 +99,7 @@ Each item below is a concrete, actionable doc gap. Check the box when done and r
 - [x] Add `## Quality Gates Baseline` section to `CLAUDE.md` with real numbers:
   - [x] `ruff check .` → 0 errors (after `uv pip install -e ".[dev]"`)
   - [x] `mypy server/ cli/` → 0 errors
-  - [x] `pytest` → 0 tests collected (no test suite yet)
+  - [x] `pytest` → Kimchi provider tests in `tests/test_kimchi_provider.py` (update baseline when more suites land)
   - [x] `npm run typecheck` → 0 errors ✓ (fixed `tsconfig.json` to include `vite/client.d.ts`)
   - [x] `npm run build` → ✓ built in ~1.8 s, 34 modules
   - [x] `npm audit --audit-level=high` → 0 vulnerabilities

--- a/docs/_internal/PROGRESS.md
+++ b/docs/_internal/PROGRESS.md
@@ -1,7 +1,7 @@
 # rag-params-finder — Build Progress
 
-**Last Updated**: 2026-05-19 (Pause/resume sweeps + Voyage model catalog expansion + voyage-context-3 segment splitting)
-**Current**: Slices 1–9 ✅ COMPLETE | Vector DB stats + collapsible rows + boot reconciliation ✅ COMPLETE | Pause/resume + expanded Voyage catalog ✅ COMPLETE | Next: Slice 10 📋 PLANNED (failed-run recovery retry) · Slice 11 📋 PLANNED (Search Explorer enhancements) · Slice 16 📋 PLANNED (honor `parallelism`)
+**Last Updated**: 2026-05-20 (Kimchi embedding provider + rebase onto main)
+**Current**: Slices 1–9 ✅ COMPLETE | Vector DB stats + collapsible rows + boot reconciliation ✅ COMPLETE | Pause/resume + expanded Voyage catalog ✅ COMPLETE | Kimchi embedding provider ✅ COMPLETE | Next: Slice 10 📋 PLANNED (failed-run recovery retry) · Slice 11 📋 PLANNED (Search Explorer enhancements) · Slice 16 📋 PLANNED (honor `parallelism`)
 
 ---
 
@@ -20,6 +20,7 @@
 | 9 — Experiment deletion | ✅ COMPLETE | ~1 h | CLI delete command + dashboard confirmation modal, cascade cleanup |
 | — — Vector DB stats + collapsible rows + boot reconciliation | ✅ COMPLETE | ~1.5 h | Cluster/experiment storage stats; collapsible panels; orphan `running` → `partial` on server boot |
 | — — Pause/resume + Voyage catalog expansion | ✅ COMPLETE | ~2 h | Cooperative pause/resume; 12 Voyage embedding models; `voyage-context-3` contextualized API + segment splitting |
+| — — Kimchi embedding provider | ✅ COMPLETE | ~45 min | OpenAI-compatible hosted embeddings + dynamic dimensions |
 | 10 — Run recovery (retry) | 📋 PLANNED | ~1–2 h | Retry FAILED `(± INTERRUPTED)` runs in-place; boot **reconciliation** done; pause/resume covers not-yet-started combos; **retry** not yet — see [`SLICE-10-RUN-RECOVERY.md`](../slices/SLICE-10-RUN-RECOVERY.md) |
 | 11 — Search Explorer enhancements | 📋 PLANNED | ~1 h | Better visualization, export results, query filtering improvements |
 | 16 — Parallel sweep execution | 📋 PLANNED | ~2–4 h | Bounded concurrent `_run_single`; see [`SLICE-16-PARALLEL-SWEEP-RUNS.md`](../slices/SLICE-16-PARALLEL-SWEEP-RUNS.md) |
@@ -530,6 +531,10 @@ Implement the 4 stubbed chunkers (fixed, token, sentence, semantic), add sparse/
 | 2026-05-19 | — | Pause/resume cooperative sweep control | `_SweepControl` threading events; `resume_sweep()` skips completed param signatures; status `paused` non-terminal |
 | 2026-05-19 | — | voyage-context-3 segment splitting | Contextualized API 32K window; tiktoken cl100k_base sizing; standard Voyage models unchanged (`embed()` path) |
 | 2026-05-19 | — | Expanded Voyage model registry | voyage-4 series, domain models, voyage-context-3, voyage-3 legacy; `contextualized` flag drives embedder dispatch |
+| 2026-05-13 | — | Kimchi model IDs are prefixed by upstream family | Avoid collisions across models with similar names |
+| 2026-05-13 | — | Kimchi dimensions are runtime-detected | Hosted catalog spans multiple upstream embedding families |
+| 2026-05-13 | — | Kimchi is embeddings-only | Avoid unsupported reranker semantics; set `rerank_model: null` |
+| 2026-05-13 | — | Dynamic indexes use `vector_index_<dimension>` | Atlas indexes require exact embedding dimensionality |
 
 ---
 

--- a/docs/_internal/PROGRESS.md
+++ b/docs/_internal/PROGRESS.md
@@ -1,7 +1,7 @@
 # rag-params-finder — Build Progress
 
 **Last Updated**: 2026-05-20 (Kimchi provider hardening + dashboard API responsiveness)
-**Current**: Slices 1–9 ✅ COMPLETE | Vector DB stats + collapsible rows + boot reconciliation ✅ COMPLETE | Pause/resume + expanded Voyage catalog ✅ COMPLETE | Kimchi embedding provider ✅ COMPLETE | Dashboard API responsiveness ✅ COMPLETE | Next: Slice 10 📋 PLANNED (failed-run recovery retry) · Slice 11 📋 PLANNED (Search Explorer enhancements) · Slice 16 📋 PLANNED (honor `parallelism`)
+**Current**: Slices 1–9 ✅ COMPLETE | Vector DB stats + collapsible rows + boot reconciliation ✅ COMPLETE | Pause/resume + expanded Voyage catalog ✅ COMPLETE | Kimchi embedding provider ✅ COMPLETE | Provider regression pytest ✅ COMPLETE | Dashboard API responsiveness ✅ COMPLETE | Next: Slice 10 📋 PLANNED (failed-run recovery retry) · Slice 11 📋 PLANNED (Search Explorer enhancements) · Slice 16 📋 PLANNED (honor `parallelism`) · Slice 17 📋 PLANNED (test suite expansion)
 
 ---
 
@@ -20,9 +20,11 @@
 | 9 — Experiment deletion | ✅ COMPLETE | ~1 h | CLI delete command + dashboard confirmation modal, cascade cleanup |
 | — — Vector DB stats + collapsible rows + boot reconciliation | ✅ COMPLETE | ~1.5 h | Cluster/experiment storage stats; collapsible panels; orphan `running` → `partial` on server boot |
 | — — Pause/resume + Voyage catalog expansion | ✅ COMPLETE | ~2 h | Cooperative pause/resume; 12 Voyage embedding models; `voyage-context-3` contextualized API + segment splitting |
-| — — Kimchi embedding provider | ✅ COMPLETE | ~2 h | CAST OpenAI-compatible embeddings; runtime dimensions; 4-model example sweep; focused pytest suite |
+| — — Kimchi embedding provider | ✅ COMPLETE | ~2 h | CAST OpenAI-compatible embeddings; runtime dimensions; 4-model example sweep; see [`SLICE-16-KIMCHI-PROVIDER.md`](../slices/SLICE-16-KIMCHI-PROVIDER.md) |
+| — — Provider regression pytest | ✅ COMPLETE | ~1 h | 39 tests: embedder dispatch, retriever index, registry, config, db-stats, Kimchi adapter — see [`SLICE-17-TEST-SUITE-EXPANSION.md`](../slices/SLICE-17-TEST-SUITE-EXPANSION.md) § Already delivered |
 | — — Dashboard API responsiveness | ✅ COMPLETE | ~1 h | Dedicated sweep/heavy-read thread pools; batched vector-db-stats; decoupled frontend polling + fetch timeouts |
 | 10 — Run recovery (retry) | 📋 PLANNED | ~1–2 h | Retry FAILED `(± INTERRUPTED)` runs in-place; boot **reconciliation** done; pause/resume covers not-yet-started combos; **retry** not yet — see [`SLICE-10-RUN-RECOVERY.md`](../slices/SLICE-10-RUN-RECOVERY.md) |
+| 17 — Test suite expansion | 📋 PLANNED | ~4–8 h | Live smoke, mock-Mongo pipeline, Kimchi batching/cache, orchestrator/pause/rerank/sparse — see [`SLICE-17-TEST-SUITE-EXPANSION.md`](../slices/SLICE-17-TEST-SUITE-EXPANSION.md) |
 | 11 — Search Explorer enhancements | 📋 PLANNED | ~1 h | Better visualization, export results, query filtering improvements |
 | 16 — Parallel sweep execution | 📋 PLANNED | ~2–4 h | Bounded concurrent `_run_single`; see [`SLICE-16-PARALLEL-SWEEP-RUNS.md`](../slices/SLICE-16-PARALLEL-SWEEP-RUNS.md) |
 
@@ -647,6 +649,7 @@ Implement the 4 stubbed chunkers (fixed, token, sentence, semantic), add sparse/
 | 14 — Docker Compose | One-command local setup | Won't (now) | ~30 min |
 | 15 — CI/CD | GitHub Actions: ruff, mypy, pytest, npm lint/build | Should | ~20 min |
 | 16 — Parallel sweep (`parallelism` > 1) | Bounded concurrent `_run_single` (+ optional Celery upgrade path); Atlas/Voyage-rate-limit aware | Should | ~2–4 h |
+| 17 — Test suite expansion | Spec: [`SLICE-17-TEST-SUITE-EXPANSION.md`](../slices/SLICE-17-TEST-SUITE-EXPANSION.md) — mock-Mongo pipeline, live Kimchi smoke (env-gated), Kimchi batching, `ensure_vector_index` cache, orchestrator/pause/rerank/sparse tests | Should | ~4–8 h |
 
 ---
 

--- a/docs/_internal/PROGRESS.md
+++ b/docs/_internal/PROGRESS.md
@@ -1,7 +1,7 @@
 # rag-params-finder — Build Progress
 
-**Last Updated**: 2026-05-20 (Kimchi embedding provider + rebase onto main)
-**Current**: Slices 1–9 ✅ COMPLETE | Vector DB stats + collapsible rows + boot reconciliation ✅ COMPLETE | Pause/resume + expanded Voyage catalog ✅ COMPLETE | Kimchi embedding provider ✅ COMPLETE | Next: Slice 10 📋 PLANNED (failed-run recovery retry) · Slice 11 📋 PLANNED (Search Explorer enhancements) · Slice 16 📋 PLANNED (honor `parallelism`)
+**Last Updated**: 2026-05-20 (Kimchi provider hardening + dashboard API responsiveness)
+**Current**: Slices 1–9 ✅ COMPLETE | Vector DB stats + collapsible rows + boot reconciliation ✅ COMPLETE | Pause/resume + expanded Voyage catalog ✅ COMPLETE | Kimchi embedding provider ✅ COMPLETE | Dashboard API responsiveness ✅ COMPLETE | Next: Slice 10 📋 PLANNED (failed-run recovery retry) · Slice 11 📋 PLANNED (Search Explorer enhancements) · Slice 16 📋 PLANNED (honor `parallelism`)
 
 ---
 
@@ -20,7 +20,8 @@
 | 9 — Experiment deletion | ✅ COMPLETE | ~1 h | CLI delete command + dashboard confirmation modal, cascade cleanup |
 | — — Vector DB stats + collapsible rows + boot reconciliation | ✅ COMPLETE | ~1.5 h | Cluster/experiment storage stats; collapsible panels; orphan `running` → `partial` on server boot |
 | — — Pause/resume + Voyage catalog expansion | ✅ COMPLETE | ~2 h | Cooperative pause/resume; 12 Voyage embedding models; `voyage-context-3` contextualized API + segment splitting |
-| — — Kimchi embedding provider | ✅ COMPLETE | ~45 min | OpenAI-compatible hosted embeddings + dynamic dimensions |
+| — — Kimchi embedding provider | ✅ COMPLETE | ~2 h | CAST OpenAI-compatible embeddings; runtime dimensions; 4-model example sweep; focused pytest suite |
+| — — Dashboard API responsiveness | ✅ COMPLETE | ~1 h | Dedicated sweep/heavy-read thread pools; batched vector-db-stats; decoupled frontend polling + fetch timeouts |
 | 10 — Run recovery (retry) | 📋 PLANNED | ~1–2 h | Retry FAILED `(± INTERRUPTED)` runs in-place; boot **reconciliation** done; pause/resume covers not-yet-started combos; **retry** not yet — see [`SLICE-10-RUN-RECOVERY.md`](../slices/SLICE-10-RUN-RECOVERY.md) |
 | 11 — Search Explorer enhancements | 📋 PLANNED | ~1 h | Better visualization, export results, query filtering improvements |
 | 16 — Parallel sweep execution | 📋 PLANNED | ~2–4 h | Bounded concurrent `_run_single`; see [`SLICE-16-PARALLEL-SWEEP-RUNS.md`](../slices/SLICE-16-PARALLEL-SWEEP-RUNS.md) |
@@ -453,6 +454,85 @@ Surface MongoDB/Atlas storage footprint in the dashboard, improve experiments li
 
 ---
 
+## Pause / Resume + Voyage Catalog Expansion ✅
+
+**Status**: ✅ COMPLETE | **Started**: 2026-05-19 | **Completed**: 2026-05-19 | **Target**: ~2 h
+
+### Goal
+Cooperatively pause long sweeps without losing completed runs; expand the Voyage embedding catalog; support `voyage-context-3` contextualized embeddings.
+
+### What Changed
+- **EDIT**: `server/core/orchestrator.py` — `_SweepControl` threading events; `resume_sweep()` skips completed parameter signatures
+- **EDIT**: `server/api/experiments.py` — `POST /experiments/{id}/pause`, `POST /experiments/{id}/resume`
+- **EDIT**: `server/core/embedder.py` — `voyage-context-3` → `contextualized_embed()` with tiktoken segment splitting (~30K tokens)
+- **EDIT**: `server/core/model_registry.py` — voyage-4/3/domain/context models; `contextualized` flag
+- **EDIT**: `cli/main.py`, `cli/api_client.py` — `pause`, `resume` commands
+- **EDIT**: `frontend/src/components/ExperimentControlButtons.tsx` — pause/resume on detail screen
+- **EDIT**: user docs — `cli-reference.md`, `getting-started.md`, `dashboard-guide.md`, `configuration.md`
+
+### Acceptance Criteria
+- [x] `rag-params-finder pause|resume <experiment-id>` works; status `paused` is non-terminal
+- [x] Resume skips parameter combos that already reached `COMPLETE`
+- [x] `voyage-context-3` long documents split into contextualized segments
+- [x] Expanded Voyage models validate at config load
+
+---
+
+## Kimchi Embedding Provider ✅
+
+**Status**: ✅ COMPLETE | **Started**: 2026-05-13 | **Completed**: 2026-05-20 | **Target**: ~2 h
+
+### Goal
+Add Kimchi (CAST.ai OpenAI-compatible) as a third embedding provider with runtime-detected dimensions and a focused example sweep.
+
+### What Changed
+- **NEW**: `server/core/kimchi_embedder.py` — OpenAI-compatible `/v1/embeddings`; CAST payload shape; full `provider/model` IDs passed through
+- **EDIT**: `server/core/model_registry.py` — Kimchi catalog with `dimensions: None` + `contextualized` flags
+- **EDIT**: `server/core/embedder.py`, `server/core/retriever.py`, `server/db/indexes.py` — routing + dynamic `vector_index_<dimension>`
+- **NEW**: `configs/example-kimchi.yaml` — 4 active OpenAI-family models; additional IDs parked until account verification
+- **NEW**: `tests/test_kimchi_provider.py` — validation, payload, runtime index selection, db-stats dimension sampling
+- **EDIT**: `server/api/experiments_shared.py` — sample stored chunk embeddings when registry `dimensions` is `None` (Kimchi vector DB stats)
+- **EDIT**: user + contributor docs — Kimchi setup in `getting-started.md`, `cloud-setup.md`, `configuration.md`, `troubleshooting.md`; slice spec [`SLICE-16-KIMCHI-PROVIDER.md`](../slices/SLICE-16-KIMCHI-PROVIDER.md)
+
+### Key Design Decisions
+| Decision | Why |
+|---|---|
+| Prefixed model IDs (`openai/text-embedding-3-large`) | Avoid collisions across upstream families behind one gateway |
+| Runtime dimensions | Catalog spans multiple embedding sizes; Atlas index must match actual vectors |
+| Embeddings-only (`rerank_model: null`) | No invented Kimchi rerank semantics |
+| Park unverified models in YAML | Registry lists many IDs; example sweep only runs models confirmed on the CAST account |
+| Sample chunk embedding for db-stats | Registry has no fixed dimension; storage estimates need one stored vector per model |
+
+### Acceptance Criteria
+- [x] `embedding.provider: kimchi` validates; secrets in `.env` only
+- [x] `example-kimchi.yaml` runs 24 combos (4 models × 6 chunk param sets × dense)
+- [x] Vector DB stats work for Kimchi experiments (no crash on `dimensions: None`)
+- [x] `uv run pytest` — Kimchi-focused tests pass
+
+---
+
+## Dashboard API Responsiveness ✅
+
+**Status**: ✅ COMPLETE | **Started**: 2026-05-19 | **Completed**: 2026-05-19 | **Target**: ~1 h
+
+### Goal
+Keep `GET /experiments` and the dashboard experiment list responsive while sweeps and expensive Mongo aggregations run.
+
+### What Changed
+- **NEW**: `server/core/executors.py` — `SWEEP_EXECUTOR` + `HEAVY_READ_EXECUTOR` thread pools
+- **EDIT**: `server/api/experiments.py` — `schedule_sweep()` / `resume` on sweep pool; db-stats on heavy-read pool
+- **EDIT**: `server/api/experiments_shared.py` — batched aggregations for vector-db-stats (3 pipeline queries vs per-experiment N+1)
+- **EDIT**: `frontend/src/constants.ts` — `API_FETCH_TIMEOUT_MS` (30s), `VECTOR_DB_STATS_FETCH_TIMEOUT_MS` (90s), `VECTOR_DB_STATS_POLL_MS` (60s)
+- **EDIT**: `frontend/src/services/fetchWithProgress.ts`, `ExperimentsScreen.tsx`, `VectorDbStatsPanel.tsx` — decoupled list vs stats loading
+
+### Acceptance Criteria
+- [x] Experiment list loads within a few seconds during an active sweep
+- [x] Vector DB stats may lag but do not block the list
+- [x] Hung polls abort instead of leaving the UI stuck indefinitely
+- [x] Troubleshooting documents starved-API and timeout behavior
+
+---
+
 ## Slice 6: Additional Chunkers + Retrieval Methods ✅
 
 **Status**: ✅ COMPLETE | **Started**: 2026-05-17 | **Completed**: 2026-05-17 | **Target**: ~45 min
@@ -535,6 +615,11 @@ Implement the 4 stubbed chunkers (fixed, token, sentence, semantic), add sparse/
 | 2026-05-13 | — | Kimchi dimensions are runtime-detected | Hosted catalog spans multiple upstream embedding families |
 | 2026-05-13 | — | Kimchi is embeddings-only | Avoid unsupported reranker semantics; set `rerank_model: null` |
 | 2026-05-13 | — | Dynamic indexes use `vector_index_<dimension>` | Atlas indexes require exact embedding dimensionality |
+| 2026-05-19 | — | Dedicated sweep + heavy-read thread pools | Default executor starved `GET /experiments` during long sweeps and db-stats aggregations |
+| 2026-05-19 | — | Batched vector-db-stats aggregations | Replaced per-experiment Mongo round-trips with three dashboard-wide pipelines |
+| 2026-05-20 | — | Kimchi db-stats samples stored embeddings | Registry `dimensions: None` cannot estimate storage until chunks exist |
+| 2026-05-20 | — | Kimchi passes full LiteLLM model ID to CAST | Stripping the provider prefix broke routing; payload matches CAST template |
+| 2026-05-20 | — | Parked Kimchi models in example YAML | Example sweep runs only account-verified models; registry retains full catalog |
 
 ---
 
@@ -572,7 +657,7 @@ Use this when resuming a session mid-slice:
 ```
 [ ] Read docs/_internal/PROGRESS.md — note current slice and last known state
 [ ] Run quality gates to confirm no regressions:
-      backend: uv run ruff check . && uv run mypy server/ cli/ && uv run pytest
+      backend: uv run ruff check . && uv run mypy server/ cli/ && uv run pytest --tb=short -q
       frontend: npm run typecheck && npm run build
 [ ] Check git status — any uncommitted changes?
 [ ] Read the current slice spec in docs/slices/SLICE-XX-*.md

--- a/docs/contributor-guide/architecture.md
+++ b/docs/contributor-guide/architecture.md
@@ -183,6 +183,7 @@ Two independent provider settings in each experiment config:
 **Embedding provider** (`embedding.provider`):
 - `local` → `server/core/local_embedder.py` → sentence-transformers `all-MiniLM-L6-v2` (384-dim)
 - `voyage` → `server/core/embedder.py` → Voyage AI API (1024-dim); `voyage-context-3` uses `contextualized_embed()` with per-document segment splitting (32K-token window)
+- `kimchi` → `server/core/kimchi_embedder.py` → OpenAI-compatible Kimchi embeddings (runtime-detected dim)
 
 **Reranking provider** (`retrieval.rerank_provider`):
 - `local` → `server/core/local_reranker.py` → CrossEncoder `cross-encoder/ms-marco-MiniLM-L-6-v2`
@@ -196,7 +197,7 @@ Provider flows explicitly through `RunParams` → `orchestrator` → embedder/re
 
 | Collection | Purpose | Key Indexes |
 |---|---|---|
-| `chunks` | Text chunks + embeddings | Vector index on `embedding` (384 or 1024-dim cosine) + filter fields |
+| `chunks` | Text chunks + embeddings | Vector index on `embedding` (`vector_index_<dimension>`) + filter fields |
 | `experiments` | Experiment metadata + sweep config | `created_at`, `status` |
 | `run_status` | Per-run phase tracking | `experiment_id`, `phase` |
 | `results` | Per-query top-K results | `experiment_id`, `query_id` |
@@ -219,7 +220,7 @@ See `docs/adr/` for Architecture Decision Records:
 |---|---|
 | FastAPI `BackgroundTasks` (not Celery) | No queue infrastructure needed while sweep runs execute sequentially *(see [`SLICE-16`](../slices/SLICE-16-PARALLEL-SWEEP-RUNS.md) for honoring `parallelism > 1` and optional Celery path)* |
 | Hand-mirrored TypeScript types | No codegen tooling (typeshare/quicktype); 5 types + 3 enums is manageable manually |
-| Separate vector indexes per dimension | Atlas requires exact `numDimensions` — `vector_index_1024` (Voyage) and `vector_index_384` (local) coexist on the same collection |
+| Separate vector indexes per dimension | Atlas requires exact `numDimensions`; local, Voyage, and runtime-detected Kimchi dimensions each use `vector_index_<dimension>` |
 | Lazy-load + cache for local models | First run downloads from HuggingFace; subsequent runs instant — avoids blocking server startup |
 | `numpy<2` pinned | torch compiled against NumPy 1.x ABI; NumPy 2.x causes `_ARRAY_API not found` crashes |
 | Shared `DashboardShell` + `AppPageChrome` components | Unified header, navigation, and page layout across all screens — consistent UX, easier maintenance |

--- a/docs/contributor-guide/architecture.md
+++ b/docs/contributor-guide/architecture.md
@@ -69,6 +69,7 @@ FastAPI Server
 | FastAPI | REST API server |
 | Python 3.12 | Language runtime |
 | Voyage AI SDK | Embeddings + reranking (hosted) |
+| Kimchi (CAST.ai) | OpenAI-compatible hosted embeddings via `kimchi_embedder.py` |
 | sentence-transformers | Local embeddings + reranking (offline) |
 | MongoDB Atlas / PyMongo | Vector storage + search |
 | LangChain text splitters | Recursive, fixed, token chunking |
@@ -103,12 +104,14 @@ rag-params-finder/
 │   │   └── runs.py          # GET /runs/{id}/status
 │   ├── core/
 │   │   ├── orchestrator.py  # run_sweep(), resume_sweep(), run_single() pipeline
+│   │   ├── executors.py     # SWEEP_EXECUTOR + HEAVY_READ_EXECUTOR (isolate long work from API pool)
 │   │   ├── startup_reconciliation.py  # fix stale running experiments on boot
 │   │   ├── atlas_storage.py # Atlas Admin API quota + dbStats footprint
 │   │   ├── pdf_parser.py    # pypdf text extraction
 │   │   ├── query_loader.py  # persona JSON → Query dataclass list
 │   │   ├── model_registry.py  # embedding + reranking model catalog
 │   │   ├── embedder.py      # Voyage embed(); voyage-context-3 → contextualized_embed + segment split
+│   │   ├── kimchi_embedder.py  # CAST OpenAI-compatible embeddings (runtime-detected dim)
 │   │   ├── local_embedder.py  # sentence-transformers embedding (lazy-load, cached)
 │   │   ├── reranker.py      # Voyage reranking client
 │   │   ├── local_reranker.py  # CrossEncoder reranking (lazy-load, cached)
@@ -232,6 +235,10 @@ See `docs/adr/` for Architecture Decision Records:
 | Boot orphan reconciliation | `BackgroundTasks` sweeps die on process exit; startup marks in-flight runs `interrupted` and sets terminal experiment status — separate from Slice 10 retry |
 | Pause / resume sweeps | Cooperative halt via `_SweepControl` threading events; `resume_sweep()` skips completed parameter signatures; status `paused` is non-terminal |
 | Vector DB stats API + dashboard | `GET /experiments/vector-db-stats` and `/{id}/db-stats`; estimated storage from chunk counts + model dimensions; optional Atlas quota bar |
+| Dedicated thread pools (`executors.py`) | Sweeps and heavy Mongo aggregations no longer compete with lightweight `GET /experiments` on the default executor |
+| Batched vector-db-stats queries | Three aggregation pipelines (chunks, results, chunking methods) replace per-experiment N+1 round-trips on the experiments list |
+| Kimchi dimension resolution for stats | When `model_registry` has `dimensions: None`, db-stats samples one stored chunk embedding per model to name indexes and estimate storage |
+| Decoupled dashboard polling | Experiment list polls every 2 s (30 s timeout); vector DB stats every 60 s (90 s timeout) so the list is not blocked by slow aggregations |
 
 ---
 

--- a/docs/contributor-guide/development.md
+++ b/docs/contributor-guide/development.md
@@ -61,17 +61,17 @@ uv run ruff check .
 # Type check — expect 0 errors
 uv run mypy server/ cli/
 
-# Tests (Kimchi provider suite in tests/test_kimchi_provider.py)
-uv run pytest --tb=short -q
+# Tests (same as CI — provider regression suite)
+rag-params-finder test
 
-# Coverage (when tests exist)
-uv run pytest --cov=server --cov=cli --cov-report=html
+# Coverage (optional)
+uv run pytest -m "not integration" --cov=server --cov=cli --cov-report=html
 ```
 
 **Baseline (as of 2026-05-20)**:
 - `ruff check .` → 0 errors
 - `mypy server/ cli/` → 0 errors
-- `pytest` → Kimchi-focused tests in `tests/test_kimchi_provider.py` (no MongoDB required for unit cases)
+- `rag-params-finder test` → 39 tests in `tests/` (no MongoDB or live API keys; GitHub Actions on PRs to `main`)
 
 ### Frontend
 
@@ -97,16 +97,19 @@ npm audit --audit-level=high
 
 ## 🧪 Testing Strategy
 
-Current approach: manual testing via CLI + Dashboard.
+**CI today:** `rag-params-finder test` (or `uv run pytest -m "not integration" --tb=short -q`) — runs on every PR and merge queue to `main`; 39 provider-regression tests (embedder dispatch, retriever indexes, config validation, Vector DB stats, Kimchi adapter parsing). No MongoDB or live API keys required.
 
-**Planned test layers** (no suite yet — see Contributing):
-- **Unit tests**: individual chunkers, embedders, rerankers with mock inputs
-- **Integration tests**: full pipeline with mock MongoDB collections and pre-computed embedding fixtures (avoids real API calls)
-- **Frontend**: TypeScript compilation serves as the basic type-correctness check (no vitest/jest setup yet)
+**Planned expansion:** [`docs/slices/SLICE-17-TEST-SUITE-EXPANSION.md`](../slices/SLICE-17-TEST-SUITE-EXPANSION.md) — parked high/medium items from the Kimchi merge review:
 
-The primary blockers for a proper test suite are:
-- Integration tests need mock MongoDB (or a test Atlas cluster)
-- Embedding tests need either a local model or pre-computed fixtures to avoid slow API calls
+| Priority | Parked in Slice 17 |
+|----------|-------------------|
+| High | Manual smoke checklist (local / Voyage / Kimchi); Kimchi Atlas `vector_index_<dim>` docs; Kimchi embedding batching; env-gated CAST integration test |
+| Medium | `ensure_vector_index` cache; orchestrator + pause/resume tests; reranker dispatch; sparse/hybrid retriever; mock-Mongo pipeline fixtures |
+| Lower | Frontend vitest; dead-code cleanup; parallel-sweep tests (with Slice 16) |
+
+Until Slice 17 ships, treat **pytest green + manual smoke** as the merge gate for provider changes.
+
+**Manual testing** remains required for full CLI + Dashboard flows (see `VERIFICATION_CHECKLIST.md` at repo root).
 
 ---
 
@@ -186,7 +189,7 @@ See `.github/workflows/ci.yml` for the full pipeline.
 
 Areas where help is most needed:
 
-- **Test suite**: pytest fixtures with mock MongoDB + pre-computed embedding fixtures
+- **Test suite (Slice 17)**: see [`SLICE-17-TEST-SUITE-EXPANSION.md`](../slices/SLICE-17-TEST-SUITE-EXPANSION.md) — mock MongoDB + pre-computed embedding fixtures, orchestrator coverage
 - **SSE live updates**: replace the 2-second polling loop with Server-Sent Events
 - **Docker Compose**: one-command `docker compose up` setup
 - **Experiment cleanup CLI**: `rag-params-finder cleanup --older-than 30d`

--- a/docs/contributor-guide/development.md
+++ b/docs/contributor-guide/development.md
@@ -61,17 +61,17 @@ uv run ruff check .
 # Type check — expect 0 errors
 uv run mypy server/ cli/
 
-# Tests (suite not yet written — 0 collected is the current baseline)
+# Tests (Kimchi provider suite in tests/test_kimchi_provider.py)
 uv run pytest --tb=short -q
 
 # Coverage (when tests exist)
 uv run pytest --cov=server --cov=cli --cov-report=html
 ```
 
-**Baseline (as of 2026-05-05)**:
+**Baseline (as of 2026-05-20)**:
 - `ruff check .` → 0 errors
 - `mypy server/ cli/` → 0 errors
-- `pytest` → 0 tests collected
+- `pytest` → Kimchi-focused tests in `tests/test_kimchi_provider.py` (no MongoDB required for unit cases)
 
 ### Frontend
 

--- a/docs/contributor-guide/extending.md
+++ b/docs/contributor-guide/extending.md
@@ -18,9 +18,9 @@ In `server/core/model_registry.py`, add to `EMBEDDING_MODELS`:
 ```python
 EMBEDDING_MODELS = {
     "my-new-model": {
-        "provider": "local",          # or "voyage"
-        "dimensions": 768,
-        "huggingface_id": "org/my-new-model",  # for local models; None for Voyage
+        "provider": "local",          # or "voyage" / "kimchi"
+        "dimensions": 768,            # use None for runtime-detected hosted dimensions
+        "huggingface_id": "org/my-new-model",  # for local models; None for Voyage/Kimchi
         "description": "Short label for docs",
         "contextualized": False,      # True only for voyage-context-* (contextualized_embed API)
     },
@@ -30,11 +30,11 @@ EMBEDDING_MODELS = {
 
 ### 2. Add provider support (if new provider)
 
-If the model uses a provider not yet supported, update `server/models/config.py` → `Provider` type and add dispatch logic in the embedder.
+If the model uses a provider not yet supported, update `server/models/config.py` → `Provider` type and add dispatch logic in the embedder. Hosted providers must read credentials from `server/settings.py`, not from YAML configs.
 
 ### 3. Update the embedder dispatcher
 
-In `server/core/embedder.py` (Voyage) or `server/core/local_embedder.py` (sentence-transformers): verify the model name routes correctly through the existing dispatch logic. For most new models of an existing provider type, no changes are needed.
+In `server/core/embedder.py`, verify the model routes to local, Voyage, or Kimchi. For most new models of an existing provider type, registry/config changes are enough.
 
 **Contextualized models** (`contextualized: True`, e.g. `voyage-context-3`):
 
@@ -45,7 +45,7 @@ In `server/core/embedder.py` (Voyage) or `server/core/local_embedder.py` (senten
 
 ### 4. Create an Atlas vector index
 
-A new dimension size requires a new Atlas vector index. See [getting-started.md](../user-guide/getting-started.md#2-create-the-atlas-vector-index) for the index JSON format.
+A new dimension size requires a new Atlas vector index. Known dimensions can be registered statically; hosted models with `dimensions=None` use the runtime embedding length and route to `vector_index_<dimension>`. See [getting-started.md](../user-guide/getting-started.md#2-create-the-atlas-vector-index) for the index JSON format.
 
 ### 5. Update the example configs
 
@@ -179,9 +179,10 @@ export async function fetchMyData(experimentId: string): Promise<MyType> {
 
 | Gotcha | What to watch for |
 |---|---|
-| Vector dimension mismatch | Local models are 384-dim; Voyage models are 1024-dim. Cannot mix in the same experiment. Each dimension needs its own Atlas vector index. |
-| Provider/model mismatch | Config validation fails if `provider: local` is paired with a Voyage model name. The `model_registry.py` cross-checks this at load time. |
+| Vector dimension mismatch | Local models are 384-dim, Voyage models are 1024-dim, and Kimchi dimensions are runtime-detected. Each dimension needs its own Atlas vector index. |
+| Provider/model mismatch | Config validation fails if `provider` is paired with a model registered to another provider. The `model_registry.py` cross-checks this at load time. |
 | Missing embeddings filter | Always filter Atlas vector search by `embedding_model` — different models produce incompatible vectors that must not be compared. |
+| Hosted provider secrets | Keep `VOYAGE_API_KEY`, `KIMCHI_API_KEY`, and base URLs in `.env`/server settings; never commit secrets or add them to YAML configs. |
 | Queries file URL caching | URL-sourced query files are downloaded to `configs/` and cached by hash. Delete the cached file to force re-download. |
 | Server must be running | The CLI requires the server at `SERVER_URL` (default: `http://localhost:8001`). All commands fail if the server is down. |
 | Rate limits on Voyage | Free tier: 3 RPM / 10k TPM (defaults). Tier 1: 2,000 RPM + model TPM — set `VOYAGE_RPM_LIMIT` / `VOYAGE_TPM_LIMIT` in `.env`. |

--- a/docs/contributor-guide/extending.md
+++ b/docs/contributor-guide/extending.md
@@ -49,7 +49,7 @@ A new dimension size requires a new Atlas vector index. Known dimensions can be 
 
 ### 5. Update the example configs
 
-Add the new model to `configs/example-mongodb-local.yaml` or `configs/example-mongodb-voyage.yaml` (whichever provider it belongs to), so users can immediately try it.
+Add the new model to the matching example config — `configs/example-mongodb-local.yaml`, `configs/example-mongodb-voyage.yaml`, or `configs/example-kimchi.yaml` — so users can immediately try it.
 
 ---
 

--- a/docs/contributor-guide/local-environment.md
+++ b/docs/contributor-guide/local-environment.md
@@ -80,7 +80,7 @@ MONGODB_URI=mongodb+srv://<user>:<pass>@<cluster>.mongodb.net/rag_params_finder?
 VOYAGE_API_KEY=vo-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # Kimchi (OPTIONAL — only if using Kimchi models)
-KIMCHI_BASE_URL=https://api.navy
+KIMCHI_BASE_URL=https://llm.cast.ai/openai
 KIMCHI_API_KEY=kimchi-xxxxxxxxxxxxxxxxxxxxxxxx
 
 # Server URL (used by CLI, default is localhost:8001)

--- a/docs/contributor-guide/local-environment.md
+++ b/docs/contributor-guide/local-environment.md
@@ -10,7 +10,7 @@ Internal notes for local setup, debugging, and maintenance. Not required for bas
 
 ## 🗄️ MongoDB Atlas — Full Setup Details
 
-**User-facing guide:** [Cloud Account Setup](../user-guide/cloud-setup.md#mongodb-atlas-required) — account, cluster, connection string, and search indexes with official MongoDB doc links.
+**User-facing guide:** [Cloud Account Setup](../user-guide/cloud-setup.md#mongodb-atlas-required-for-all-sweeps) — account, cluster, connection string, and search indexes with official MongoDB doc links.
 
 The sections below are contributor/debugging notes. Prefer the cloud-setup guide for onboarding.
 
@@ -52,7 +52,7 @@ The `text_search_index`, `vector_index_384`, and `vector_index_1024` all coexist
 
 ## 🤖 Voyage AI Setup
 
-**User-facing guide:** [Cloud Account Setup → Voyage AI](../user-guide/cloud-setup.md#voyage-ai-optional) — account, API key, $5 credit for Tier 1 rate limits.
+**User-facing guide:** [Cloud Account Setup → Voyage AI](../user-guide/cloud-setup.md#voyage-ai-required-for-voyage-sweep) — account, API key, $5 credit for Tier 1 rate limits.
 
 **`voyage-context-3`**: uses the contextualized embedding API (not standard `embed()`). The server splits long documents into segments that fit the 32K-token window. See [configuration.md](../user-guide/configuration.md#voyage-context-3-contextualized-api) and [troubleshooting.md](../user-guide/troubleshooting.md#-voyage-context-3-token-limit-exceeded).
 

--- a/docs/contributor-guide/local-environment.md
+++ b/docs/contributor-guide/local-environment.md
@@ -80,7 +80,7 @@ MONGODB_URI=mongodb+srv://<user>:<pass>@<cluster>.mongodb.net/rag_params_finder?
 VOYAGE_API_KEY=vo-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # Kimchi (OPTIONAL — only if using Kimchi models)
-KIMCHI_BASE_URL=https://your-kimchi-host.example
+KIMCHI_BASE_URL=https://api.navy
 KIMCHI_API_KEY=kimchi-xxxxxxxxxxxxxxxxxxxxxxxx
 
 # Server URL (used by CLI, default is localhost:8001)

--- a/docs/contributor-guide/local-environment.md
+++ b/docs/contributor-guide/local-environment.md
@@ -58,6 +58,18 @@ The `text_search_index`, `vector_index_384`, and `vector_index_1024` all coexist
 
 ---
 
+## 🍜 Kimchi Setup
+
+Kimchi is optional and only needed for `embedding.provider: kimchi`.
+
+1. Get the OpenAI-compatible Kimchi embeddings base URL.
+2. Create an API key for the service.
+3. Copy both into `.env` as `KIMCHI_BASE_URL` and `KIMCHI_API_KEY`.
+
+Kimchi model dimensions are detected at runtime. If Atlas cannot create search indexes programmatically on your cluster tier, create `vector_index_<dimension>` manually after the server logs the detected dimension.
+
+---
+
 ## 🔑 Full .env Reference
 
 ```bash
@@ -67,11 +79,17 @@ MONGODB_URI=mongodb+srv://<user>:<pass>@<cluster>.mongodb.net/rag_params_finder?
 # Voyage AI (OPTIONAL — only if using Voyage models)
 VOYAGE_API_KEY=vo-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
+# Kimchi (OPTIONAL — only if using Kimchi models)
+KIMCHI_BASE_URL=https://your-kimchi-host.example
+KIMCHI_API_KEY=kimchi-xxxxxxxxxxxxxxxxxxxxxxxx
+
 # Server URL (used by CLI, default is localhost:8001)
 SERVER_URL=http://localhost:8001
 
 # Rate limits (Voyage only — set based on your tier; see .env.example)
 # Tier 1 example: VOYAGE_RPM_LIMIT=2000  VOYAGE_TPM_LIMIT=16000000  # voyage-4-lite / voyage-3.5-lite
+KIMCHI_RPM_LIMIT=60
+KIMCHI_TPM_LIMIT=0
 
 # Optional — Atlas Admin API for dashboard storage quota bar
 # ATLAS_PUBLIC_KEY=

--- a/docs/slices/SLICE-16-KIMCHI-PROVIDER.md
+++ b/docs/slices/SLICE-16-KIMCHI-PROVIDER.md
@@ -17,8 +17,10 @@ Add Kimchi as an embeddings-only provider so one experiment config can sweep the
 - [x] Kimchi calls use an OpenAI-compatible `/v1/embeddings` adapter.
 - [x] Runtime embedding dimensions route to `vector_index_<dimension>`.
 - [x] `configs/example-kimchi.yaml` sweeps four verified OpenAI-family models (24 runs); additional registry IDs parked in YAML until CAST account verification.
-- [x] Focused tests cover validation, config loading, response parsing, and runtime index selection.
+- [x] Provider regression pytest suite (dispatch, retriever index, registry dims, config, db-stats, Kimchi adapter parsing) — see **Already delivered** in [`SLICE-17-TEST-SUITE-EXPANSION.md`](./SLICE-17-TEST-SUITE-EXPANSION.md).
 - [x] User and contributor docs describe Kimchi setup and dynamic dimensions.
+
+**Deferred to Slice 17:** live CAST smoke, mock-Mongo pipeline tests, Kimchi batching, `ensure_vector_index` cache, orchestrator/pause-resume/sparse-hybrid coverage — see parked work in [`SLICE-17-TEST-SUITE-EXPANSION.md`](./SLICE-17-TEST-SUITE-EXPANSION.md).
 
 ## Key Decisions
 
@@ -43,5 +45,7 @@ Add Kimchi as an embeddings-only provider so one experiment config can sweep the
 ```bash
 uv run ruff check .
 uv run mypy server/ cli/
-uv run pytest --tb=short -q
+rag-params-finder test   # 39 tests — provider regression; CI runs on PRs to main; not a substitute for live Kimchi smoke (Slice 17)
 ```
+
+Manual pre-merge smoke (local → Voyage → Kimchi + Atlas `vector_index_<dim>`) is tracked in [`SLICE-17-TEST-SUITE-EXPANSION.md`](./SLICE-17-TEST-SUITE-EXPANSION.md).

--- a/docs/slices/SLICE-16-KIMCHI-PROVIDER.md
+++ b/docs/slices/SLICE-16-KIMCHI-PROVIDER.md
@@ -1,8 +1,10 @@
-# Slice 16 — Kimchi Provider
+# Kimchi Provider (delivered slice)
+
+> **Note:** Filename uses `SLICE-16` for historical reasons. Parallel sweep execution is tracked separately in [`SLICE-16-PARALLEL-SWEEP-RUNS.md`](./SLICE-16-PARALLEL-SWEEP-RUNS.md).
 
 ## Status
 
-✅ COMPLETE — 2026-05-13
+✅ COMPLETE — 2026-05-13 (core) · hardened 2026-05-20 (CAST payload, db-stats, example config)
 
 ## Goal
 
@@ -14,7 +16,7 @@ Add Kimchi as an embeddings-only provider so one experiment config can sweep the
 - [x] Kimchi credentials stay server-side via `KIMCHI_BASE_URL` and `KIMCHI_API_KEY`.
 - [x] Kimchi calls use an OpenAI-compatible `/v1/embeddings` adapter.
 - [x] Runtime embedding dimensions route to `vector_index_<dimension>`.
-- [x] `configs/example-kimchi.yaml` lists all unique requested Kimchi model IDs.
+- [x] `configs/example-kimchi.yaml` sweeps four verified OpenAI-family models (24 runs); additional registry IDs parked in YAML until CAST account verification.
 - [x] Focused tests cover validation, config loading, response parsing, and runtime index selection.
 - [x] User and contributor docs describe Kimchi setup and dynamic dimensions.
 
@@ -26,6 +28,15 @@ Add Kimchi as an embeddings-only provider so one experiment config can sweep the
 | Runtime dimensions for Kimchi | The catalog spans multiple upstream model families with different embedding sizes |
 | Kimchi embeddings only | Keeps reranking behavior unchanged and avoids inventing unsupported reranker semantics |
 | Secrets in settings only | Preserves the existing server-side secret boundary |
+| Full LiteLLM model ID to CAST API | Stripping the `openai/` prefix broke routing |
+| CAST embedding payload shape | Request body must match CAST template (`input` + `model`) |
+| Sample stored embeddings for db-stats | Registry `dimensions: None` — storage estimates need one chunk vector per model |
+
+## Post-delivery fixes (2026-05-20)
+
+- Vector DB stats no longer crash on Kimchi experiments (`_sample_embedding_dimension` in `experiments_shared.py`).
+- `KIMCHI_BASE_URL` documented as `https://llm.cast.ai/openai` (not the supported-providers discovery URL).
+- Example config pared to four active models; Mistral/Gemini/Azure/etc. remain in registry but commented as parked.
 
 ## Verification
 

--- a/docs/slices/SLICE-16-KIMCHI-PROVIDER.md
+++ b/docs/slices/SLICE-16-KIMCHI-PROVIDER.md
@@ -1,0 +1,36 @@
+# Slice 16 — Kimchi Provider
+
+## Status
+
+✅ COMPLETE — 2026-05-13
+
+## Goal
+
+Add Kimchi as an embeddings-only provider so one experiment config can sweep the Kimchi-hosted embedding catalog.
+
+## Acceptance Criteria
+
+- [x] `embedding.provider: kimchi` validates against Kimchi-registered model IDs.
+- [x] Kimchi credentials stay server-side via `KIMCHI_BASE_URL` and `KIMCHI_API_KEY`.
+- [x] Kimchi calls use an OpenAI-compatible `/v1/embeddings` adapter.
+- [x] Runtime embedding dimensions route to `vector_index_<dimension>`.
+- [x] `configs/example-kimchi.yaml` lists all unique requested Kimchi model IDs.
+- [x] Focused tests cover validation, config loading, response parsing, and runtime index selection.
+- [x] User and contributor docs describe Kimchi setup and dynamic dimensions.
+
+## Key Decisions
+
+| Decision | Why |
+|---|---|
+| Prefixed model IDs like `openai/text-embedding-3-large` | Avoid collisions across upstream providers hosted behind Kimchi |
+| Runtime dimensions for Kimchi | The catalog spans multiple upstream model families with different embedding sizes |
+| Kimchi embeddings only | Keeps reranking behavior unchanged and avoids inventing unsupported reranker semantics |
+| Secrets in settings only | Preserves the existing server-side secret boundary |
+
+## Verification
+
+```bash
+uv run ruff check .
+uv run mypy server/ cli/
+uv run pytest --tb=short -q
+```

--- a/docs/slices/SLICE-17-TEST-SUITE-EXPANSION.md
+++ b/docs/slices/SLICE-17-TEST-SUITE-EXPANSION.md
@@ -1,0 +1,127 @@
+# SLICE 17 — Test Suite Expansion (Integration, E2E, Kimchi Hardening)
+
+**MoSCoW:** SHOULD *(confidence for merges and refactors; not blocking Kimchi MVP or hackathon demo)*
+**Target time:** ~4–8 h *(phased; can ship unit/integration layers before live smoke automation)*
+**Status:** 📋 PLANNED
+
+> **Context:** Kimchi provider delivery (see [`SLICE-16-KIMCHI-PROVIDER.md`](./SLICE-16-KIMCHI-PROVIDER.md)) added a **provider regression suite** (39 pytest cases, 2026-05-20). This slice tracks everything still **untested in CI** and the **manual / operational** gates called out during the Kimchi ↔ `main` merge review.
+
+---
+
+## Goal
+
+Expand automated coverage beyond provider dispatch and stats so merges to `main` do not rely on manual smoke alone. Close gaps for orchestration, retrieval modes, Kimchi live API behavior, and performance-related code paths (`ensure_vector_index`, embedding batching).
+
+---
+
+## Already delivered (baseline — do not re-scope)
+
+Provider regression tests landed with Kimchi hardening:
+
+| Module | Covers |
+|--------|--------|
+| `tests/test_embedder_provider_dispatch.py` | Explicit `local` / `voyage` / `kimchi` routing; unknown provider → `ValueError`; Voyage contextualized vs standard path |
+| `tests/test_retriever_vector_index.py` | Dense search uses `vector_index_{len(query)}` + `ensure_vector_index` for 384 / 1024 / 1536 |
+| `tests/test_model_registry_dimensions.py` | Fixed dims (local/Voyage); runtime Kimchi (`dimensions: None`); `get_dimensions()` raises for runtime models |
+| `tests/test_experiment_config_providers.py` | Pydantic + CLI load for local/voyage/kimchi; Kimchi rerank rejected |
+| `tests/test_experiments_db_stats.py` | Vector DB stats: registry dims (local/Voyage); sampled chunk dims (Kimchi) |
+| `tests/test_kimchi_provider.py` | Kimchi payload parsing, URL normalization, CAST model ID routing, example config |
+
+**Verification today:** `rag-params-finder test` or `uv run pytest -m "not integration" --tb=short -q` (no MongoDB, no live API keys required; same command as CI on PRs to `main`).
+
+---
+
+## Parked work — priority matrix
+
+### High — merge / production confidence
+
+| Item | Type | Notes |
+|------|------|--------|
+| **Manual smoke checklist** | Manual / doc | Document and optionally script-check: `example-mongodb-local.yaml`, `example-mongodb-voyage.yaml`, `example-kimchi.yaml` end-to-end with server + Atlas. **Not automatable in CI without secrets/cluster.** |
+| **Atlas indexes for Kimchi dims** | Ops / doc | Startup ensures `vector_index_384` + `vector_index_1024` only. Kimchi example sweep needs **`vector_index_1536`** and **`vector_index_3072`** (OpenAI-family models). Test slice should document required indexes; optional test asserts index names in stats when fixtures present. |
+| **Kimchi embedding batching** | Code + test | `kimchi_embedder._embed` posts **one HTTP request per chunk** → slow sweeps, 429 risk. Implement batching (or bounded concurrency) when CAST API supports it; add unit tests for batch split/retry. |
+| **Live CAST/Kimchi integration test** | Integration (env-gated) | `@pytest.mark.integration` skipped unless `KIMCHI_API_KEY` + `KIMCHI_BASE_URL` set. One probe embed + dimension assertion. Catches auth, routing, and real vector lengths. |
+
+### Medium — correctness and ops debt
+
+| Item | Type | Notes |
+|------|------|--------|
+| **`ensure_vector_index` cache** | Code + test | `retriever.dense_search` calls Atlas `list_search_indexes` (and maybe create) **per query**. Cache per-dimension “exists” in-process; test that second call does not re-list. |
+| **Orchestrator phase tests** | Unit/integration | Mock Mongo + embedder/retriever boundaries: PARSING → CHUNKING → EMBEDDING → STORING → QUERYING → RERANKING transitions, `on_error: continue` vs `stop`. |
+| **Pause / resume** | Integration | Cooperative pause stops scheduling; resume continues; characterization tests with mocked orchestrator state. |
+| **Reranking** | Unit | Local CrossEncoder + Voyage reranker dispatch (mirror embedder provider tests). |
+| **Sparse / hybrid retrieval** | Unit | `sparse_search` pipeline shape; `hybrid_search` RRF merge with mocked `aggregate` results. |
+| **Mock MongoDB integration** | Integration | Fixtures for `chunks`, `experiments`, `run_status`, `results`; full pipeline slice without network (pre-computed embedding fixtures). Blocker called out in `docs/contributor-guide/development.md`. |
+| **Parked Kimchi registry models** | Manual / doc | Registry lists 40+ IDs; example config enables four. Tests cannot verify CAST account availability — document `supported-providers` curl check before enabling parked models. |
+
+### Lower — nice to have in same slice or follow-on
+
+| Item | Type | Notes |
+|------|------|--------|
+| **Frontend component tests** | Frontend | vitest/jest for `ExperimentsScreen`, polling, delete modal (TypeScript-only gate today). |
+| **Remove dead `kimchi_embedder.get_dimensions()`** | Code cleanup | Unused probe helper; embed path caches dims inline. |
+| **`KIMCHI_TPM_LIMIT=0` behavior** | Code + test | Document “RPM-only throttling”; optional test that limiter respects TPM when set. |
+| **Parallel sweep characterization** | Integration | When [`SLICE-16-PARALLEL-SWEEP-RUNS.md`](./SLICE-16-PARALLEL-SWEEP-RUNS.md) ships: `parallelism: 1` matches today; `parallelism > 1` scheduling tests. |
+
+---
+
+## Acceptance criteria *(implementation exit)*
+
+### Phase A — Documentation and manual gates
+
+- [ ] `docs/user-guide/troubleshooting.md` (or contributor testing doc) includes **pre-merge smoke checklist** (local → Voyage → Kimchi) and **Kimchi Atlas index** requirements (`vector_index_1536`, `vector_index_3072`, etc.).
+- [ ] Slice 17 cross-linked from `docs/contributor-guide/development.md` Testing Strategy (replace “no suite yet” where outdated).
+
+### Phase B — Automated expansion (CI-safe)
+
+- [ ] `tests/conftest.py` with shared fixtures (mock collections, sample embeddings, minimal `ExperimentConfig` builders).
+- [ ] Orchestrator tests (mocked boundaries) for at least one happy path and one `on_error: stop` path.
+- [ ] Reranker provider dispatch tests (local + voyage).
+- [ ] Sparse + hybrid retriever tests with mocked Mongo `aggregate`.
+- [ ] Test that `ensure_vector_index` is not called repeatedly for the same dimension after cache *(after cache implemented)*.
+
+### Phase C — Optional live / heavy
+
+- [ ] Env-gated Kimchi integration test (`pytest -m integration` documented in development.md).
+- [ ] Kimchi embedding batching implemented + batch unit tests.
+- [ ] Mock-Mongo full-pipeline integration test (no Voyage/Kimchi/Atlas network).
+
+---
+
+## Out of scope (other slices)
+
+| Work | Slice |
+|------|--------|
+| Honor `execution.parallelism` | [`SLICE-16-PARALLEL-SWEEP-RUNS.md`](./SLICE-16-PARALLEL-SWEEP-RUNS.md) |
+| Failed-run retry CLI/API | [`SLICE-10-RUN-RECOVERY.md`](./SLICE-10-RUN-RECOVERY.md) |
+| CI workflow itself | Done — `.github/workflows/ci.yml` (Slice 15 roadmap item) |
+| README screenshots | `docs/_internal/DOC-GAPS.md` Gap 1 |
+
+---
+
+## Key files (expected touch)
+
+| Area | Files |
+|------|--------|
+| Tests | `tests/conftest.py`, `tests/test_orchestrator.py`, `tests/test_reranker_dispatch.py`, `tests/test_retriever_sparse_hybrid.py`, `tests/test_kimchi_integration.py` *(optional)* |
+| Code *(if batching/cache in scope)* | `server/core/kimchi_embedder.py`, `server/core/retriever.py`, `server/db/indexes.py` |
+| Docs | `docs/contributor-guide/development.md`, `docs/user-guide/troubleshooting.md` |
+
+---
+
+## Verification
+
+```bash
+uv run ruff check .
+uv run mypy server/ cli/
+uv run pytest --tb=short -q                    # default CI — unit + mocked
+uv run pytest -m integration --tb=short -q   # optional — requires KIMCHI_* / VOYAGE_* / MONGODB_URI
+```
+
+---
+
+## References
+
+- Kimchi merge review (branch `tessl-hackathon-kimchi-integration` vs `main`): provider dispatch, runtime vector indexes, db-stats, no live API coverage.
+- `README.md` Contributing — test suite with mock MongoDB called out as priority.
+- `VERIFICATION_CHECKLIST.md` — manual dashboard/regression cases (align smoke checklist with Slice 17 Phase A).

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -36,6 +36,9 @@ rag-params-finder run --config configs/example-mongodb-local.yaml --no-watch
 
 # Voyage AI experiment (requires VOYAGE_API_KEY in .env)
 rag-params-finder run --config configs/example-mongodb-voyage.yaml
+
+# Kimchi-hosted embedding sweep (requires KIMCHI_BASE_URL and KIMCHI_API_KEY)
+rag-params-finder run --config configs/example-kimchi.yaml
 ```
 
 When watching, the CLI renders a live Rich table showing each run's current phase:

--- a/docs/user-guide/cloud-setup.md
+++ b/docs/user-guide/cloud-setup.md
@@ -9,7 +9,7 @@
 
 ## Before you run a sweep
 
-Both example configs use **dense + sparse + hybrid** retrieval — you need **two** Atlas search indexes (vector + text), not just one.
+Both example configs use **dense + sparse + hybrid** retrieval — you need **two** Atlas search indexes (vector + text), not just one. The Kimchi example uses **dense only** — vector index only (runtime dimension).
 
 ### Local sweep — `example-mongodb-local.yaml`
 
@@ -43,6 +43,23 @@ Complete the **local sweep checklist** above, then add:
 | 9 | `vector_index_1024` instead of `vector_index_384` | [MongoDB → step 6](#6-create-search-indexes-m0--required-before-sweep) |
 
 Steps 1–5 use `vector_index_384`; step 9 swaps in `vector_index_1024` for Voyage embeddings. You need **both** vector indexes if you run local and Voyage sweeps on the same cluster.
+
+### Kimchi sweep — `example-kimchi.yaml`
+
+```bash
+rag-params-finder run --config configs/example-kimchi.yaml
+```
+
+Complete the **local sweep checklist** (steps 1–5), then add:
+
+| # | Step | Where |
+|---|---|---|
+| 6 | `KIMCHI_BASE_URL` + `KIMCHI_API_KEY` in `.env` | [Getting Started → Configure](../user-guide/getting-started.md#1-set-environment-variables) |
+| 7 | Vector index for runtime embedding dimension | See below — `vector_index_<dimension>` |
+
+Kimchi models have **runtime-detected dimensions** (e.g. 1536 for `openai/text-embedding-3-large`). The server routes to `vector_index_<dimension>` and tries to create the index programmatically on **M10+** clusters. On **M0**, watch server logs during the first embed/query and create the matching vector index manually (same JSON shape as step 6b, with the logged `numDimensions`).
+
+The current `example-kimchi.yaml` uses **dense retrieval only** — you do **not** need `text_search_index` unless you add sparse/hybrid to the config.
 
 ---
 
@@ -92,7 +109,7 @@ MONGODB_URI=mongodb+srv://...
 
 ### 6. Create search indexes (M0 — required before sweep)
 
-On **M0/M2/M5**, indexes must be created in the Atlas UI **before** the sweep reaches the QUERYING phase. Both example configs need **vector + text** indexes.
+On **M0/M2/M5**, indexes must be created in the Atlas UI **before** the sweep reaches the QUERYING phase. Local and Voyage configs need **vector + text** indexes; Kimchi dense-only sweeps need a vector index at the runtime dimension.
 
 **6a. Create the `chunks` collection** (if it does not exist):
 
@@ -104,7 +121,8 @@ Atlas UI → **Browse Collections** → database `rag_params_finder` → **Creat
 |---|---|---|
 | `example-mongodb-local.yaml` | `vector_index_384` | `384` |
 | `example-mongodb-voyage.yaml` | `vector_index_1024` | `1024` |
-| Both (same cluster) | create **both** | `384` and `1024` |
+| `example-kimchi.yaml` | `vector_index_<dimension>` | runtime (from server log) |
+| Both local + Voyage (same cluster) | create **both** | `384` and `1024` |
 
 **Vector index JSON** (set `numDimensions` and name as above):
 
@@ -193,6 +211,9 @@ rag-params-finder run --config configs/example-mongodb-local.yaml
 
 # Voyage — 90 runs, requires steps above
 rag-params-finder run --config configs/example-mongodb-voyage.yaml
+
+# Kimchi — hosted embeddings, requires KIMCHI_BASE_URL + KIMCHI_API_KEY
+rag-params-finder run --config configs/example-kimchi.yaml
 ```
 
 Dashboard (optional): `cd frontend && npm run dev` → `http://localhost:5173`

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -16,7 +16,7 @@ Place config files in `configs/`. Ready-to-run configs:
 |---|---|---|---|---|---|---|
 | `example-mongodb-local.yaml` | MongoDB Atlas | local (all-MiniLM-L6-v2) | all 5 methods | dense · sparse · hybrid | 90 | No |
 | `example-mongodb-voyage.yaml` | MongoDB Atlas | Voyage AI (all models) | all 5 methods | dense · sparse · hybrid | 90 | Yes |
-| `example-kimchi.yaml` | MongoDB Atlas | Kimchi-hosted embeddings | all 5 methods | dense · sparse · hybrid | varies | Yes |
+| `example-kimchi.yaml` | MongoDB Atlas | Kimchi-hosted embeddings | recursive | dense | 24 | Yes |
 
 Each config is a **full Cartesian sweep**: every combination of embedding model, chunking method, chunk size, overlap, and retrieval method runs as an independent experiment.
 
@@ -233,14 +233,22 @@ To **re-run only failed combinations inside an existing experiment** *(same `exp
 
 ## 🍜 Kimchi Config
 
-`configs/example-kimchi.yaml` sweeps the Kimchi-hosted embedding catalog with prefixed model IDs such as `mistral/codestral-embed`, `openai/text-embedding-3-large`, and `hosted_vllm/bge-m3`.
+`configs/example-kimchi.yaml` sweeps four OpenAI-family Kimchi models with recursive chunking and dense retrieval. Additional prefixed model IDs are registered in `model_registry.py` (many parked in the YAML until provider availability is confirmed).
 
 ```yaml
 embedding:
   provider: kimchi
   models:
-    - mistral/codestral-embed
     - openai/text-embedding-3-large
+    - openai/text-embedding-ada-002
+    - openai/text-embedding-3-small
+    - openai/text-embedding-ada-002-v2
+
+chunking:
+  methods: [recursive]
+  params:
+    chunk_sizes: [256, 512, 1024]
+    overlaps: [50, 100]
 
 retrieval:
   methods: [dense]

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -10,12 +10,13 @@ All YAML fields, sweep expansion rules, and queries file format.
 
 ## ⚙️ Experiment Config (YAML)
 
-Place config files in `configs/`. Two ready-to-run configs are provided, one per vector-DB × provider combination:
+Place config files in `configs/`. Ready-to-run configs:
 
 | Config file | Vector DB | Embedding provider | Chunking | Retrieval | Runs | API key? |
 |---|---|---|---|---|---|---|
 | `example-mongodb-local.yaml` | MongoDB Atlas | local (all-MiniLM-L6-v2) | all 5 methods | dense · sparse · hybrid | 90 | No |
-| `example-mongodb-voyage.yaml` | MongoDB Atlas | Voyage AI (all 3 models) | all 5 methods | dense · sparse · hybrid | 90 | Yes |
+| `example-mongodb-voyage.yaml` | MongoDB Atlas | Voyage AI (all models) | all 5 methods | dense · sparse · hybrid | 90 | Yes |
+| `example-kimchi.yaml` | MongoDB Atlas | Kimchi-hosted embeddings | all 5 methods | dense · sparse · hybrid | varies | Yes |
 
 Each config is a **full Cartesian sweep**: every combination of embedding model, chunking method, chunk size, overlap, and retrieval method runs as an independent experiment.
 
@@ -32,9 +33,9 @@ queries_file: ./configs/questions.example.json  # local path or URL
                                                  # URL downloads to ./configs/ on first use and caches
 
 embedding:
-  provider: local                    # "local" (sentence-transformers) or "voyage"
+  provider: local                    # "local", "voyage", or "kimchi"
   models:
-    - all-MiniLM-L6-v2               # must match provider: local models can't be paired with provider: voyage
+    - all-MiniLM-L6-v2               # models must match the declared provider
 
 chunking:
   methods:
@@ -117,6 +118,8 @@ Canonical list: `server/core/model_registry.py` (`EMBEDDING_MODELS`, `RERANKER_M
 | `voyage-3.5` | 1024 | `voyage` | Previous-gen standard |
 | `voyage-3` | 1024 | `voyage` | Voyage 3 general |
 | `voyage-multilingual-2` | 1024 | `voyage` | Multilingual |
+| **Kimchi-hosted** | | | |
+| `mistral/codestral-embed` and other prefixed IDs | Runtime | `kimchi` | OpenAI-compatible hosted embeddings — see `model_registry.py` |
 
 ### Reranker models
 
@@ -132,7 +135,7 @@ Canonical list: `server/core/model_registry.py` (`EMBEDDING_MODELS`, `RERANKER_M
 
 **Provider/model must match.** The system validates at config load time — a `provider: local` config with a Voyage model name will fail immediately with a clear error.
 
-**Atlas vector index** selection is automatic: local models (384-dim) use `vector_index_384`; Voyage models (1024-dim) use `vector_index_1024`. Both can coexist on the same `chunks` collection.
+**Atlas vector index** selection is automatic: local models (384-dim) use `vector_index_384`; Voyage models (1024-dim) use `vector_index_1024`; Kimchi models use the runtime embedding length and route to `vector_index_<dimension>`. All can coexist on the same `chunks` collection.
 
 ### `voyage-context-3` (contextualized API)
 
@@ -225,6 +228,29 @@ For a targeted subset, copy the file and trim the `methods` or `chunk_sizes` lis
 To **continue an incomplete sweep** without re-submitting YAML, pause and resume the same experiment (CLI or dashboard) — completed parameter combinations are skipped automatically.
 
 To **re-run only failed combinations inside an existing experiment** *(same `experiment_id`, keep successful runs)*, see the planned workflow in [`../slices/SLICE-10-RUN-RECOVERY.md`](../slices/SLICE-10-RUN-RECOVERY.md) — today this requires manual YAML reshaping, pause/resume for not-yet-started combos, or a new submit.
+
+---
+
+## 🍜 Kimchi Config
+
+`configs/example-kimchi.yaml` sweeps the Kimchi-hosted embedding catalog with prefixed model IDs such as `mistral/codestral-embed`, `openai/text-embedding-3-large`, and `hosted_vllm/bge-m3`.
+
+```yaml
+embedding:
+  provider: kimchi
+  models:
+    - mistral/codestral-embed
+    - openai/text-embedding-3-large
+
+retrieval:
+  methods: [dense]
+  top_k_initial: 20
+  top_k_final: 5
+  rerank_provider: local
+  rerank_model: null
+```
+
+Kimchi support is embeddings-only. Set `KIMCHI_BASE_URL` and `KIMCHI_API_KEY` server-side in `.env`; do not put secrets in YAML config files.
 
 ---
 

--- a/docs/user-guide/dashboard-guide.md
+++ b/docs/user-guide/dashboard-guide.md
@@ -31,7 +31,7 @@ The landing screen shows all submitted experiments, newest first.
 
 **Collapsible rows**: Click the chevron on a row to expand inline details without leaving the list. Expansion state is remembered per experiment (`localStorage`).
 
-**Vector DB stats panel** (top of list): Aggregated storage footprint for your Atlas cluster — total chunks, estimated embedding storage, active index names, and per-experiment breakdown. Polls `GET /experiments/vector-db-stats` on refresh. Cluster quota bar appears when Atlas Admin API credentials or `MONGODB_STORAGE_LIMIT_MB` is configured.
+**Vector DB stats panel** (top of list): Aggregated storage footprint for your Atlas cluster — total chunks, estimated embedding storage, active index names, and per-experiment breakdown. Loads from `GET /experiments/vector-db-stats` on its own schedule (**every 60 s**, 90 s fetch timeout) so a slow stats aggregation does not block the experiment list (2 s poll, 30 s timeout). Cluster quota bar appears when Atlas Admin API credentials or `MONGODB_STORAGE_LIMIT_MB` is configured. Kimchi experiments resolve embedding dimensions by sampling stored chunk vectors when the registry has no fixed size.
 
 **Actions**:
 - **View details**: Click any row to open the Experiment Detail screen
@@ -147,7 +147,8 @@ This allows direct comparison of configs that used different models or retrieval
 
 | Screen | Polls | Interval | Stops When |
 |---|---|---|---|
-| Experiments List | Yes | Every 2 s | Never (always refreshes) |
+| Experiments List | Yes | Every 2 s (`GET /experiments`) | Never (always refreshes) |
+| Experiments List — Vector DB stats | Yes | Every 60 s (`GET /experiments/vector-db-stats`) | Never; may show “loading” while list is already visible |
 | Experiment Detail | Yes | Every 2 s | Status reaches terminal state (`paused` is non-terminal — polling continues) |
 | Search Explorer | No | — | Loads once |
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -61,7 +61,7 @@ VOYAGE_RPM_LIMIT=2000
 VOYAGE_TPM_LIMIT=16000000
 
 # Optional — only needed for Kimchi-hosted embedding models
-KIMCHI_BASE_URL=https://api.navy
+KIMCHI_BASE_URL=https://llm.cast.ai/openai
 KIMCHI_API_KEY=kimchi-xxxxxxxxxxxxxxxxxxxxxxxx
 KIMCHI_RPM_LIMIT=60
 KIMCHI_TPM_LIMIT=0

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -61,7 +61,7 @@ VOYAGE_RPM_LIMIT=2000
 VOYAGE_TPM_LIMIT=16000000
 
 # Optional — only needed for Kimchi-hosted embedding models
-KIMCHI_BASE_URL=https://your-kimchi-host.example
+KIMCHI_BASE_URL=https://api.navy
 KIMCHI_API_KEY=kimchi-xxxxxxxxxxxxxxxxxxxxxxxx
 KIMCHI_RPM_LIMIT=60
 KIMCHI_TPM_LIMIT=0

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -16,8 +16,8 @@ Everything you need to run your first RAG parameter sweep experiment.
 |---|---|---|
 | Python | 3.12+ | Install via [python.org](https://www.python.org/downloads/) or `pyenv install 3.12.2` |
 | Node.js | 22+ | Install via [nodejs.org](https://nodejs.org/) or `nvm install 22` |
-| MongoDB Atlas | Free tier (M0) | **Required** — see [Cloud Account Setup](cloud-setup.md#mongodb-atlas-required) |
-| Voyage AI | Optional | Only for Voyage models — see [Cloud Account Setup](cloud-setup.md#voyage-ai-optional) |
+| MongoDB Atlas | Free tier (M0) | **Required** — see [Cloud Account Setup](cloud-setup.md#mongodb-atlas-required-for-all-sweeps) |
+| Voyage AI | Optional | Only for Voyage models — see [Cloud Account Setup](cloud-setup.md#voyage-ai-required-for-voyage-sweep) |
 | Kimchi API key | Optional | Only for Kimchi-hosted embedding sweeps |
 
 **New to Atlas or Voyage?** Start with **[Cloud Account Setup](cloud-setup.md)** — account creation, connection string, search indexes, API key, and Tier 1 billing (~15 min).
@@ -73,7 +73,7 @@ Full variable reference: [Troubleshooting → Environment Variables](troubleshoo
 
 ### 2. Search indexes (required before sweep)
 
-Both example configs use dense + sparse + hybrid — create **`vector_index_384`** (local) or **`vector_index_1024`** (Voyage) **and** **`text_search_index`** on the `chunks` collection.
+Example configs use dense + sparse + hybrid for local/Voyage sweeps — create **`vector_index_384`** (local) or **`vector_index_1024`** (Voyage) **and** **`text_search_index`** on the `chunks` collection. The Kimchi example uses dense only (vector index at runtime dimension; see below).
 
 **M0 free tier:** do this manually in Atlas UI before running a sweep — see [Cloud Account Setup → step 6](cloud-setup.md#6-create-search-indexes-m0--required-before-sweep).
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -18,6 +18,7 @@ Everything you need to run your first RAG parameter sweep experiment.
 | Node.js | 22+ | Install via [nodejs.org](https://nodejs.org/) or `nvm install 22` |
 | MongoDB Atlas | Free tier (M0) | **Required** — see [Cloud Account Setup](cloud-setup.md#mongodb-atlas-required) |
 | Voyage AI | Optional | Only for Voyage models — see [Cloud Account Setup](cloud-setup.md#voyage-ai-optional) |
+| Kimchi API key | Optional | Only for Kimchi-hosted embedding sweeps |
 
 **New to Atlas or Voyage?** Start with **[Cloud Account Setup](cloud-setup.md)** — account creation, connection string, search indexes, API key, and Tier 1 billing (~15 min).
 
@@ -59,6 +60,12 @@ VOYAGE_API_KEY=vo-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 VOYAGE_RPM_LIMIT=2000
 VOYAGE_TPM_LIMIT=16000000
 
+# Optional — only needed for Kimchi-hosted embedding models
+KIMCHI_BASE_URL=https://your-kimchi-host.example
+KIMCHI_API_KEY=kimchi-xxxxxxxxxxxxxxxxxxxxxxxx
+KIMCHI_RPM_LIMIT=60
+KIMCHI_TPM_LIMIT=0
+
 SERVER_URL=http://localhost:8001
 ```
 
@@ -71,6 +78,13 @@ Both example configs use dense + sparse + hybrid — create **`vector_index_384`
 **M0 free tier:** do this manually in Atlas UI before running a sweep — see [Cloud Account Setup → step 6](cloud-setup.md#6-create-search-indexes-m0--required-before-sweep).
 
 **M10+ paid tier:** server creates indexes on startup — check uvicorn logs.
+
+For **Kimchi models**, dimensions are detected at runtime. The server will try to create
+`vector_index_<dimension>` automatically when the first query embedding is generated. If
+your Atlas tier does not support programmatic search index creation, create the same JSON
+shape manually with the dimension from the server log.
+
+All vector indexes can coexist on the same collection. Wait ~1–2 minutes for the index to build before running queries.
 
 ---
 
@@ -119,6 +133,9 @@ rag-params-finder run --config configs/example-mongodb-local.yaml
 
 # Voyage sweep — checklist items 1–9
 rag-params-finder run --config configs/example-mongodb-voyage.yaml
+
+# Kimchi-hosted embeddings — requires KIMCHI_BASE_URL and KIMCHI_API_KEY in .env
+rag-params-finder run --config configs/example-kimchi.yaml
 
 # Submit and detach (check dashboard for status instead)
 rag-params-finder run --config configs/example-mongodb-local.yaml --detach

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -137,6 +137,8 @@ embedding:
 
 **Fix**:
 - Set both values in `.env`; never put them in config YAML.
+- Use `KIMCHI_BASE_URL=https://llm.cast.ai/openai`. Do not use the
+  `supported-providers` discovery URL as the embeddings base URL.
 - Confirm the server was restarted after editing `.env`.
 - Use `configs/example-kimchi.yaml` only when `embedding.provider: kimchi` should call the hosted Kimchi service.
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -144,6 +144,31 @@ embedding:
 
 ---
 
+## 🍜 Kimchi embedding API errors
+
+**Symptom**: EMBEDDING phase fails with HTTP 4xx from CAST, “model not found”, or empty embeddings.
+
+**Fix**:
+- Confirm `KIMCHI_BASE_URL=https://llm.cast.ai/openai` and restart uvicorn after editing `.env`.
+- Use the **full** registry model ID in YAML (e.g. `openai/text-embedding-3-large`) — do not strip the provider prefix.
+- List models your API key can call: `curl -s https://api.cast.ai/v1/llm/openai/supported-providers -H "X-API-Key: $KIMCHI_API_KEY"`.
+- Move unverified models out of `embedding.models` (see parked list in `configs/example-kimchi.yaml`).
+
+---
+
+## 🍜 Kimchi vector DB stats empty or previously crashed
+
+**Symptom**: Dashboard vector DB stats panel errors or shows no embedding dimensions for a Kimchi experiment.
+
+**Cause**: Kimchi models have `dimensions: None` in the registry. Storage estimates need at least one stored chunk per embedding model.
+
+**Fix**:
+- **Server ≥ 2026-05-20**: db-stats samples one chunk embedding per model automatically after the first successful STORING phase.
+- If stats are still empty, confirm the experiment has completed at least one run through STORING for that model.
+- Upgrade if you are on an older build that assumed fixed dimensions for all providers.
+
+---
+
 ## ⏱️ Voyage API rate limit hit
 
 **Symptom**: `voyageai.error.RateLimitError: Rate limit exceeded` in server logs; run status shows `failed`.

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -12,7 +12,7 @@ Common errors and how to fix them.
 
 **Symptom**: server logs show `Search index 'vector_index' not found` or queries return no results.
 
-**Cause**: Search indexes are missing or not yet **ACTIVE**. On M0 free tier they must be created manually; on M10+ check server logs for auto-creation failures.
+**Cause**: Search indexes are missing or not yet **ACTIVE**. On M0 free tier they must be created manually; on M10+ check server logs for auto-creation failures. Kimchi models use runtime-detected dimensions — the index name must match the embedding vector length (`vector_index_<dimension>`).
 
 **Fix**: Full steps → [Cloud Account Setup → step 6](cloud-setup.md#6-create-search-indexes-m0--required-before-sweep). Quick reference — **Voyage models** (1024-dim), name: `vector_index_1024`:
 ```json
@@ -42,7 +42,9 @@ Common errors and how to fix them.
 }
 ```
 
-Both indexes can coexist on the same `chunks` collection — the server selects the correct one automatically based on the model. Wait **~1–2 minutes** for the index to build before running queries.
+For Kimchi models, dimensions are detected at runtime and the server routes to `vector_index_<dimension>`. If programmatic index creation is unsupported on your Atlas tier, copy the dimension from the server log and create the matching index manually.
+
+All indexes can coexist on the same `chunks` collection. Wait **~1–2 minutes** for the index to build before running queries.
 
 ---
 
@@ -81,16 +83,16 @@ Wait ~1–2 minutes. The `text_search_index` and your vector indexes coexist on 
 
 ---
 
-## ⚠️ Dimension mismatch (local vs Voyage models)
+## ⚠️ Dimension mismatch (local vs Voyage vs Kimchi models)
 
 **Symptom**: vector search fails with a dimension error, or results are nonsensical.
 
-**Cause**: local models produce 384-dim embeddings; Voyage models produce 1024-dim. Vectors from different models cannot be compared in the same search index.
+**Cause**: local models produce 384-dim embeddings, Voyage models produce 1024-dim embeddings, and Kimchi-hosted models vary by model. Vectors from different models cannot be compared in the same search index.
 
 **Fix**:
-- Each embedding model needs its own Atlas vector index (`vector_index_384` or `vector_index_1024`)
+- Each embedding dimension needs its own Atlas vector index (`vector_index_384`, `vector_index_1024`, or `vector_index_<runtime-dim>`)
 - Never mix providers within the same experiment config (the system validates this at config load time)
-- The server automatically routes to the correct index via `get_index_name(model)` in `server/core/retriever.py`
+- The server automatically routes to the correct index from the query embedding length in `server/core/retriever.py`
 
 ---
 
@@ -114,12 +116,29 @@ embedding:
   models:
     - voyage-3.5-lite
 
+# Correct — kimchi provider with prefixed Kimchi model ID
+embedding:
+  provider: kimchi
+  models:
+    - openai/text-embedding-3-large
+
 # Wrong — will fail validation immediately
 embedding:
   provider: local
   models:
     - voyage-3.5-lite   # ERROR: voyage model with local provider
 ```
+
+---
+
+## 🍜 Kimchi credentials missing
+
+**Symptom**: run fails during the EMBEDDING phase with `KIMCHI_BASE_URL not set` or `KIMCHI_API_KEY not set`.
+
+**Fix**:
+- Set both values in `.env`; never put them in config YAML.
+- Confirm the server was restarted after editing `.env`.
+- Use `configs/example-kimchi.yaml` only when `embedding.provider: kimchi` should call the hosted Kimchi service.
 
 ---
 
@@ -267,9 +286,13 @@ db.results.deleteMany({experiment_id: exp_id})
 |---|---|---|---|
 | `MONGODB_URI` | Yes | — | MongoDB Atlas connection string |
 | `VOYAGE_API_KEY` | No | — | Voyage AI API key (only if using Voyage models) |
+| `KIMCHI_BASE_URL` | No | — | Kimchi OpenAI-compatible embeddings endpoint |
+| `KIMCHI_API_KEY` | No | — | Kimchi API key (only if using Kimchi models) |
 | `SERVER_URL` | No | `http://localhost:8001` | FastAPI server URL (used by CLI) |
 | `VOYAGE_RPM_LIMIT` | No | `3` | Voyage requests-per-minute limit (throttle guard; free-tier default) |
 | `VOYAGE_TPM_LIMIT` | No | `10000` | Voyage tokens-per-minute limit (free-tier default) |
+| `KIMCHI_RPM_LIMIT` | No | `60` | Kimchi requests-per-minute limit |
+| `KIMCHI_TPM_LIMIT` | No | `0` | Kimchi tokens-per-minute limit; `0` disables token throttling |
 | `ATLAS_PUBLIC_KEY` | No | — | Atlas Admin API public key — enables cluster storage quota in dashboard |
 | `ATLAS_PRIVATE_KEY` | No | — | Atlas Admin API private key |
 | `ATLAS_GROUP_ID` | No | — | 24-char Atlas **project** ID (from cloud.mongodb.com URL) |
@@ -284,7 +307,7 @@ db.results.deleteMany({experiment_id: exp_id})
 
 | Collection | Purpose | Key Indexes |
 |---|---|---|
-| `chunks` | Text chunks + embeddings | Vector index on `embedding` (cosine, 384 or 1024-dim) + filter fields |
+| `chunks` | Text chunks + embeddings | Vector index on `embedding` (`vector_index_<dimension>`) + filter fields |
 | `experiments` | Experiment metadata + sweep config | `created_at`, `status` |
 | `run_status` | Per-run phase tracking | `experiment_id`, `phase` |
 | `results` | Per-query top-K results | `experiment_id`, `query_id` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,10 @@ python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]
+markers = [
+    "integration: live API or Atlas tests (require env vars; excluded from default CI and CLI)",
+]

--- a/server/api/experiments_shared.py
+++ b/server/api/experiments_shared.py
@@ -179,14 +179,76 @@ def _bytes_to_mb(value: float) -> float:
     return round(value / (1024 * 1024), 2)
 
 
+def _sample_embedding_dimension(experiment_id: str, embedding_model: str) -> int | None:
+    sample = get_collection(CHUNKS_COLLECTION).find_one(
+        {"experiment_id": experiment_id, "embedding_model": embedding_model},
+        {"embedding": 1},
+    )
+    if not sample:
+        return None
+    embedding = sample.get("embedding")
+    if not embedding:
+        return None
+    return len(embedding)
+
+
+def _resolved_embedding_dimensions(
+    embedding_models: list[str],
+    experiment_id: str | None = None,
+) -> list[int]:
+    from server.core.model_registry import EMBEDDING_MODELS, get_model_info
+
+    dims: list[int] = []
+    for model in embedding_models:
+        if model not in EMBEDDING_MODELS:
+            continue
+        fixed = get_model_info(model)["dimensions"]
+        if fixed is not None:
+            dims.append(fixed)
+            continue
+        if not experiment_id:
+            continue
+        sampled = _sample_embedding_dimension(experiment_id, model)
+        if sampled is not None:
+            dims.append(sampled)
+    return dims
+
+
+def _resolved_index_names(
+    embedding_models: list[str],
+    experiment_id: str | None = None,
+) -> list[str]:
+    from server.core.model_registry import (
+        EMBEDDING_MODELS,
+        get_index_name_for_dimensions,
+        get_model_info,
+    )
+
+    names: set[str] = set()
+    for model in embedding_models:
+        if model not in EMBEDDING_MODELS:
+            continue
+        fixed = get_model_info(model)["dimensions"]
+        if fixed is not None:
+            names.add(get_index_name_for_dimensions(fixed))
+            continue
+        if not experiment_id:
+            continue
+        sampled = _sample_embedding_dimension(experiment_id, model)
+        if sampled is not None:
+            names.add(get_index_name_for_dimensions(sampled))
+    return sorted(names)
+
+
 def _storage_breakdown_mb(
-    total_chunks: int, embedding_models: list[str]
+    total_chunks: int,
+    embedding_models: list[str],
+    experiment_id: str | None = None,
 ) -> tuple[float, float, float]:
     if total_chunks == 0:
         return 0.0, 0.0, 0.0
-    from server.core.model_registry import EMBEDDING_MODELS, get_dimensions
 
-    dims = [get_dimensions(model) for model in embedding_models if model in EMBEDDING_MODELS]
+    dims = _resolved_embedding_dimensions(embedding_models, experiment_id)
     if not dims:
         return 0.0, 0.0, 0.0
     avg_dim = sum(dims) / len(dims)
@@ -200,8 +262,10 @@ def _storage_breakdown_mb(
     )
 
 
-def _estimate_storage_mb(total_chunks: int, embedding_models: list[str]) -> float:
-    _, _, total_mb = _storage_breakdown_mb(total_chunks, embedding_models)
+def _estimate_storage_mb(
+    total_chunks: int, embedding_models: list[str], experiment_id: str | None = None
+) -> float:
+    _, _, total_mb = _storage_breakdown_mb(total_chunks, embedding_models, experiment_id)
     return total_mb
 
 
@@ -256,23 +320,21 @@ def _assemble_experiment_db_stats(
     runs_with_data: int,
     run_breakdown: list[dict],
 ) -> dict:
-    from server.core.model_registry import EMBEDDING_MODELS, get_dimensions, get_index_name
     from server.db.indexes import TEXT_SEARCH_INDEX_NAME
 
-    embedding_dimensions = sorted(
-        {get_dimensions(model) for model in embedding_models if model in EMBEDDING_MODELS}
-    )
+    experiment_id = str((experiment or {}).get("experiment_id") or "") or None
+    embedding_dimensions = sorted(_resolved_embedding_dimensions(embedding_models, experiment_id))
     unique_documents = len((experiment or {}).get("data_paths") or [])
-    index_names = sorted(
-        {get_index_name(model) for model in embedding_models if model in EMBEDDING_MODELS}
-    )
+    index_names = _resolved_index_names(embedding_models, experiment_id)
     retrieval_methods = _retrieval_methods_for_experiment(experiment)
     if any(method in {"sparse", "hybrid"} for method in retrieval_methods):
         index_names.append(TEXT_SEARCH_INDEX_NAME)
         index_names = sorted(set(index_names))
 
     avg_chunks_per_run = round(total_chunks / runs_with_data, 1) if runs_with_data else 0.0
-    embedding_mb, metadata_mb, total_mb = _storage_breakdown_mb(total_chunks, embedding_models)
+    embedding_mb, metadata_mb, total_mb = _storage_breakdown_mb(
+        total_chunks, embedding_models, experiment_id
+    )
     sweep = (experiment or {}).get("sweep_summary") or {}
 
     return {

--- a/server/core/embedder.py
+++ b/server/core/embedder.py
@@ -60,25 +60,37 @@ def _token_budget_per_request() -> int:
 
 
 def embed_documents(texts: list[str], model: str, provider: str = "local") -> list[list[float]]:
-    """Embed documents, dispatching to local or Voyage AI based on provider."""
+    """Embed documents, dispatching to the configured provider."""
     if provider == "local":
         from server.core.local_embedder import embed_documents_local
 
         return embed_documents_local(texts, model)
-    if is_contextualized_embedding(model):
-        return _embed_documents_voyage_context(texts, model)
-    return _embed_documents_voyage(texts, model)
+    if provider == "voyage":
+        if is_contextualized_embedding(model):
+            return _embed_documents_voyage_context(texts, model)
+        return _embed_documents_voyage(texts, model)
+    if provider == "kimchi":
+        from server.core.kimchi_embedder import embed_documents_kimchi
+
+        return embed_documents_kimchi(texts, model)
+    raise ValueError(f"Unsupported embedding provider '{provider}'")
 
 
 def embed_query(text: str, model: str, provider: str = "local") -> list[float]:
-    """Embed a single query, dispatching to local or Voyage AI based on provider."""
+    """Embed a single query, dispatching to the configured provider."""
     if provider == "local":
         from server.core.local_embedder import embed_query_local
 
         return embed_query_local(text, model)
-    if is_contextualized_embedding(model):
-        return _embed_query_voyage_context(text, model)
-    return _embed_query_voyage(text, model)
+    if provider == "voyage":
+        if is_contextualized_embedding(model):
+            return _embed_query_voyage_context(text, model)
+        return _embed_query_voyage(text, model)
+    if provider == "kimchi":
+        from server.core.kimchi_embedder import embed_query_kimchi
+
+        return embed_query_kimchi(text, model)
+    raise ValueError(f"Unsupported embedding provider '{provider}'")
 
 
 def _embed_documents_voyage(texts: list[str], model: str) -> list[list[float]]:

--- a/server/core/kimchi_embedder.py
+++ b/server/core/kimchi_embedder.py
@@ -110,15 +110,23 @@ def _embed(texts: list[str], model: str) -> list[list[float]]:
         return []
 
     client = get_client()
-    tokens = estimate_tokens(texts)
-    payload = {"model": _to_api_model_name(model), "input": texts}
+    return [_embed_one(client, text, model) for text in texts]
+
+
+def _embed_one(client: httpx.Client, text: str, model: str) -> list[float]:
+    tokens = estimate_tokens([text])
+    payload = _build_embedding_payload(model, text)
 
     def _request() -> httpx.Response:
         return client.post("/v1/embeddings", json=payload)
 
     response = _call_with_retry(_request, estimated_tokens=tokens)
     body = response.json()
-    return _parse_embeddings(body, expected_count=len(texts))
+    return _parse_embeddings(body, expected_count=1)[0]
+
+
+def _build_embedding_payload(model: str, text: str) -> dict[str, str]:
+    return {"model": _to_api_model_name(model), "input": text}
 
 
 def _call_with_retry(
@@ -158,10 +166,13 @@ def _call_with_retry(
 
 
 def _to_api_model_name(model: str) -> str:
-    """Convert internal provider-prefixed IDs to CAST/OpenAI model names."""
-    if "/" not in model:
-        return model
-    return model.split("/", 1)[1]
+    """Return the model name as-is for the CAST/LiteLLM API.
+
+    CAST.ai's LiteLLM gateway routes by the full provider/model string
+    (e.g. "mistral/codestral-embed"). Stripping the prefix causes a 400
+    "no registered providers found" error.
+    """
+    return model
 
 
 def _parse_embeddings(body: dict[str, Any], expected_count: int) -> list[list[float]]:

--- a/server/core/kimchi_embedder.py
+++ b/server/core/kimchi_embedder.py
@@ -1,0 +1,153 @@
+"""Kimchi OpenAI-compatible embedding client."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+
+from server.core.rate_limiter import RateLimiter, estimate_tokens
+from server.settings import settings
+from server.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+MAX_RETRIES = 5
+INITIAL_BACKOFF_S = 2.0
+
+_client: httpx.Client | None = None
+_limiter: RateLimiter | None = None
+_dimensions_cache: dict[str, int] = {}
+
+
+def get_client() -> httpx.Client:
+    """Get Kimchi HTTP client singleton."""
+    global _client
+    if _client is None:
+        if not settings.kimchi_base_url:
+            raise ValueError("KIMCHI_BASE_URL not set in .env or environment")
+        if not settings.kimchi_api_key:
+            raise ValueError("KIMCHI_API_KEY not set in .env or environment")
+
+        _client = httpx.Client(
+            base_url=settings.kimchi_base_url.rstrip("/"),
+            headers={
+                "Authorization": f"Bearer {settings.kimchi_api_key}",
+                "Content-Type": "application/json",
+            },
+            timeout=60.0,
+        )
+        logger.info("Kimchi embedding client initialized")
+    return _client
+
+
+def get_limiter() -> RateLimiter:
+    """Get shared Kimchi rate limiter singleton."""
+    global _limiter
+    if _limiter is None:
+        _limiter = RateLimiter(
+            rpm=settings.kimchi_rpm_limit,
+            tpm=settings.kimchi_tpm_limit,
+        )
+        logger.info(
+            f"Kimchi rate limiter initialized: {settings.kimchi_rpm_limit} RPM, "
+            f"{settings.kimchi_tpm_limit} TPM"
+        )
+    return _limiter
+
+
+def get_dimensions(model: str) -> int:
+    """Probe and cache the embedding dimension for a Kimchi model."""
+    if model not in _dimensions_cache:
+        _dimensions_cache[model] = len(embed_query_kimchi("dimension probe", model))
+    return _dimensions_cache[model]
+
+
+def embed_documents_kimchi(texts: list[str], model: str) -> list[list[float]]:
+    """Embed documents with Kimchi."""
+    logger.info(f"Embedding {len(texts)} documents with Kimchi model={model}")
+    embeddings = _embed(texts, model)
+    if embeddings:
+        _dimensions_cache[model] = len(embeddings[0])
+    logger.info(f"Generated {len(embeddings)} Kimchi embeddings, dim={len(embeddings[0])}")
+    return embeddings
+
+
+def embed_query_kimchi(text: str, model: str) -> list[float]:
+    """Embed a single query with Kimchi."""
+    logger.info(f"Embedding query with Kimchi model={model}")
+    embedding = _embed([text], model)[0]
+    _dimensions_cache[model] = len(embedding)
+    logger.info(f"Generated Kimchi query embedding, dim={len(embedding)}")
+    return embedding
+
+
+def _embed(texts: list[str], model: str) -> list[list[float]]:
+    if not texts:
+        return []
+
+    client = get_client()
+    tokens = estimate_tokens(texts)
+    payload = {"model": model, "input": texts}
+
+    def _request() -> httpx.Response:
+        return client.post("/v1/embeddings", json=payload)
+
+    response = _call_with_retry(_request, estimated_tokens=tokens)
+    body = response.json()
+    return _parse_embeddings(body, expected_count=len(texts))
+
+
+def _call_with_retry(
+    fn: Callable[[], httpx.Response],
+    estimated_tokens: int = 0,
+) -> httpx.Response:
+    backoff = INITIAL_BACKOFF_S
+    for attempt in range(1, MAX_RETRIES + 1):
+        get_limiter().wait(estimated_tokens=estimated_tokens)
+        try:
+            response: httpx.Response = fn()
+            if response.status_code == 429 or response.status_code >= 500:
+                raise httpx.HTTPStatusError(
+                    f"Retryable Kimchi HTTP status {response.status_code}",
+                    request=response.request,
+                    response=response,
+                )
+            response.raise_for_status()
+            return response
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            retryable = status == 429 or status >= 500
+            if not retryable or attempt == MAX_RETRIES:
+                raise
+            logger.warning(
+                f"Kimchi HTTP {status} on attempt {attempt}/{MAX_RETRIES}, "
+                f"backing off {backoff:.0f}s"
+            )
+            time.sleep(backoff)
+            backoff *= 2
+    raise RuntimeError("unreachable")
+
+
+def _parse_embeddings(body: dict[str, Any], expected_count: int) -> list[list[float]]:
+    data = body.get("data")
+    if not isinstance(data, list):
+        raise ValueError("Kimchi embeddings response missing list field 'data'")
+
+    ordered = sorted(
+        data,
+        key=lambda item: item.get("index", 0) if isinstance(item, dict) else 0,
+    )
+    embeddings: list[list[float]] = []
+    for item in ordered:
+        if not isinstance(item, dict) or not isinstance(item.get("embedding"), list):
+            raise ValueError("Kimchi embeddings response contained an invalid embedding item")
+        embeddings.append([float(value) for value in item["embedding"]])
+
+    if len(embeddings) != expected_count:
+        raise ValueError(
+            f"Kimchi returned {len(embeddings)} embeddings for {expected_count} input texts"
+        )
+    return embeddings

--- a/server/core/kimchi_embedder.py
+++ b/server/core/kimchi_embedder.py
@@ -31,8 +31,9 @@ def get_client() -> httpx.Client:
         if not settings.kimchi_api_key:
             raise ValueError("KIMCHI_API_KEY not set in .env or environment")
 
+        base_url = _normalize_base_url(settings.kimchi_base_url)
         _client = httpx.Client(
-            base_url=settings.kimchi_base_url.rstrip("/"),
+            base_url=base_url,
             headers={
                 "Authorization": f"Bearer {settings.kimchi_api_key}",
                 "Content-Type": "application/json",
@@ -41,6 +42,26 @@ def get_client() -> httpx.Client:
         )
         logger.info("Kimchi embedding client initialized")
     return _client
+
+
+def _normalize_base_url(raw_base_url: str) -> str:
+    """Normalize an OpenAI-compatible base URL to the provider root.
+
+    The adapter always posts to /v1/embeddings. Users often copy SDK base URLs
+    that already end in /v1, or full endpoint URLs that end in /v1/embeddings.
+    """
+    base_url = raw_base_url.rstrip("/")
+    if "supported-providers" in base_url:
+        logger.warning(
+            "KIMCHI_BASE_URL points to the CAST provider discovery endpoint; "
+            "using https://llm.cast.ai/openai for embeddings instead"
+        )
+        return "https://llm.cast.ai/openai"
+    if base_url.endswith("/v1/embeddings"):
+        return base_url[: -len("/v1/embeddings")]
+    if base_url.endswith("/v1"):
+        return base_url[: -len("/v1")]
+    return base_url
 
 
 def get_limiter() -> RateLimiter:
@@ -90,7 +111,7 @@ def _embed(texts: list[str], model: str) -> list[list[float]]:
 
     client = get_client()
     tokens = estimate_tokens(texts)
-    payload = {"model": model, "input": texts}
+    payload = {"model": _to_api_model_name(model), "input": texts}
 
     def _request() -> httpx.Response:
         return client.post("/v1/embeddings", json=payload)
@@ -115,6 +136,11 @@ def _call_with_retry(
                     request=response.request,
                     response=response,
                 )
+            if response.status_code >= 400:
+                raise ValueError(
+                    f"Kimchi embeddings request failed with HTTP {response.status_code}: "
+                    f"{response.text}"
+                )
             response.raise_for_status()
             return response
         except httpx.HTTPStatusError as exc:
@@ -129,6 +155,13 @@ def _call_with_retry(
             time.sleep(backoff)
             backoff *= 2
     raise RuntimeError("unreachable")
+
+
+def _to_api_model_name(model: str) -> str:
+    """Convert internal provider-prefixed IDs to CAST/OpenAI model names."""
+    if "/" not in model:
+        return model
+    return model.split("/", 1)[1]
 
 
 def _parse_embeddings(body: dict[str, Any], expected_count: int) -> list[list[float]]:

--- a/server/core/model_registry.py
+++ b/server/core/model_registry.py
@@ -15,8 +15,8 @@ logger = get_logger(__name__)
 
 
 class EmbeddingModelInfo(TypedDict):
-    provider: str  # "voyage" | "local"
-    dimensions: int
+    provider: str  # "voyage" | "local" | "kimchi"
+    dimensions: int | None
     huggingface_id: str | None
     description: str
     contextualized: bool  # uses contextualized_embed() API (e.g. voyage-context-3)
@@ -26,6 +26,56 @@ class RerankerModelInfo(TypedDict):
     provider: str  # "voyage" | "local"
     huggingface_id: str | None
     description: str
+
+
+_KIMCHI_EMBEDDING_MODELS = [
+    ("mistral/codestral-embed", "Kimchi-hosted Mistral Codestral embedding"),
+    ("mistral/mistral-embed", "Kimchi-hosted Mistral embedding"),
+    ("mistral/codestral-embed-2505", "Kimchi-hosted Mistral Codestral 2505 embedding"),
+    ("databricks/databricks-gte-large-en", "Kimchi-hosted Databricks GTE large English"),
+    ("databricks/databricks-bge-large-en", "Kimchi-hosted Databricks BGE large English"),
+    (
+        "vertex_ai-language-models/gemini-flash-experimental",
+        "Kimchi-hosted Vertex AI Gemini Flash experimental embedding",
+    ),
+    ("gemini/gemini-embedding-2-preview", "Kimchi-hosted Gemini embedding 2 preview"),
+    ("gemini/gemini-embedding-001", "Kimchi-hosted Gemini embedding 001"),
+    ("gemini/gemini-embedding-2", "Kimchi-hosted Gemini embedding 2"),
+    ("perplexity/pplx-embed-v1-0.6b", "Kimchi-hosted Perplexity PPLX embed v1 0.6B"),
+    ("perplexity/pplx-embed-v1-4b", "Kimchi-hosted Perplexity PPLX embed v1 4B"),
+    ("azure/text-embedding-3-large", "Kimchi-hosted Azure text-embedding-3-large"),
+    ("azure/text-embedding-ada-002", "Kimchi-hosted Azure text-embedding-ada-002"),
+    ("azure/ada", "Kimchi-hosted Azure Ada embedding"),
+    ("bedrock/marengo-embed-2-7", "Kimchi-hosted Bedrock Marengo Embed 2.7"),
+    ("bedrock/titan-embed-text-v2", "Kimchi-hosted Bedrock Titan Embed Text v2"),
+    ("bedrock/embed-v4:0", "Kimchi-hosted Bedrock Embed v4"),
+    ("bedrock/embed-english-v3", "Kimchi-hosted Bedrock Embed English v3"),
+    ("bedrock/embed-multilingual-v3", "Kimchi-hosted Bedrock Embed Multilingual v3"),
+    ("bedrock/titan-embed-image-v1", "Kimchi-hosted Bedrock Titan Embed Image v1"),
+    (
+        "bedrock/nova-2-multimodal-embeddings-v1:0",
+        "Kimchi-hosted Bedrock Nova 2 multimodal embeddings v1",
+    ),
+    ("bedrock/titan-embed-text-v1", "Kimchi-hosted Bedrock Titan Embed Text v1"),
+    ("openai/text-embedding-3-large", "Kimchi-hosted OpenAI text-embedding-3-large"),
+    ("openai/text-embedding-ada-002", "Kimchi-hosted OpenAI text-embedding-ada-002"),
+    ("openai/text-embedding-3-small", "Kimchi-hosted OpenAI text-embedding-3-small"),
+    ("openai/text-embedding-ada-002-v2", "Kimchi-hosted OpenAI text-embedding-ada-002-v2"),
+    ("hosted_vllm/gte-qwen2-7b-instruct", "Kimchi-hosted vLLM GTE Qwen2 7B instruct"),
+    (
+        "hosted_vllm/multilingual-e5-large-instruct",
+        "Kimchi-hosted vLLM multilingual E5 large instruct",
+    ),
+    ("hosted_vllm/bge-base-en-v1.5", "Kimchi-hosted vLLM BGE base English v1.5"),
+    ("hosted_vllm/multilingual-e5-large", "Kimchi-hosted vLLM multilingual E5 large"),
+    ("hosted_vllm/bge-m3", "Kimchi-hosted vLLM BGE M3"),
+    (
+        "azure_ai/Cohere-embed-v3-multilingual",
+        "Kimchi-hosted Azure AI Cohere Embed v3 multilingual",
+    ),
+    ("azure_ai/embed-v-4-0", "Kimchi-hosted Azure AI Embed v4.0"),
+    ("azure_ai/Cohere-embed-v3-english", "Kimchi-hosted Azure AI Cohere Embed v3 English"),
+]
 
 
 EMBEDDING_MODELS: dict[str, EmbeddingModelInfo] = {
@@ -124,6 +174,15 @@ EMBEDDING_MODELS: dict[str, EmbeddingModelInfo] = {
         "description": "Fast general-purpose sentence embeddings (384-dim, ~23MB)",
         "contextualized": False,
     },
+    **{
+        model_id: {
+            "provider": "kimchi",
+            "dimensions": None,
+            "huggingface_id": None,
+            "description": description,
+        }
+        for model_id, description in _KIMCHI_EMBEDDING_MODELS
+    },
 }
 
 RERANKER_MODELS: dict[str, RerankerModelInfo] = {
@@ -178,7 +237,13 @@ def get_provider(model_id: str) -> str:
 
 
 def get_dimensions(model_id: str) -> int:
-    return get_model_info(model_id)["dimensions"]
+    dimensions = get_model_info(model_id)["dimensions"]
+    if dimensions is None:
+        raise ValueError(
+            f"Embedding model '{model_id}' has runtime-detected dimensions. "
+            "Use get_index_name_for_dimensions(len(embedding)) after embedding."
+        )
+    return dimensions
 
 
 def is_contextualized_embedding(model_id: str) -> bool:
@@ -194,6 +259,10 @@ def list_embedding_models(*, provider: str | None = None) -> list[str]:
 def get_index_name(model_id: str) -> str:
     dims = get_dimensions(model_id)
     return f"vector_index_{dims}"
+
+
+def get_index_name_for_dimensions(dimensions: int) -> str:
+    return f"vector_index_{dimensions}"
 
 
 def get_reranker_info(model_id: str) -> RerankerModelInfo:

--- a/server/core/model_registry.py
+++ b/server/core/model_registry.py
@@ -180,6 +180,7 @@ EMBEDDING_MODELS: dict[str, EmbeddingModelInfo] = {
             "dimensions": None,
             "huggingface_id": None,
             "description": description,
+            "contextualized": False,
         }
         for model_id, description in _KIMCHI_EMBEDDING_MODELS
     },

--- a/server/core/retriever.py
+++ b/server/core/retriever.py
@@ -1,6 +1,6 @@
-from server.core.model_registry import get_index_name
+from server.core.model_registry import get_index_name_for_dimensions
 from server.db.atlas import CHUNKS_COLLECTION, get_collection
-from server.db.indexes import TEXT_SEARCH_INDEX_NAME
+from server.db.indexes import TEXT_SEARCH_INDEX_NAME, ensure_vector_index
 from server.models.enums import RetrievalMethod
 from server.models.results import Chunk, SearchResult
 from server.utils.logger import get_logger
@@ -15,7 +15,9 @@ def dense_search(
 ) -> list[SearchResult]:
     """Perform dense vector search using Atlas $vectorSearch."""
 
-    index_name = get_index_name(embedding_model)
+    dimensions = len(query_embedding)
+    index_name = get_index_name_for_dimensions(dimensions)
+    ensure_vector_index(dimensions)
     logger.debug(
         f"Dense search for experiment={experiment_id}, model={embedding_model}, "
         f"index={index_name}, k={top_k}"

--- a/server/db/indexes.py
+++ b/server/db/indexes.py
@@ -120,6 +120,30 @@ def create_vector_indexes() -> bool:
     return _wait_for_indexes_ready(chunks, names)
 
 
+def ensure_vector_index(dimensions: int) -> bool:
+    """Ensure a vector search index exists for a runtime-detected dimension."""
+    name = f"vector_index_{dimensions}"
+    chunks = get_collection(CHUNKS_COLLECTION)
+    existing = _get_existing_search_indexes(chunks)
+    if name in existing:
+        return True
+
+    try:
+        chunks.create_search_indexes(models=[_build_vector_index_model(name, dimensions)])
+        logger.info(f"Created vector search index: {name}")
+    except Exception as e:
+        err_str = str(e)
+        if "CommandNotFound" in err_str or "no such command" in err_str.lower():
+            logger.warning(
+                "Programmatic vector index creation not supported on this cluster tier (M0/M2/M5). "
+                f"Create index '{name}' manually in the Atlas UI with numDimensions={dimensions}."
+            )
+            return False
+        raise
+
+    return _wait_for_indexes_ready(chunks, [name])
+
+
 def _wait_for_indexes_ready(collection, names: list[str], timeout_s: int = 120) -> bool:
     """Poll until all named search indexes reach 'READY' status."""
     logger.info(f"Waiting for vector indexes to become active (timeout {timeout_s}s)...")

--- a/server/models/config.py
+++ b/server/models/config.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field, model_validator
 from server.core.model_registry import EMBEDDING_MODELS, RERANKER_MODELS
 from server.models.enums import ChunkingMethod, RetrievalMethod
 
-Provider = Literal["local", "voyage"]
+Provider = Literal["local", "voyage", "kimchi"]
 DatabaseProvider = Literal["mongodb"]  # Future: "pinecone", "weaviate", "qdrant"
 
 
@@ -51,6 +51,8 @@ class RetrievalConfig(BaseModel):
     def validate_rerank_model_matches_provider(self) -> "RetrievalConfig":
         if self.rerank_model is None:
             return self
+        if self.rerank_provider == "kimchi":
+            raise ValueError("Kimchi is supported for embeddings only; set rerank_model to null")
         if self.rerank_model not in RERANKER_MODELS:
             known = ", ".join(RERANKER_MODELS)
             raise ValueError(f"Unknown reranker model '{self.rerank_model}'. Known: {known}")

--- a/server/models/status.py
+++ b/server/models/status.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, Field
 
 from server.models.enums import ChunkingMethod, Phase, RetrievalMethod
 
-Provider = Literal["local", "voyage"]
+Provider = Literal["local", "voyage", "kimchi"]
 DatabaseProvider = Literal["mongodb"]  # Future: "pinecone", "weaviate", "qdrant"
 
 

--- a/server/settings.py
+++ b/server/settings.py
@@ -56,6 +56,12 @@ class Settings(BaseSettings):
     # Leave blank to derive from MONGODB_URI host (e.g. thesandboxcluster.5uaqybx.mongodb.net).
     atlas_cluster_name: str = ""
 
+    # Kimchi OpenAI-compatible embeddings endpoint.
+    kimchi_base_url: str = ""
+    kimchi_api_key: str = ""
+    kimchi_rpm_limit: int = 60
+    kimchi_tpm_limit: int = 0
+
     @field_validator("cors_origins", mode="before")
     @classmethod
     def parse_cors_origins(cls, value: object) -> list[str]:
@@ -76,6 +82,8 @@ logger.info(f"Settings loaded: server_url={settings.server_url}")
 logger.debug(
     f"Settings detail: mongodb_uri={'***' if settings.mongodb_uri else '(not set)'}, "
     f"voyage_api_key={'***' if settings.voyage_api_key else '(not set)'}, "
+    f"kimchi_base_url={settings.kimchi_base_url or '(not set)'}, "
+    f"kimchi_api_key={'***' if settings.kimchi_api_key else '(not set)'}, "
     f"recover_on_boot={settings.recover_on_boot}, "
     f"cors_origins={settings.cors_origins}, "
     f"cors_allow_localhost_origin_regex={settings.cors_allow_localhost_origin_regex}"

--- a/tests/test_embedder_provider_dispatch.py
+++ b/tests/test_embedder_provider_dispatch.py
@@ -1,0 +1,112 @@
+"""Regression tests for explicit embedding provider dispatch (local / voyage / kimchi)."""
+
+from __future__ import annotations
+
+import pytest
+
+from server.core import embedder
+
+
+def test_embed_documents_routes_local_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, list[str], str]] = []
+
+    def fake_local(texts: list[str], model: str) -> list[list[float]]:
+        calls.append(("local", texts, model))
+        return [[0.1, 0.2]]
+
+    monkeypatch.setattr(
+        "server.core.local_embedder.embed_documents_local",
+        fake_local,
+    )
+
+    result = embedder.embed_documents(["chunk"], "all-MiniLM-L6-v2", provider="local")
+
+    assert calls == [("local", ["chunk"], "all-MiniLM-L6-v2")]
+    assert result == [[0.1, 0.2]]
+
+
+def test_embed_query_routes_local_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, str, str]] = []
+
+    def fake_local(text: str, model: str) -> list[float]:
+        calls.append(("local", text, model))
+        return [0.1, 0.2, 0.3]
+
+    monkeypatch.setattr("server.core.local_embedder.embed_query_local", fake_local)
+
+    result = embedder.embed_query("question", "all-MiniLM-L6-v2", provider="local")
+
+    assert calls == [("local", "question", "all-MiniLM-L6-v2")]
+    assert result == [0.1, 0.2, 0.3]
+
+
+def test_embed_documents_routes_voyage_standard_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    def fake_voyage(texts: list[str], model: str) -> list[list[float]]:
+        calls.append(f"voyage:{model}:{len(texts)}")
+        return [[1.0]]
+
+    def fail_context(texts: list[str], model: str) -> list[list[float]]:
+        raise AssertionError("contextualized path should not run for voyage-3.5-lite")
+
+    monkeypatch.setattr(embedder, "_embed_documents_voyage", fake_voyage)
+    monkeypatch.setattr(embedder, "_embed_documents_voyage_context", fail_context)
+
+    result = embedder.embed_documents(["a", "b"], "voyage-3.5-lite", provider="voyage")
+
+    assert calls == ["voyage:voyage-3.5-lite:2"]
+    assert result == [[1.0]]
+
+
+def test_embed_query_routes_voyage_contextualized_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    def fail_standard(text: str, model: str) -> list[float]:
+        raise AssertionError("standard voyage path should not run for voyage-context-3")
+
+    def fake_context(text: str, model: str) -> list[float]:
+        calls.append(f"context:{model}")
+        return [0.5, 0.6]
+
+    monkeypatch.setattr(embedder, "_embed_query_voyage", fail_standard)
+    monkeypatch.setattr(embedder, "_embed_query_voyage_context", fake_context)
+
+    result = embedder.embed_query("long doc", "voyage-context-3", provider="voyage")
+
+    assert calls == ["context:voyage-context-3"]
+    assert result == [0.5, 0.6]
+
+
+def test_embed_documents_routes_kimchi_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[list[str], str]] = []
+
+    def fake_kimchi(texts: list[str], model: str) -> list[list[float]]:
+        calls.append((texts, model))
+        return [[9.0, 8.0]]
+
+    monkeypatch.setattr(
+        "server.core.kimchi_embedder.embed_documents_kimchi",
+        fake_kimchi,
+    )
+
+    result = embedder.embed_documents(
+        ["kimchi-chunk"],
+        "openai/text-embedding-3-large",
+        provider="kimchi",
+    )
+
+    assert calls == [(["kimchi-chunk"], "openai/text-embedding-3-large")]
+    assert result == [[9.0, 8.0]]
+
+
+@pytest.mark.parametrize("provider", ["", "azure", "unknown"])
+def test_embed_documents_rejects_unsupported_provider(provider: str) -> None:
+    with pytest.raises(ValueError, match=f"Unsupported embedding provider '{provider}'"):
+        embedder.embed_documents(["text"], "any-model", provider=provider)
+
+
+@pytest.mark.parametrize("provider", ["", "azure"])
+def test_embed_query_rejects_unsupported_provider(provider: str) -> None:
+    with pytest.raises(ValueError, match=f"Unsupported embedding provider '{provider}'"):
+        embedder.embed_query("text", "any-model", provider=provider)

--- a/tests/test_experiment_config_providers.py
+++ b/tests/test_experiment_config_providers.py
@@ -1,0 +1,68 @@
+"""Regression tests for experiment config validation across embedding providers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from cli.config_loader import load_config
+from server.models.config import ExperimentConfig
+
+
+def _minimal_config(provider: str, models: list[str]) -> dict[str, Any]:
+    return {
+        "experiment_name": "provider-regression",
+        "data_paths": ["./input_data/pdfs/The_Federal_Pell_Grant_Program.pdf"],
+        "queries_file": "./configs/questions.example.json",
+        "database_provider": "mongodb",
+        "embedding": {"provider": provider, "models": models},
+        "chunking": {
+            "methods": ["recursive"],
+            "params": {"chunk_sizes": [256], "overlaps": [50]},
+        },
+        "retrieval": {
+            "methods": ["dense"],
+            "top_k_initial": 20,
+            "top_k_final": 5,
+            "rerank_provider": "local",
+            "rerank_model": None,
+        },
+        "execution": {"parallelism": 1, "on_error": "continue"},
+    }
+
+
+def test_local_provider_accepts_local_model() -> None:
+    config = ExperimentConfig.model_validate(_minimal_config("local", ["all-MiniLM-L6-v2"]))
+    assert config.embedding.provider == "local"
+
+
+def test_voyage_provider_accepts_voyage_model() -> None:
+    config = ExperimentConfig.model_validate(_minimal_config("voyage", ["voyage-3.5-lite"]))
+    assert config.embedding.provider == "voyage"
+
+
+def test_voyage_provider_rejects_local_model() -> None:
+    with pytest.raises(ValidationError, match="belongs to provider 'local'"):
+        ExperimentConfig.model_validate(_minimal_config("voyage", ["all-MiniLM-L6-v2"]))
+
+
+def test_kimchi_rerank_provider_is_rejected() -> None:
+    payload = _minimal_config("kimchi", ["openai/text-embedding-3-large"])
+    payload["retrieval"]["rerank_provider"] = "kimchi"
+    payload["retrieval"]["rerank_model"] = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+    with pytest.raises(ValidationError, match="Kimchi is supported for embeddings only"):
+        ExperimentConfig.model_validate(payload)
+
+
+def test_example_local_config_loads() -> None:
+    config = load_config("configs/example-mongodb-local.yaml")
+    assert config["embedding"]["provider"] == "local"
+    assert config["embedding"]["models"] == ["all-MiniLM-L6-v2"]
+
+
+def test_example_voyage_config_loads() -> None:
+    config = load_config("configs/example-mongodb-voyage.yaml")
+    assert config["embedding"]["provider"] == "voyage"

--- a/tests/test_experiments_db_stats.py
+++ b/tests/test_experiments_db_stats.py
@@ -1,0 +1,62 @@
+"""Regression tests for Vector DB stats dimension and index resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+from server.api import experiments_shared
+
+
+def _base_stats_kwargs() -> dict:
+    return {
+        "total_chunks": 100,
+        "chunking_breakdown": {"recursive": 100},
+        "total_results": 10,
+        "unique_queries": 2,
+        "runs_with_data": 4,
+        "run_breakdown": [],
+    }
+
+
+def test_db_stats_uses_registry_dimensions_for_voyage_without_chunk_sample() -> None:
+    stats = experiments_shared._assemble_experiment_db_stats(
+        {"experiment_id": "exp-voyage", "data_paths": ["./input_data/pdfs/sample.pdf"]},
+        embedding_models=["voyage-3.5-lite"],
+        **_base_stats_kwargs(),
+    )
+
+    assert stats["embedding_dimensions"] == [1024]
+    assert stats["index_names"] == ["vector_index_1024"]
+    assert stats["estimated_storage_mb"] > 0
+
+
+def test_db_stats_uses_registry_dimensions_for_local_without_chunk_sample() -> None:
+    stats = experiments_shared._assemble_experiment_db_stats(
+        {"experiment_id": "exp-local", "data_paths": ["./input_data/pdfs/sample.pdf"]},
+        embedding_models=["all-MiniLM-L6-v2"],
+        **_base_stats_kwargs(),
+    )
+
+    assert stats["embedding_dimensions"] == [384]
+    assert stats["index_names"] == ["vector_index_384"]
+
+
+def test_db_stats_samples_runtime_dimensions_for_kimchi_when_chunks_exist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeCollection:
+        def find_one(self, filter: dict[str, str], projection: dict[str, int]) -> dict | None:
+            if filter.get("embedding_model") == "openai/text-embedding-3-large":
+                return {"embedding": [0.0] * 3072}
+            return None
+
+    monkeypatch.setattr(experiments_shared, "get_collection", lambda _name: FakeCollection())
+
+    stats = experiments_shared._assemble_experiment_db_stats(
+        {"experiment_id": "exp-kimchi", "data_paths": ["./input_data/pdfs/sample.pdf"]},
+        embedding_models=["openai/text-embedding-3-large"],
+        **_base_stats_kwargs(),
+    )
+
+    assert stats["embedding_dimensions"] == [3072]
+    assert "vector_index_3072" in stats["index_names"]

--- a/tests/test_kimchi_provider.py
+++ b/tests/test_kimchi_provider.py
@@ -6,7 +6,12 @@ from pydantic import ValidationError
 
 from cli.config_loader import load_config
 from server.core import retriever
-from server.core.kimchi_embedder import _normalize_base_url, _parse_embeddings, _to_api_model_name
+from server.core.kimchi_embedder import (
+    _build_embedding_payload,
+    _normalize_base_url,
+    _parse_embeddings,
+    _to_api_model_name,
+)
 from server.core.model_registry import EMBEDDING_MODELS
 from server.models.config import ExperimentConfig
 
@@ -88,9 +93,18 @@ def test_kimchi_base_url_normalization(raw_base_url: str, normalized: str) -> No
     assert _normalize_base_url(raw_base_url) == normalized
 
 
-def test_kimchi_api_model_name_strips_internal_provider_prefix() -> None:
-    assert _to_api_model_name("mistral/codestral-embed") == "codestral-embed"
+def test_kimchi_api_model_name_passes_full_litellm_identifier() -> None:
+    # CAST.ai's LiteLLM gateway routes by provider/model — the prefix must be kept.
+    assert _to_api_model_name("mistral/codestral-embed") == "mistral/codestral-embed"
+    assert _to_api_model_name("openai/text-embedding-3-large") == "openai/text-embedding-3-large"
     assert _to_api_model_name("text-embedding-3-large") == "text-embedding-3-large"
+
+
+def test_kimchi_embedding_payload_matches_cast_template() -> None:
+    assert _build_embedding_payload("mistral/codestral-embed", "Text to embed") == {
+        "model": "mistral/codestral-embed",
+        "input": "Text to embed",
+    }
 
 
 def test_dense_search_uses_runtime_embedding_dimension(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_kimchi_provider.py
+++ b/tests/test_kimchi_provider.py
@@ -5,7 +5,6 @@ import pytest
 from pydantic import ValidationError
 
 from cli.config_loader import load_config
-from server.core import retriever
 from server.core.kimchi_embedder import (
     _build_embedding_payload,
     _normalize_base_url,
@@ -103,58 +102,5 @@ def test_kimchi_embedding_payload_matches_cast_template() -> None:
     }
 
 
-def test_dense_search_uses_runtime_embedding_dimension(monkeypatch: pytest.MonkeyPatch) -> None:
-    seen: dict[str, Any] = {}
-
-    def fake_ensure_vector_index(dimensions: int) -> bool:
-        seen["dimensions"] = dimensions
-        return True
-
-    class FakeCollection:
-        def aggregate(self, pipeline: list[dict[str, Any]]) -> list[dict[str, Any]]:
-            seen["index"] = pipeline[0]["$vectorSearch"]["index"]
-            return []
-
-    monkeypatch.setattr(retriever, "ensure_vector_index", fake_ensure_vector_index)
-    monkeypatch.setattr(retriever, "get_collection", lambda _name: FakeCollection())
-
-    results = retriever.dense_search(
-        query_embedding=[0.1, 0.2, 0.3],
-        experiment_id="experiment-1",
-        embedding_model="mistral/codestral-embed",
-        top_k=5,
-    )
-
-    assert results == []
-    assert seen == {"dimensions": 3, "index": "vector_index_3"}
-
-
 def test_example_kimchi_config_path_exists() -> None:
     assert Path("configs/example-kimchi.yaml").exists()
-
-
-def test_db_stats_resolves_runtime_kimchi_dimensions(monkeypatch: pytest.MonkeyPatch) -> None:
-    from server.api import experiments_shared
-
-    class FakeCollection:
-        def find_one(self, filter: dict[str, str], projection: dict[str, int]) -> dict | None:
-            if filter.get("embedding_model") == "mistral/codestral-embed":
-                return {"embedding": [0.0] * 1536}
-            return None
-
-    monkeypatch.setattr(experiments_shared, "get_collection", lambda _name: FakeCollection())
-
-    stats = experiments_shared._assemble_experiment_db_stats(
-        {"experiment_id": "exp-kimchi", "data_paths": ["./input_data/pdfs/sample.pdf"]},
-        total_chunks=10,
-        embedding_models=["mistral/codestral-embed"],
-        chunking_breakdown={"recursive": 10},
-        total_results=5,
-        unique_queries=1,
-        runs_with_data=1,
-        run_breakdown=[],
-    )
-
-    assert stats["embedding_dimensions"] == [1536]
-    assert "vector_index_1536" in stats["index_names"]
-    assert stats["estimated_storage_mb"] > 0

--- a/tests/test_kimchi_provider.py
+++ b/tests/test_kimchi_provider.py
@@ -1,0 +1,102 @@
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from cli.config_loader import load_config
+from server.core import retriever
+from server.core.kimchi_embedder import _parse_embeddings
+from server.core.model_registry import EMBEDDING_MODELS
+from server.models.config import ExperimentConfig
+
+
+def _minimal_config(provider: str, models: list[str]) -> dict[str, Any]:
+    return {
+        "experiment_name": "test-kimchi",
+        "data_paths": ["./input_data/pdfs/The_Federal_Pell_Grant_Program.pdf"],
+        "queries_file": "./configs/questions.example.json",
+        "database_provider": "mongodb",
+        "embedding": {
+            "provider": provider,
+            "models": models,
+        },
+        "chunking": {
+            "methods": ["recursive"],
+            "params": {"chunk_sizes": [256], "overlaps": [50]},
+        },
+        "retrieval": {
+            "methods": ["dense"],
+            "top_k_initial": 20,
+            "top_k_final": 5,
+            "rerank_provider": "local",
+            "rerank_model": None,
+        },
+        "execution": {"parallelism": 1, "on_error": "continue"},
+    }
+
+
+def test_kimchi_provider_model_validation_succeeds() -> None:
+    config = ExperimentConfig.model_validate(
+        _minimal_config("kimchi", ["mistral/codestral-embed"])
+    )
+
+    assert config.embedding.provider == "kimchi"
+    assert config.embedding.models == ["mistral/codestral-embed"]
+    assert EMBEDDING_MODELS["mistral/codestral-embed"]["dimensions"] is None
+
+
+def test_provider_model_mismatch_still_fails() -> None:
+    with pytest.raises(ValidationError, match="belongs to provider 'kimchi'"):
+        ExperimentConfig.model_validate(
+            _minimal_config("local", ["mistral/codestral-embed"])
+        )
+
+
+def test_example_kimchi_config_loads() -> None:
+    config = load_config("configs/example-kimchi.yaml")
+
+    assert config["embedding"]["provider"] == "kimchi"
+    assert len(config["embedding"]["models"]) == 34
+    assert len(set(config["embedding"]["models"])) == 34
+
+
+def test_kimchi_response_parsing_preserves_embedding_order() -> None:
+    body = {
+        "data": [
+            {"index": 1, "embedding": [3, 4]},
+            {"index": 0, "embedding": [1, 2]},
+        ]
+    }
+
+    assert _parse_embeddings(body, expected_count=2) == [[1.0, 2.0], [3.0, 4.0]]
+
+
+def test_dense_search_uses_runtime_embedding_dimension(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, Any] = {}
+
+    def fake_ensure_vector_index(dimensions: int) -> bool:
+        seen["dimensions"] = dimensions
+        return True
+
+    class FakeCollection:
+        def aggregate(self, pipeline: list[dict[str, Any]]) -> list[dict[str, Any]]:
+            seen["index"] = pipeline[0]["$vectorSearch"]["index"]
+            return []
+
+    monkeypatch.setattr(retriever, "ensure_vector_index", fake_ensure_vector_index)
+    monkeypatch.setattr(retriever, "get_collection", lambda _name: FakeCollection())
+
+    results = retriever.dense_search(
+        query_embedding=[0.1, 0.2, 0.3],
+        experiment_id="experiment-1",
+        embedding_model="mistral/codestral-embed",
+        top_k=5,
+    )
+
+    assert results == []
+    assert seen == {"dimensions": 3, "index": "vector_index_3"}
+
+
+def test_example_kimchi_config_path_exists() -> None:
+    assert Path("configs/example-kimchi.yaml").exists()

--- a/tests/test_kimchi_provider.py
+++ b/tests/test_kimchi_provider.py
@@ -6,7 +6,7 @@ from pydantic import ValidationError
 
 from cli.config_loader import load_config
 from server.core import retriever
-from server.core.kimchi_embedder import _parse_embeddings
+from server.core.kimchi_embedder import _normalize_base_url, _parse_embeddings, _to_api_model_name
 from server.core.model_registry import EMBEDDING_MODELS
 from server.models.config import ExperimentConfig
 
@@ -70,6 +70,27 @@ def test_kimchi_response_parsing_preserves_embedding_order() -> None:
     }
 
     assert _parse_embeddings(body, expected_count=2) == [[1.0, 2.0], [3.0, 4.0]]
+
+
+@pytest.mark.parametrize(
+    ("raw_base_url", "normalized"),
+    [
+        ("https://llm.cast.ai/openai", "https://llm.cast.ai/openai"),
+        ("https://llm.cast.ai/openai/v1", "https://llm.cast.ai/openai"),
+        ("https://llm.cast.ai/openai/v1/embeddings", "https://llm.cast.ai/openai"),
+        (
+            "https://api.cast.ai/v1/llm/openai/supported-providers",
+            "https://llm.cast.ai/openai",
+        ),
+    ],
+)
+def test_kimchi_base_url_normalization(raw_base_url: str, normalized: str) -> None:
+    assert _normalize_base_url(raw_base_url) == normalized
+
+
+def test_kimchi_api_model_name_strips_internal_provider_prefix() -> None:
+    assert _to_api_model_name("mistral/codestral-embed") == "codestral-embed"
+    assert _to_api_model_name("text-embedding-3-large") == "text-embedding-3-large"
 
 
 def test_dense_search_uses_runtime_embedding_dimension(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_kimchi_provider.py
+++ b/tests/test_kimchi_provider.py
@@ -131,3 +131,30 @@ def test_dense_search_uses_runtime_embedding_dimension(monkeypatch: pytest.Monke
 
 def test_example_kimchi_config_path_exists() -> None:
     assert Path("configs/example-kimchi.yaml").exists()
+
+
+def test_db_stats_resolves_runtime_kimchi_dimensions(monkeypatch: pytest.MonkeyPatch) -> None:
+    from server.api import experiments_shared
+
+    class FakeCollection:
+        def find_one(self, filter: dict[str, str], projection: dict[str, int]) -> dict | None:
+            if filter.get("embedding_model") == "mistral/codestral-embed":
+                return {"embedding": [0.0] * 1536}
+            return None
+
+    monkeypatch.setattr(experiments_shared, "get_collection", lambda _name: FakeCollection())
+
+    stats = experiments_shared._assemble_experiment_db_stats(
+        {"experiment_id": "exp-kimchi", "data_paths": ["./input_data/pdfs/sample.pdf"]},
+        total_chunks=10,
+        embedding_models=["mistral/codestral-embed"],
+        chunking_breakdown={"recursive": 10},
+        total_results=5,
+        unique_queries=1,
+        runs_with_data=1,
+        run_breakdown=[],
+    )
+
+    assert stats["embedding_dimensions"] == [1536]
+    assert "vector_index_1536" in stats["index_names"]
+    assert stats["estimated_storage_mb"] > 0

--- a/tests/test_kimchi_provider.py
+++ b/tests/test_kimchi_provider.py
@@ -42,9 +42,7 @@ def _minimal_config(provider: str, models: list[str]) -> dict[str, Any]:
 
 
 def test_kimchi_provider_model_validation_succeeds() -> None:
-    config = ExperimentConfig.model_validate(
-        _minimal_config("kimchi", ["mistral/codestral-embed"])
-    )
+    config = ExperimentConfig.model_validate(_minimal_config("kimchi", ["mistral/codestral-embed"]))
 
     assert config.embedding.provider == "kimchi"
     assert config.embedding.models == ["mistral/codestral-embed"]
@@ -53,17 +51,15 @@ def test_kimchi_provider_model_validation_succeeds() -> None:
 
 def test_provider_model_mismatch_still_fails() -> None:
     with pytest.raises(ValidationError, match="belongs to provider 'kimchi'"):
-        ExperimentConfig.model_validate(
-            _minimal_config("local", ["mistral/codestral-embed"])
-        )
+        ExperimentConfig.model_validate(_minimal_config("local", ["mistral/codestral-embed"]))
 
 
 def test_example_kimchi_config_loads() -> None:
     config = load_config("configs/example-kimchi.yaml")
 
     assert config["embedding"]["provider"] == "kimchi"
-    assert len(config["embedding"]["models"]) == 34
-    assert len(set(config["embedding"]["models"])) == 34
+    assert len(config["embedding"]["models"]) == 4
+    assert len(set(config["embedding"]["models"])) == 4
 
 
 def test_kimchi_response_parsing_preserves_embedding_order() -> None:

--- a/tests/test_model_registry_dimensions.py
+++ b/tests/test_model_registry_dimensions.py
@@ -1,0 +1,40 @@
+"""Regression tests for fixed vs runtime embedding dimensions in the model registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from server.core.model_registry import (
+    get_dimensions,
+    get_index_name,
+    get_index_name_for_dimensions,
+    get_model_info,
+)
+
+
+def test_get_dimensions_returns_local_model_size() -> None:
+    assert get_dimensions("all-MiniLM-L6-v2") == 384
+
+
+def test_get_dimensions_returns_voyage_model_size() -> None:
+    assert get_dimensions("voyage-3.5-lite") == 1024
+
+
+def test_get_dimensions_raises_for_runtime_kimchi_models() -> None:
+    with pytest.raises(ValueError, match="runtime-detected dimensions"):
+        get_dimensions("openai/text-embedding-3-large")
+
+
+def test_get_index_name_matches_registry_for_fixed_dimension_models() -> None:
+    assert get_index_name("all-MiniLM-L6-v2") == "vector_index_384"
+    assert get_index_name("voyage-3.5-lite") == "vector_index_1024"
+
+
+def test_get_index_name_for_dimensions_builds_expected_atlas_index_name() -> None:
+    assert get_index_name_for_dimensions(3072) == "vector_index_3072"
+
+
+def test_kimchi_models_are_registered_with_null_dimensions() -> None:
+    info = get_model_info("mistral/codestral-embed")
+    assert info["provider"] == "kimchi"
+    assert info["dimensions"] is None

--- a/tests/test_retriever_vector_index.py
+++ b/tests/test_retriever_vector_index.py
@@ -1,0 +1,51 @@
+"""Regression tests for dense search vector index selection by embedding dimension."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from server.core import retriever
+
+
+@pytest.mark.parametrize(
+    ("query_embedding", "embedding_model", "expected_index"),
+    [
+        ([0.0] * 384, "all-MiniLM-L6-v2", "vector_index_384"),
+        ([0.0] * 1024, "voyage-3.5-lite", "vector_index_1024"),
+        ([0.0] * 1536, "openai/text-embedding-3-large", "vector_index_1536"),
+    ],
+)
+def test_dense_search_selects_index_from_query_vector_length(
+    monkeypatch: pytest.MonkeyPatch,
+    query_embedding: list[float],
+    embedding_model: str,
+    expected_index: str,
+) -> None:
+    seen: dict[str, Any] = {}
+
+    def fake_ensure_vector_index(dimensions: int) -> bool:
+        seen["dimensions"] = dimensions
+        return True
+
+    class FakeCollection:
+        def aggregate(self, pipeline: list[dict[str, Any]]) -> list[dict[str, Any]]:
+            seen["index"] = pipeline[0]["$vectorSearch"]["index"]
+            seen["filter_model"] = pipeline[0]["$vectorSearch"]["filter"]["embedding_model"]
+            return []
+
+    monkeypatch.setattr(retriever, "ensure_vector_index", fake_ensure_vector_index)
+    monkeypatch.setattr(retriever, "get_collection", lambda _name: FakeCollection())
+
+    results = retriever.dense_search(
+        query_embedding=query_embedding,
+        experiment_id="exp-local",
+        embedding_model=embedding_model,
+        top_k=10,
+    )
+
+    assert results == []
+    assert seen["dimensions"] == len(query_embedding)
+    assert seen["index"] == expected_index
+    assert seen["filter_model"] == {"$eq": embedding_model}


### PR DESCRIPTION
## Summary
- Adds Kimchi (CAST AI) OpenAI-compatible embedding provider with runtime-detected dimensions
- Rebases onto latest `main` — preserves voyage-context-3, sparse/hybrid retrieval, Atlas quota, pause/resume
- Includes `configs/example-kimchi.yaml` and documentation updates

## Test plan
- [ ] Set `KIMCHI_BASE_URL=https://llm.cast.ai/openai` and `KIMCHI_API_KEY` in `.env`
- [ ] Run `rag-params-finder run --config configs/example-kimchi.yaml`
- [ ] Verify dynamic `vector_index_<dimension>` creation and dense search
- [ ] Confirm quality gates pass: `uv run ruff check .`, `uv run mypy server/ cli/`, frontend typecheck/build


Made with [Cursor](https://cursor.com)