### PR TITLE
chore(ci): add repo lint hooks and sync toolchain docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,36 @@ on:
     branches: [main]
 
 jobs:
+  repo-lint:
+    name: Repo lint (shell, workflows, docs)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dev dependencies (pre-commit hooks)
+        run: uv pip install --system -e ".[dev]"
+
+      - name: Shellcheck
+        run: pre-commit run shellcheck --all-files
+
+      - name: Actionlint
+        run: pre-commit run actionlint --all-files
+
+      - name: Markdownlint
+        run: pre-commit run markdownlint --all-files
+
   backend:
     name: Backend (Python)
     runs-on: ubuntu-latest

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,19 @@
+{
+  "default": true,
+  "MD001": false,
+  "MD012": false,
+  "MD013": false,
+  "MD022": false,
+  "MD024": { "siblings_only": true },
+  "MD029": false,
+  "MD031": false,
+  "MD032": false,
+  "MD033": false,
+  "MD034": false,
+  "MD036": false,
+  "MD040": false,
+  "MD041": false,
+  "MD050": false,
+  "MD051": false,
+  "MD058": false
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@
 # Principle: one tool per concern, every tool earns its seconds.
 # Intentionally excluded from pre-commit (run via scripts/quality-gates.sh):
 #   pytest+coverage, pip-audit, npm audit
+# Repo lint (shellcheck, actionlint, markdownlint): also in CI via scripts/repo-lint.sh
 #
 # Install:
 #   uv pip install -e ".[dev]" && pre-commit install
@@ -25,6 +26,30 @@ repos:
         args: ['--maxkb=500']
       - id: detect-private-key
       - id: debug-statements
+
+  # ── Shell, GitHub Actions, Markdown ─────────────────────
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        files: ^scripts/.*\.sh$
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.43.0
+    hooks:
+      - id: markdownlint
+        args: [--config, .markdownlint.json]
+        files: \.md$
+        exclude: |
+          (?x)^(
+            \.claude/|
+            frontend/node_modules/
+          )
 
   # ── Secrets ──────────────────────────────────────────────
   - repo: https://github.com/gitleaks/gitleaks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,9 +4,12 @@
 #   pytest+coverage, pip-audit, npm audit
 # Repo lint (shellcheck, actionlint, markdownlint): also in CI via scripts/repo-lint.sh
 #
-# Install:
-#   uv pip install -e ".[dev]" && pre-commit install
-# Run all:  pre-commit run --all-files
+# Install (commit + push hooks):
+#   uv pip install -e ".[dev]"
+#   pre-commit install --hook-type pre-commit --hook-type pre-push
+#   # or: bash scripts/install-git-hooks.sh
+# Run all (commit stage):  pre-commit run --all-files
+# Run push stage only:     pre-commit run --hook-stage pre-push --all-files
 # Full gates: ./scripts/quality-gates.sh [--full]
 
 repos:
@@ -104,3 +107,14 @@ repos:
         pass_filenames: false
         files: ^frontend/
         exclude: ^frontend/node_modules/
+
+  # ── Pre-push: quick quality gates (repo lint + lint + tests) ─
+  - repo: local
+    hooks:
+      - id: quality-gates-pre-push
+        name: quality gates (pre-push)
+        entry: bash scripts/quality-gates.sh --quick
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,8 @@
 #   pre-commit install --hook-type pre-commit --hook-type pre-push
 #   # or: bash scripts/install-git-hooks.sh
 # Run all (commit stage):  pre-commit run --all-files
-# Run push stage only:     pre-commit run --hook-stage pre-push --all-files
+# Run push stage only:     pre-commit run essential-checks-pre-push --hook-stage pre-push
+# Same hooks as commit, all files: pre-commit run --all-files --hook-stage pre-commit
 # Full gates: ./scripts/quality-gates.sh [--full]
 
 repos:
@@ -108,12 +109,12 @@ repos:
         files: ^frontend/
         exclude: ^frontend/node_modules/
 
-  # ── Pre-push: quick quality gates (repo lint + lint + tests) ─
+  # ── Pre-push: same essential hooks as commit, entire repo ─
   - repo: local
     hooks:
-      - id: quality-gates-pre-push
-        name: quality gates (pre-push)
-        entry: bash scripts/quality-gates.sh --quick
+      - id: essential-checks-pre-push
+        name: essential checks (pre-push)
+        entry: pre-commit run --all-files --hook-stage pre-commit
         language: system
         pass_filenames: false
         always_run: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,9 @@ Agent session entry point for `rag-params-finder`.
 
 ```bash
 # Quality gates (mirrors CI — run before every commit)
-./scripts/quality-gates.sh              # full CI mirror
-./scripts/quality-gates.sh --quick      # lint + typecheck + unit tests only
+./scripts/quality-gates.sh              # full CI mirror (repo lint + backend + frontend + audits)
+bash scripts/repo-lint.sh               # shellcheck + actionlint + markdownlint only
+./scripts/quality-gates.sh --quick      # repo lint + lint + typecheck + unit tests (no coverage/build/audits)
 ./scripts/quality-gates.sh --full       # + local gitleaks + pre-commit all-files
 python scripts/check_integrity.py       # unit tests + import smoke
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ rag-params-finder indexes list            # Atlas Search indexes (known vs unkno
 rag-params-finder indexes reset           # drop unknown indexes + ensure required
 rag-params-finder indexes reset --all     # drop all chunks search indexes + recreate
 uv pip install -e ".[dev]"
-bash scripts/install-git-hooks.sh          # pre-commit on commit + quality-gates --quick on push
+bash scripts/install-git-hooks.sh          # essential checks on commit (staged) and push (all files)
 
 # Frontend
 cd frontend && npm run dev                     # start dashboard → http://localhost:5173

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Agent session entry point for `rag-params-finder`.
 
 ## Key rules
 
-- Run quality gates before and after every change (see `CLAUDE.md` → Quality Gates Baseline).
+- Run quality gates before and after every change; install hooks with `bash scripts/install-git-hooks.sh` (commit + pre-push checks — see `CLAUDE.md` → Quality Gates Baseline).
 - Follow the slice execution playbook in `CLAUDE.md` → Slice Execution Playbook.
 - Secrets (`VOYAGE_API_KEY`, `MONGODB_URI`) stay server-side — never in CLI configs or committed files.
 - Provider/model must match: `provider: local` + Voyage model → Pydantic validation error.
@@ -35,6 +35,7 @@ rag-params-finder indexes list            # Atlas Search indexes (known vs unkno
 rag-params-finder indexes reset           # drop unknown indexes + ensure required
 rag-params-finder indexes reset --all     # drop all chunks search indexes + recreate
 uv pip install -e ".[dev]"
+bash scripts/install-git-hooks.sh          # pre-commit on commit + quality-gates --quick on push
 
 # Frontend
 cd frontend && npm run dev                     # start dashboard → http://localhost:5173

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Slice 20 toolchain hardening** — unified `./scripts/quality-gates.sh` mirroring CI; `check_integrity.py`, `pip-audit.sh`
 - **CI:** scoped 80% coverage gate, ESLint, bandit SAST, pip-audit, gitleaks secrets scan job
 - **Repo lint:** shellcheck (`scripts/*.sh`), actionlint (GitHub Actions), markdownlint (`.markdownlint.json`) in pre-commit, `scripts/repo-lint.sh`, and CI `repo-lint` job
-- **Pre-push hook:** `quality-gates.sh --quick` on every `git push` via `scripts/install-git-hooks.sh`
+- **Pre-push hook:** same essential pre-commit checks on every `git push` (`pre-commit run --all-files` via `install-git-hooks.sh`)
 - **Repo hygiene:** `.gitleaks.toml`, `.nvmrc`, `.editorconfig`, `.gitattributes`, Dependabot
 - **Frontend:** ESLint + `eslint-plugin-security` wired in CI and pre-commit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Agent docs:** Graph-first exploration workflow in [AGENTS.md](AGENTS.md) and [CLAUDE.md](CLAUDE.md)
 - **Slice 20 toolchain hardening** — unified `./scripts/quality-gates.sh` mirroring CI; `check_integrity.py`, `pip-audit.sh`
 - **CI:** scoped 80% coverage gate, ESLint, bandit SAST, pip-audit, gitleaks secrets scan job
+- **Repo lint:** shellcheck (`scripts/*.sh`), actionlint (GitHub Actions), markdownlint (`.markdownlint.json`) in pre-commit, `scripts/repo-lint.sh`, and CI `repo-lint` job
 - **Repo hygiene:** `.gitleaks.toml`, `.nvmrc`, `.editorconfig`, `.gitattributes`, Dependabot
 - **Frontend:** ESLint + `eslint-plugin-security` wired in CI and pre-commit
 
@@ -210,7 +211,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Architecture Decision Records** (ADRs) in `docs/adr/` (two-process architecture, dual providers, MongoDB Atlas choice)
 - **Slice specifications** in `docs/slices/` (detailed acceptance criteria, verification steps)
-- **Pre-commit hooks** (ruff, mypy, prettier) via `.pre-commit-config.yaml`
+- **Pre-commit hooks** (ruff, mypy) via `.pre-commit-config.yaml`
 - **Comprehensive badges** across README and docs (build status, coverage, license, Python/Node versions)
 - **Quality gates baseline documentation** (lint, type check, test counts, bundle size)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Slice 20 toolchain hardening** — unified `./scripts/quality-gates.sh` mirroring CI; `check_integrity.py`, `pip-audit.sh`
 - **CI:** scoped 80% coverage gate, ESLint, bandit SAST, pip-audit, gitleaks secrets scan job
 - **Repo lint:** shellcheck (`scripts/*.sh`), actionlint (GitHub Actions), markdownlint (`.markdownlint.json`) in pre-commit, `scripts/repo-lint.sh`, and CI `repo-lint` job
+- **Pre-push hook:** `quality-gates.sh --quick` on every `git push` via `scripts/install-git-hooks.sh`
 - **Repo hygiene:** `.gitleaks.toml`, `.nvmrc`, `.editorconfig`, `.gitattributes`, Dependabot
 - **Frontend:** ESLint + `eslint-plugin-security` wired in CI and pre-commit
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ Two-process architecture: config submission (CLI) is separate from execution (Se
 # Setup
 uv venv && source .venv/bin/activate
 uv pip install -e ".[dev]"
+bash scripts/install-git-hooks.sh   # commit + pre-push hooks
 
 # Run server
 uvicorn server.main:app --reload --port 8001
@@ -153,6 +154,7 @@ Provider/model must match — registry in `model_registry.py` validates at confi
 ```
 [ ] Read docs/_internal/PROGRESS.md — confirm current state and which slice is next
 [ ] Read or create the slice spec in docs/slices/SLICE-XX-*.md
+[ ] bash scripts/install-git-hooks.sh (once per machine — commit + pre-push checks)
 [ ] Run all quality gates — confirm zero regressions before starting
 [ ] Note the exact acceptance criteria — these are the exit conditions
 ```
@@ -183,7 +185,7 @@ cd frontend && npm run lint && npm run typecheck && npm run build
 ### Post-slice checklist
 ```
 [ ] All acceptance criteria checked ✅
-[ ] Quality gates pass (zero regressions)
+[ ] Quality gates pass (zero regressions) — ./scripts/quality-gates.sh; git push runs --quick via pre-push hook
 [ ] Slice status updated in docs/_internal/PROGRESS.md (🔨 → ✅ COMPLETE)
 [ ] Decisions logged in PROGRESS.md Decision Log
 [ ] Committed with a short, specific message
@@ -194,6 +196,10 @@ cd frontend && npm run lint && npm run typecheck && npm run build
 ## Quality Gates Baseline
 
 **Unified script:** `./scripts/quality-gates.sh` (mirrors CI — 11 steps including repo lint)
+
+**Git hooks** (after `bash scripts/install-git-hooks.sh`):
+- **commit** → pre-commit (staged-file lint)
+- **push** → `quality-gates.sh --quick` (repo lint + lint + unit tests + eslint + tsc)
 
 **Repo lint** (2026-05-27):
 - `bash scripts/repo-lint.sh` → shellcheck + actionlint + markdownlint pass

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,9 @@ uv run mypy server/ cli/
 # Tests
 uv run pytest --tb=short -q
 
-# All quality gates (mirrors CI)
+# All quality gates (mirrors CI — repo lint + backend + frontend + audits)
 ./scripts/quality-gates.sh
+bash scripts/repo-lint.sh   # shell + workflows + Markdown only
 ```
 
 ### Frontend (Node.js 22+)
@@ -164,8 +165,11 @@ Record every non-obvious choice in `docs/_internal/PROGRESS.md` → Decision Log
 
 ### Verify-all commands (run before each commit)
 ```bash
-# One command — mirrors CI
+# One command — mirrors CI (repo lint is step 1)
 ./scripts/quality-gates.sh
+
+# Repo lint only (shell + workflows + Markdown)
+bash scripts/repo-lint.sh
 
 # Or individually:
 uv run ruff check .
@@ -189,7 +193,10 @@ cd frontend && npm run lint && npm run typecheck && npm run build
 
 ## Quality Gates Baseline
 
-**Unified script:** `./scripts/quality-gates.sh` (mirrors CI)
+**Unified script:** `./scripts/quality-gates.sh` (mirrors CI — 11 steps including repo lint)
+
+**Repo lint** (2026-05-27):
+- `bash scripts/repo-lint.sh` → shellcheck + actionlint + markdownlint pass
 
 **Backend** (2026-05-27):
 - `ruff check .` → 0 errors

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,7 +185,7 @@ cd frontend && npm run lint && npm run typecheck && npm run build
 ### Post-slice checklist
 ```
 [ ] All acceptance criteria checked ✅
-[ ] Quality gates pass (zero regressions) — ./scripts/quality-gates.sh; git push runs --quick via pre-push hook
+[ ] Quality gates pass (zero regressions) — ./scripts/quality-gates.sh; git push runs essential pre-commit hooks on all files
 [ ] Slice status updated in docs/_internal/PROGRESS.md (🔨 → ✅ COMPLETE)
 [ ] Decisions logged in PROGRESS.md Decision Log
 [ ] Committed with a short, specific message
@@ -199,7 +199,7 @@ cd frontend && npm run lint && npm run typecheck && npm run build
 
 **Git hooks** (after `bash scripts/install-git-hooks.sh`):
 - **commit** → pre-commit (staged-file lint)
-- **push** → `quality-gates.sh --quick` (repo lint + lint + unit tests + eslint + tsc)
+- **push** → same essential pre-commit hooks on entire repo (`pre-commit run --all-files`)
 
 **Repo lint** (2026-05-27):
 - `bash scripts/repo-lint.sh` → shellcheck + actionlint + markdownlint pass

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Contributions welcome — please open an issue first to discuss the change.
 
 **Running experiments does not require any extra tooling** — the [user guide](docs/user-guide/getting-started.md) path (Atlas, CLI, optional dashboard) is enough.
 
-**Contributors** use the [Development Guide](docs/contributor-guide/development.md) for quality gates, the slice workflow, and [release cadence](docs/contributor-guide/release-process.md#when-to-release) (release when a slice or feature is user-visible; see [CHANGELOG](CHANGELOG.md) `Unreleased` during development).
+**Contributors** use the [Development Guide](docs/contributor-guide/development.md) for quality gates (`./scripts/quality-gates.sh`, `scripts/repo-lint.sh`), the slice workflow, and [release cadence](docs/contributor-guide/release-process.md#when-to-release) (release when a slice or feature is user-visible; see [CHANGELOG](CHANGELOG.md) `Unreleased` during development).
 
 Optional **AI-assisted development** (Cursor / Claude Code with the `code-review-graph` knowledge graph) is documented in the development guide — it helps navigate this repo faster; it is not part of the RAG sweep runtime.
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Contributions welcome — please open an issue first to discuss the change.
 
 **Running experiments does not require any extra tooling** — the [user guide](docs/user-guide/getting-started.md) path (Atlas, CLI, optional dashboard) is enough.
 
-**Contributors** use the [Development Guide](docs/contributor-guide/development.md) for quality gates (`./scripts/quality-gates.sh`, `scripts/repo-lint.sh`), the slice workflow, and [release cadence](docs/contributor-guide/release-process.md#when-to-release) (release when a slice or feature is user-visible; see [CHANGELOG](CHANGELOG.md) `Unreleased` during development).
+**Contributors** use the [Development Guide](docs/contributor-guide/development.md) for setup (`bash scripts/install-git-hooks.sh` — checks on commit and push), quality gates (`./scripts/quality-gates.sh`), the slice workflow, and [release cadence](docs/contributor-guide/release-process.md#when-to-release) (release when a slice or feature is user-visible; see [CHANGELOG](CHANGELOG.md) `Unreleased` during development).
 
 Optional **AI-assisted development** (Cursor / Claude Code with the `code-review-graph` knowledge graph) is documented in the development guide — it helps navigate this repo faster; it is not part of the RAG sweep runtime.
 

--- a/docs/_internal/DOC-GAPS.md
+++ b/docs/_internal/DOC-GAPS.md
@@ -80,7 +80,7 @@ Each item below is a concrete, actionable doc gap. Check the box when done and r
 
 **Reference**: pre-rag has a standalone spec file per slice (`SLICE-07-SLIDING-WINDOW.md`, etc.).
 
-**2026-05-27 supplement:** All slice specs link to `./scripts/quality-gates.sh` / [`development.md`](../contributor-guide/development.md); Slice 20 documents repo lint + `scripts/install-git-hooks.sh` (pre-commit on commit, `quality-gates --quick` on push).
+**2026-05-27 supplement:** All slice specs link to `./scripts/quality-gates.sh` / [`development.md`](../contributor-guide/development.md); Slice 20 documents repo lint + `scripts/install-git-hooks.sh` (essential pre-commit checks on commit and push).
 
 ---
 
@@ -120,9 +120,9 @@ Each item below is a concrete, actionable doc gap. Check the box when done and r
 
 - [x] Add `.github/workflows/ci.yml` — repo-lint: shellcheck + actionlint + markdownlint; backend: ruff + format + mypy + bandit + pytest/coverage + pip-audit; frontend: eslint + tsc + build + npm audit; secrets: gitleaks
 - [x] CI documented in `CLAUDE.md`, `development.md`, Slice 20 spec
-- [x] Pre-push hook: `quality-gates.sh --quick` on every `git push` (see `install-git-hooks.sh`)
+- [x] Pre-push hook: essential pre-commit checks on every `git push` (`pre-commit run --all-files`)
 
-**Superseded note (2026-05-27):** ESLint is wired (`frontend/.eslintrc.cjs`). Use `./scripts/quality-gates.sh` for full local/CI parity; `git push` runs `--quick` when hooks are installed.
+**Superseded note (2026-05-27):** ESLint is wired (`frontend/.eslintrc.cjs`). Use `./scripts/quality-gates.sh` for full local/CI parity; `git push` runs essential pre-commit hooks when installed.
 
 **Reference**: pre-rag's Slice 1 established CI as a first-class deliverable; Slice 20 hardened to Serious tier.
 

--- a/docs/_internal/DOC-GAPS.md
+++ b/docs/_internal/DOC-GAPS.md
@@ -80,7 +80,7 @@ Each item below is a concrete, actionable doc gap. Check the box when done and r
 
 **Reference**: pre-rag has a standalone spec file per slice (`SLICE-07-SLIDING-WINDOW.md`, etc.).
 
-**2026-05-27 supplement:** All slice specs link to `./scripts/quality-gates.sh` / [`development.md`](../contributor-guide/development.md); Slice 20 documents repo lint (shellcheck, actionlint, markdownlint).
+**2026-05-27 supplement:** All slice specs link to `./scripts/quality-gates.sh` / [`development.md`](../contributor-guide/development.md); Slice 20 documents repo lint + `scripts/install-git-hooks.sh` (pre-commit on commit, `quality-gates --quick` on push).
 
 ---
 
@@ -100,6 +100,7 @@ Each item below is a concrete, actionable doc gap. Check the box when done and r
 **Priority**: Medium
 
 - [x] Add `## Quality Gates Baseline` section to `CLAUDE.md` with real numbers:
+  - [x] `bash scripts/install-git-hooks.sh` → pre-commit + pre-push hooks documented
   - [x] `bash scripts/repo-lint.sh` → shellcheck + actionlint + markdownlint pass
   - [x] `ruff check .` → 0 errors
   - [x] `mypy server/ cli/` → 0 errors
@@ -119,8 +120,9 @@ Each item below is a concrete, actionable doc gap. Check the box when done and r
 
 - [x] Add `.github/workflows/ci.yml` — repo-lint: shellcheck + actionlint + markdownlint; backend: ruff + format + mypy + bandit + pytest/coverage + pip-audit; frontend: eslint + tsc + build + npm audit; secrets: gitleaks
 - [x] CI documented in `CLAUDE.md`, `development.md`, Slice 20 spec
+- [x] Pre-push hook: `quality-gates.sh --quick` on every `git push` (see `install-git-hooks.sh`)
 
-**Superseded note (2026-05-27):** ESLint is wired (`frontend/.eslintrc.cjs`). Use `./scripts/quality-gates.sh` for local/CI parity.
+**Superseded note (2026-05-27):** ESLint is wired (`frontend/.eslintrc.cjs`). Use `./scripts/quality-gates.sh` for full local/CI parity; `git push` runs `--quick` when hooks are installed.
 
 **Reference**: pre-rag's Slice 1 established CI as a first-class deliverable; Slice 20 hardened to Serious tier.
 

--- a/docs/_internal/DOC-GAPS.md
+++ b/docs/_internal/DOC-GAPS.md
@@ -1,7 +1,7 @@
 # Documentation Gap Tracker
 
 **Created**: 2026-05-05
-**Last Updated**: 2026-05-27 (baselines refreshed after Slice 20; gaps 7–8 notes superseded)
+**Last Updated**: 2026-05-27 (baselines refreshed after Slice 20 + repo lint; gaps 7–8 notes superseded)
 **Reference**: Gap analysis vs [pre-rag-explorer-dashboard](https://github.com/neomatrix369/pre-rag-explorer-dashboard)
 
 Each item below is a concrete, actionable doc gap. Check the box when done and record the date.
@@ -80,6 +80,8 @@ Each item below is a concrete, actionable doc gap. Check the box when done and r
 
 **Reference**: pre-rag has a standalone spec file per slice (`SLICE-07-SLIDING-WINDOW.md`, etc.).
 
+**2026-05-27 supplement:** All slice specs link to `./scripts/quality-gates.sh` / [`development.md`](../contributor-guide/development.md); Slice 20 documents repo lint (shellcheck, actionlint, markdownlint).
+
 ---
 
 ## Gap 6 — PROGRESS.md housekeeping
@@ -98,6 +100,7 @@ Each item below is a concrete, actionable doc gap. Check the box when done and r
 **Priority**: Medium
 
 - [x] Add `## Quality Gates Baseline` section to `CLAUDE.md` with real numbers:
+  - [x] `bash scripts/repo-lint.sh` → shellcheck + actionlint + markdownlint pass
   - [x] `ruff check .` → 0 errors
   - [x] `mypy server/ cli/` → 0 errors
   - [x] `pytest` → **23 tests** (2026-05-27): 17 search-index + 3 sweep + 3 tiebreaker; 80% coverage on 4 scoped modules
@@ -106,7 +109,7 @@ Each item below is a concrete, actionable doc gap. Check the box when done and r
   - [x] `npm run build` → ~4 s, 49 modules
   - [x] `npm audit --audit-level=high` → 0 high vulnerabilities
 
-**Reference**: `CLAUDE.md`, `development.md`, `./scripts/quality-gates.sh` (canonical local mirror).
+**Reference**: `CLAUDE.md`, `development.md`, `./scripts/quality-gates.sh` (canonical local mirror), `./scripts/repo-lint.sh`.
 
 ---
 
@@ -114,7 +117,7 @@ Each item below is a concrete, actionable doc gap. Check the box when done and r
 
 **Priority**: Low–Medium
 
-- [x] Add `.github/workflows/ci.yml` — backend: ruff + format + mypy + bandit + pytest/coverage + pip-audit; frontend: eslint + tsc + build + npm audit; secrets: gitleaks
+- [x] Add `.github/workflows/ci.yml` — repo-lint: shellcheck + actionlint + markdownlint; backend: ruff + format + mypy + bandit + pytest/coverage + pip-audit; frontend: eslint + tsc + build + npm audit; secrets: gitleaks
 - [x] CI documented in `CLAUDE.md`, `development.md`, Slice 20 spec
 
 **Superseded note (2026-05-27):** ESLint is wired (`frontend/.eslintrc.cjs`). Use `./scripts/quality-gates.sh` for local/CI parity.

--- a/docs/_internal/DOCS-CODE-AUDIT.md
+++ b/docs/_internal/DOCS-CODE-AUDIT.md
@@ -16,6 +16,7 @@
 |------|--------|
 | `quality-gates.sh` ↔ `ci.yml` | ✅ Aligned (repo-lint, bandit, coverage, pip-audit, eslint, gitleaks) |
 | `repo-lint.sh` ↔ pre-commit hooks | ✅ shellcheck, actionlint, markdownlint (same revs via pre-commit) |
+| `quality-gates.sh --quick` ↔ pre-push hook | ✅ `install-git-hooks.sh` installs pre-push stage |
 | Test count in contributor docs | ✅ **23** pytest tests (was incorrectly cited as 39 in PROGRESS) |
 | Kimchi provider | ⚠️ `Provider` type includes `kimchi`; embedder/registry on `tessl-hackathon-kimchi-integration` branch only — not on main |
 | `development.md` testing section | ✅ Updated (was "no suite yet") |

--- a/docs/_internal/DOCS-CODE-AUDIT.md
+++ b/docs/_internal/DOCS-CODE-AUDIT.md
@@ -16,7 +16,7 @@
 |------|--------|
 | `quality-gates.sh` ↔ `ci.yml` | ✅ Aligned (repo-lint, bandit, coverage, pip-audit, eslint, gitleaks) |
 | `repo-lint.sh` ↔ pre-commit hooks | ✅ shellcheck, actionlint, markdownlint (same revs via pre-commit) |
-| `quality-gates.sh --quick` ↔ pre-push hook | ✅ `install-git-hooks.sh` installs pre-push stage |
+| pre-commit `--all-files` ↔ pre-push hook | ✅ same essential hooks as commit; `install-git-hooks.sh` |
 | Test count in contributor docs | ✅ **23** pytest tests (was incorrectly cited as 39 in PROGRESS) |
 | Kimchi provider | ⚠️ `Provider` type includes `kimchi`; embedder/registry on `tessl-hackathon-kimchi-integration` branch only — not on main |
 | `development.md` testing section | ✅ Updated (was "no suite yet") |

--- a/docs/_internal/DOCS-CODE-AUDIT.md
+++ b/docs/_internal/DOCS-CODE-AUDIT.md
@@ -1,6 +1,6 @@
 # Documentation vs Code Audit
 
-**Audit date**: 2026-05-23 (full pass) · **Supplement**: 2026-05-27 (Slice 20 + test counts)
+**Audit date**: 2026-05-23 (full pass) · **Supplement**: 2026-05-27 (Slice 20 + repo lint + test counts)
 **Auditor**: Claude (automated verification)
 **Scope**: README.md, user guides, contributor guides, code implementation
 
@@ -14,7 +14,8 @@
 
 | Area | Status |
 |------|--------|
-| `quality-gates.sh` ↔ `ci.yml` | ✅ Aligned (bandit, coverage, pip-audit, eslint, gitleaks job) |
+| `quality-gates.sh` ↔ `ci.yml` | ✅ Aligned (repo-lint, bandit, coverage, pip-audit, eslint, gitleaks) |
+| `repo-lint.sh` ↔ pre-commit hooks | ✅ shellcheck, actionlint, markdownlint (same revs via pre-commit) |
 | Test count in contributor docs | ✅ **23** pytest tests (was incorrectly cited as 39 in PROGRESS) |
 | Kimchi provider | ⚠️ `Provider` type includes `kimchi`; embedder/registry on `tessl-hackathon-kimchi-integration` branch only — not on main |
 | `development.md` testing section | ✅ Updated (was "no suite yet") |

--- a/docs/_internal/PROGRESS.md
+++ b/docs/_internal/PROGRESS.md
@@ -408,7 +408,7 @@ Implement comprehensive experiment deletion with confirmation flows and cascadin
 - [x] ConfirmDeleteModal shows experiment details and deletion warning
 - [x] Delete button disabled for running experiments with tooltip
 - [x] Success toast shows deletion statistics
-- [x] All pre-commit hooks pass (ruff, mypy, eslint, repo lint, tsc, build); pre-push runs `quality-gates.sh --quick`
+- [x] All pre-commit hooks pass (ruff, mypy, eslint, repo lint, tsc, build); pre-push runs same hooks on all files
 - [x] Documentation updated (CLI reference, troubleshooting guide)
 
 ### Testing Notes
@@ -621,7 +621,7 @@ Implement the 4 stubbed chunkers (fixed, token, sentence, semantic), add sparse/
 | 2026-05-23 | 19 | Slice 19 spec for storage quota guard | M0 hit 515/512 MB; writes blocked (cancel/delete deadlock); `dbStats` understated cluster usage; mirror search-index preflight pattern — spec in [`SLICE-19-STORAGE-QUOTA-GUARD.md`](../slices/SLICE-19-STORAGE-QUOTA-GUARD.md) |
 | 2026-05-27 | 20 | Docs synced to toolchain + test reality | 23 pytest tests (not 39); Kimchi on integration branch only; `quality-gates.sh` in interrupt recovery; CI/bandit/gitleaks documented |
 | 2026-05-27 | 20 | Repo lint in CI + pre-commit | shellcheck (`scripts/*.sh`), actionlint, markdownlint; `scripts/repo-lint.sh`; pragmatic `.markdownlint.json`; CI `repo-lint` job (4 jobs total) |
-| 2026-05-27 | 20 | Pre-push = quality-gates --quick | Every `git push` runs quick stack locally; full gates + CI on PR to `main`; `install-git-hooks.sh` installs both hook types |
+| 2026-05-27 | 20 | Pre-push = essential pre-commit checks | Every `git push` runs `pre-commit --all-files` (same hooks as commit); full `quality-gates.sh` + CI on PR |
 
 ---
 
@@ -695,7 +695,7 @@ Use this when resuming a session mid-slice:
 [ ] Git hooks installed: bash scripts/install-git-hooks.sh (once per machine)
 [ ] Run quality gates to confirm no regressions:
       ./scripts/quality-gates.sh          # full CI mirror before PR
-      # git push runs --quick via pre-push hook when hooks installed
+      # git push runs essential pre-commit hooks on all files when hooks installed
 [ ] Check git status — any uncommitted changes?
 [ ] Read the current slice spec in docs/slices/SLICE-XX-*.md
 [ ] Resume from the last incomplete acceptance criterion

--- a/docs/_internal/PROGRESS.md
+++ b/docs/_internal/PROGRESS.md
@@ -1,6 +1,6 @@
 # rag-params-finder — Build Progress
 
-**Last Updated**: 2026-05-27 (Slice 20 ✅ toolchain + repo lint; docs synced)
+**Last Updated**: 2026-05-27 (Slice 20 ✅ toolchain, repo lint, pre-push hooks; docs synced)
 **Current**: … | **Slice 20 ✅ COMPLETE** (toolchain hardening on `chore/slice-20-toolchain-hardening`) | Next: Slice 10 📋 · …
 
 ---
@@ -31,8 +31,8 @@
 | 11 — Search Explorer enhancements | 📋 PLANNED | ~1 h | Better visualization, export results, query filtering improvements |
 | 16 — Parallel sweep execution | 📋 PLANNED | ~2–4 h | Bounded concurrent `_run_single`; see [`SLICE-16-PARALLEL-SWEEP-RUNS.md`](../slices/SLICE-16-PARALLEL-SWEEP-RUNS.md) |
 | 19 — Atlas storage quota guard | 📋 PLANNED | ~3–5 h | Preflight + runtime `OperationFailure` 8000 handling + force-delete recovery; M0 incident 2026-05-23 — see [`SLICE-19-STORAGE-QUOTA-GUARD.md`](../slices/SLICE-19-STORAGE-QUOTA-GUARD.md) |
-| 20 — Toolchain hardening | ✅ COMPLETE | ~2–3 h | quality-gates.sh, repo-lint (shellcheck/actionlint/markdownlint), coverage CI gate, ESLint, bandit, pip-audit, gitleaks CI, dependabot — see [`SLICE-20-TOOLCHAIN-HARDENING.md`](../slices/SLICE-20-TOOLCHAIN-HARDENING.md) |
-| ~~15 — CI/CD~~ | ✅ (via 20) | — | Superseded by Slice 20 — `.github/workflows/ci.yml` + `quality-gates.sh` |
+| 20 — Toolchain hardening | ✅ COMPLETE | ~2–3 h | quality-gates.sh, repo-lint, pre-push hook (`install-git-hooks.sh`), coverage CI, ESLint, bandit, pip-audit, gitleaks, dependabot — [`SLICE-20-TOOLCHAIN-HARDENING.md`](../slices/SLICE-20-TOOLCHAIN-HARDENING.md) |
+| ~~15 — CI/CD~~ | ✅ (via 20) | — | Superseded by Slice 20 — CI + `quality-gates.sh` + git hooks |
 
 **Legend**: 📋 PLANNED | 🔨 IN PROGRESS | ✅ COMPLETE | 🔀 BRANCH (implemented on named branch, not main)
 
@@ -408,7 +408,7 @@ Implement comprehensive experiment deletion with confirmation flows and cascadin
 - [x] ConfirmDeleteModal shows experiment details and deletion warning
 - [x] Delete button disabled for running experiments with tooltip
 - [x] Success toast shows deletion statistics
-- [x] All pre-commit hooks pass (ruff, mypy, eslint, repo lint, tsc, build)
+- [x] All pre-commit hooks pass (ruff, mypy, eslint, repo lint, tsc, build); pre-push runs `quality-gates.sh --quick`
 - [x] Documentation updated (CLI reference, troubleshooting guide)
 
 ### Testing Notes
@@ -621,6 +621,7 @@ Implement the 4 stubbed chunkers (fixed, token, sentence, semantic), add sparse/
 | 2026-05-23 | 19 | Slice 19 spec for storage quota guard | M0 hit 515/512 MB; writes blocked (cancel/delete deadlock); `dbStats` understated cluster usage; mirror search-index preflight pattern — spec in [`SLICE-19-STORAGE-QUOTA-GUARD.md`](../slices/SLICE-19-STORAGE-QUOTA-GUARD.md) |
 | 2026-05-27 | 20 | Docs synced to toolchain + test reality | 23 pytest tests (not 39); Kimchi on integration branch only; `quality-gates.sh` in interrupt recovery; CI/bandit/gitleaks documented |
 | 2026-05-27 | 20 | Repo lint in CI + pre-commit | shellcheck (`scripts/*.sh`), actionlint, markdownlint; `scripts/repo-lint.sh`; pragmatic `.markdownlint.json`; CI `repo-lint` job (4 jobs total) |
+| 2026-05-27 | 20 | Pre-push = quality-gates --quick | Every `git push` runs quick stack locally; full gates + CI on PR to `main`; `install-git-hooks.sh` installs both hook types |
 
 ---
 
@@ -691,10 +692,10 @@ Use this when resuming a session mid-slice:
 
 ```
 [ ] Read docs/_internal/PROGRESS.md — note current slice and last known state
+[ ] Git hooks installed: bash scripts/install-git-hooks.sh (once per machine)
 [ ] Run quality gates to confirm no regressions:
-      ./scripts/quality-gates.sh          # step 1: repo-lint + backend + frontend + audits
-      # or --quick: repo-lint + lint + typecheck + unit tests (skips coverage/build/audits)
-      # or: bash scripts/repo-lint.sh only
+      ./scripts/quality-gates.sh          # full CI mirror before PR
+      # git push runs --quick via pre-push hook when hooks installed
 [ ] Check git status — any uncommitted changes?
 [ ] Read the current slice spec in docs/slices/SLICE-XX-*.md
 [ ] Resume from the last incomplete acceptance criterion

--- a/docs/_internal/PROGRESS.md
+++ b/docs/_internal/PROGRESS.md
@@ -1,6 +1,6 @@
 # rag-params-finder — Build Progress
 
-**Last Updated**: 2026-05-27 (Slice 20 ✅ toolchain hardening; docs synced to code)
+**Last Updated**: 2026-05-27 (Slice 20 ✅ toolchain + repo lint; docs synced)
 **Current**: … | **Slice 20 ✅ COMPLETE** (toolchain hardening on `chore/slice-20-toolchain-hardening`) | Next: Slice 10 📋 · …
 
 ---
@@ -31,7 +31,7 @@
 | 11 — Search Explorer enhancements | 📋 PLANNED | ~1 h | Better visualization, export results, query filtering improvements |
 | 16 — Parallel sweep execution | 📋 PLANNED | ~2–4 h | Bounded concurrent `_run_single`; see [`SLICE-16-PARALLEL-SWEEP-RUNS.md`](../slices/SLICE-16-PARALLEL-SWEEP-RUNS.md) |
 | 19 — Atlas storage quota guard | 📋 PLANNED | ~3–5 h | Preflight + runtime `OperationFailure` 8000 handling + force-delete recovery; M0 incident 2026-05-23 — see [`SLICE-19-STORAGE-QUOTA-GUARD.md`](../slices/SLICE-19-STORAGE-QUOTA-GUARD.md) |
-| 20 — Toolchain hardening | ✅ COMPLETE | ~2–3 h | quality-gates.sh, coverage CI gate, ESLint, bandit, pip-audit, gitleaks CI, dependabot — see [`SLICE-20-TOOLCHAIN-HARDENING.md`](../slices/SLICE-20-TOOLCHAIN-HARDENING.md) |
+| 20 — Toolchain hardening | ✅ COMPLETE | ~2–3 h | quality-gates.sh, repo-lint (shellcheck/actionlint/markdownlint), coverage CI gate, ESLint, bandit, pip-audit, gitleaks CI, dependabot — see [`SLICE-20-TOOLCHAIN-HARDENING.md`](../slices/SLICE-20-TOOLCHAIN-HARDENING.md) |
 | ~~15 — CI/CD~~ | ✅ (via 20) | — | Superseded by Slice 20 — `.github/workflows/ci.yml` + `quality-gates.sh` |
 
 **Legend**: 📋 PLANNED | 🔨 IN PROGRESS | ✅ COMPLETE | 🔀 BRANCH (implemented on named branch, not main)
@@ -408,7 +408,7 @@ Implement comprehensive experiment deletion with confirmation flows and cascadin
 - [x] ConfirmDeleteModal shows experiment details and deletion warning
 - [x] Delete button disabled for running experiments with tooltip
 - [x] Success toast shows deletion statistics
-- [x] All pre-commit hooks pass (ruff, mypy, tsc, build)
+- [x] All pre-commit hooks pass (ruff, mypy, eslint, repo lint, tsc, build)
 - [x] Documentation updated (CLI reference, troubleshooting guide)
 
 ### Testing Notes
@@ -620,6 +620,7 @@ Implement the 4 stubbed chunkers (fixed, token, sentence, semantic), add sparse/
 | 2026-05-23 | 18 | Maintain old fields indefinitely | Keep `retrieval_method`, `retrieval_provider`, `retrieval_model` in DB — synthesized from single retriever for backward compat |
 | 2026-05-23 | 19 | Slice 19 spec for storage quota guard | M0 hit 515/512 MB; writes blocked (cancel/delete deadlock); `dbStats` understated cluster usage; mirror search-index preflight pattern — spec in [`SLICE-19-STORAGE-QUOTA-GUARD.md`](../slices/SLICE-19-STORAGE-QUOTA-GUARD.md) |
 | 2026-05-27 | 20 | Docs synced to toolchain + test reality | 23 pytest tests (not 39); Kimchi on integration branch only; `quality-gates.sh` in interrupt recovery; CI/bandit/gitleaks documented |
+| 2026-05-27 | 20 | Repo lint in CI + pre-commit | shellcheck (`scripts/*.sh`), actionlint, markdownlint; `scripts/repo-lint.sh`; pragmatic `.markdownlint.json`; CI `repo-lint` job (4 jobs total) |
 
 ---
 
@@ -691,8 +692,9 @@ Use this when resuming a session mid-slice:
 ```
 [ ] Read docs/_internal/PROGRESS.md — note current slice and last known state
 [ ] Run quality gates to confirm no regressions:
-      ./scripts/quality-gates.sh
-      # or --quick: lint + typecheck + unit tests only
+      ./scripts/quality-gates.sh          # step 1: repo-lint + backend + frontend + audits
+      # or --quick: repo-lint + lint + typecheck + unit tests (skips coverage/build/audits)
+      # or: bash scripts/repo-lint.sh only
 [ ] Check git status — any uncommitted changes?
 [ ] Read the current slice spec in docs/slices/SLICE-XX-*.md
 [ ] Resume from the last incomplete acceptance criterion

--- a/docs/contributor-guide/development.md
+++ b/docs/contributor-guide/development.md
@@ -52,11 +52,20 @@ rag-params-finder run --config configs/example-mongodb-local.yaml
 
 Run all gates before committing. All must pass with zero regressions.
 
+**CI jobs** (`.github/workflows/ci.yml`): `repo-lint` → `backend` → `frontend` → `secrets` (four parallel jobs).
+
+| Layer | Tools |
+|-------|--------|
+| Repo | shellcheck (`scripts/*.sh`), actionlint, markdownlint |
+| Backend | ruff, ruff format, mypy, bandit, pytest + coverage, pip-audit |
+| Frontend | eslint, tsc, build, npm audit |
+| Secrets | gitleaks |
+
 **One command (mirrors CI exactly):**
 
 ```bash
 ./scripts/quality-gates.sh              # full CI mirror (default)
-./scripts/quality-gates.sh --quick      # lint + typecheck + unit tests only
+./scripts/quality-gates.sh --quick      # repo lint + lint + typecheck + unit tests (skips coverage/build/audits)
 ./scripts/quality-gates.sh --full       # CI mirror + local gitleaks + pre-commit all-files
 ```
 
@@ -117,12 +126,32 @@ npm audit --audit-level=high
 - `npm run build` → built in ~4s, 49 modules
 - `npm audit --audit-level=high` → 0 high vulnerabilities
 
+### Repo lint (shell, workflows, Markdown)
+
+```bash
+bash scripts/repo-lint.sh
+# or individually via pre-commit:
+pre-commit run shellcheck --all-files
+pre-commit run actionlint --all-files
+pre-commit run markdownlint --all-files
+```
+
+| Tool | Scope | Config |
+|------|--------|--------|
+| **Shellcheck** | `scripts/*.sh` | via `shellcheck-py` pre-commit hook |
+| **Actionlint** | `.github/workflows/*.yml` | — |
+| **Markdownlint** | `*.md` (excludes `.claude/`) | `.markdownlint.json` |
+
+Runs in CI (`repo-lint` job), `./scripts/quality-gates.sh`, and pre-commit.
+
 ### Pre-commit
 
 ```bash
 uv pip install -e ".[dev]"
 pre-commit install
 ```
+
+Hooks include Python (ruff, mypy, bandit), frontend (eslint, verify), secrets (gitleaks), hygiene, and repo lint above.
 
 ---
 
@@ -171,7 +200,7 @@ rag-params-finder/
 │   ├── adr/             # Architecture Decision Records
 │   ├── slices/          # Slice specs (dev-internal)
 │   └── _internal/       # Dev log, gap tracker, Graphiti exports
-└── .github/workflows/   # CI (see § CI — backend, frontend, secrets jobs)
+└── .github/workflows/   # CI (see § CI — repo-lint, backend, frontend, secrets)
 ```
 
 ---
@@ -211,10 +240,11 @@ Record every non-obvious choice in `docs/_internal/PROGRESS.md` → Decision Log
 
 ## 🔄 CI
 
-GitHub Actions runs on every push and PR to `main` (three jobs — see `.github/workflows/ci.yml`):
+GitHub Actions runs on every push and PR to `main` (four jobs — see `.github/workflows/ci.yml`):
 
 | Job | Steps |
 |-----|--------|
+| **Repo lint** | `pre-commit run shellcheck` → `actionlint` → `markdownlint` (all files) |
 | **Backend (Python)** | `ruff check` → `ruff format --check` → `mypy` → `bandit -ll` → `pytest` + 80% scoped coverage → `scripts/pip-audit.sh` |
 | **Frontend (Node.js)** | `npm run lint` → `npm run typecheck` → `npm run build` → `npm audit --audit-level=high` (Node from repo-root `.nvmrc`) |
 | **Secrets** | `gitleaks-action` with `.gitleaks.toml` |

--- a/docs/contributor-guide/development.md
+++ b/docs/contributor-guide/development.md
@@ -19,7 +19,7 @@ Dev environment setup, quality gates, testing strategy, and the slice workflow f
 # Install Python dev dependencies (includes ruff, mypy, pytest, pre-commit)
 uv pip install -e ".[dev]"
 
-# Git hooks: lint on commit, quality-gates --quick on every push
+# Git hooks: essential checks on commit (staged) and push (whole repo)
 bash scripts/install-git-hooks.sh
 
 # Start the server
@@ -158,10 +158,12 @@ bash scripts/install-git-hooks.sh
 
 | Hook | When | What runs |
 |------|------|-----------|
-| **pre-commit** | `git commit` | Staged-file checks: hygiene, gitleaks, repo lint, ruff, mypy, bandit, frontend eslint/verify (when paths match) |
-| **pre-push** | `git push` | `./scripts/quality-gates.sh --quick` — repo lint, ruff, format, mypy, bandit, unit tests, eslint, tsc |
+| **pre-commit** | `git commit` | Essential checks on **staged** files (see list below) |
+| **pre-push** | `git push` | Same essential checks on the **entire repo** (`pre-commit run --all-files`) |
 
-**pre-push** skips coverage threshold, pip-audit, npm audit, and production build (those run in CI on PR / push to `main`). Run `./scripts/quality-gates.sh` before opening a PR for full parity.
+**Essential checks** (commit + push): trailing whitespace / EOF / YAML·JSON·TOML syntax, merge conflicts, large files, private keys, gitleaks, shellcheck (`scripts/*.sh`), actionlint, markdownlint, bandit, ruff + format, mypy, frontend eslint + verify (when `frontend/` applies).
+
+**Not on push** (run manually or in CI): pytest + coverage, pip-audit, npm audit. Run `./scripts/quality-gates.sh` before opening a PR for full CI parity.
 
 Emergency bypass (use sparingly): `git push --no-verify`
 
@@ -176,8 +178,8 @@ pre-commit run --hook-stage pre-push --all-files
 | Trigger | What runs |
 |---------|-----------|
 | `git commit` | **pre-commit** — staged files (hygiene, secrets, repo lint, ruff, mypy, bandit, frontend when touched) |
-| `git push` | **pre-push** — `./scripts/quality-gates.sh --quick` (repo lint + lint + unit tests + eslint + tsc) |
-| PR or push to `main` | **GitHub Actions** — full CI (four jobs; includes coverage, pip-audit, npm audit, build) |
+| `git push` | **pre-push** — same essential hooks as commit, all files |
+| PR or push to `main` | **GitHub Actions** — full CI (four jobs; includes pytest, coverage, pip-audit, npm audit, build) |
 | Manual | `./scripts/quality-gates.sh` — full local mirror of CI before opening a PR |
 
 ---
@@ -256,7 +258,7 @@ Record every non-obvious choice in `docs/_internal/PROGRESS.md` → Decision Log
 
 ```
 [ ] All acceptance criteria checked ✅
-[ ] Quality gates pass — ./scripts/quality-gates.sh; git push exercised pre-push hook
+[ ] Quality gates pass — ./scripts/quality-gates.sh; git push exercised essential pre-push hook
 [ ] Slice status updated in docs/_internal/PROGRESS.md (🔨 → ✅ COMPLETE)
 [ ] Decisions logged in PROGRESS.md Decision Log
 [ ] Committed with a short, specific message
@@ -279,7 +281,7 @@ GitHub Actions runs on every push and PR to `main` (four jobs — see `.github/w
 
 Dependabot opens weekly PRs for pip, npm, and GitHub Actions (`.github/dependabot.yml`).
 
-**Local mirrors:** `./scripts/quality-gates.sh` (full, before PR). **`git push`** runs `--quick` automatically if `install-git-hooks.sh` was used. `--full` adds gitleaks + `pre-commit run --all-files` (manual).
+**Local mirrors:** `./scripts/quality-gates.sh` (full, before PR). **`git push`** runs essential pre-commit hooks on all files if `install-git-hooks.sh` was used. `--quick` / `--full` are manual only.
 
 ---
 

--- a/docs/contributor-guide/development.md
+++ b/docs/contributor-guide/development.md
@@ -173,6 +173,13 @@ Test push hook without pushing:
 pre-commit run --hook-stage pre-push --all-files
 ```
 
+**Push did not run checks?** Git only runs hooks that exist under `.git/hooks/`. A plain `pre-commit install` (no `--hook-type pre-push`) installs **commit** only. After pulling hook changes, re-run:
+
+```bash
+bash scripts/install-git-hooks.sh
+test -x .git/hooks/pre-push && echo "pre-push hook OK"
+```
+
 ### When checks run (local vs GitHub)
 
 | Trigger | What runs |

--- a/docs/contributor-guide/development.md
+++ b/docs/contributor-guide/development.md
@@ -16,8 +16,11 @@ Dev environment setup, quality gates, testing strategy, and the slice workflow f
 ### Backend
 
 ```bash
-# Install Python dev dependencies (includes ruff, mypy, pytest)
+# Install Python dev dependencies (includes ruff, mypy, pytest, pre-commit)
 uv pip install -e ".[dev]"
+
+# Git hooks: lint on commit, quality-gates --quick on every push
+bash scripts/install-git-hooks.sh
 
 # Start the server
 uvicorn server.main:app --reload --port 8001
@@ -144,14 +147,38 @@ pre-commit run markdownlint --all-files
 
 Runs in CI (`repo-lint` job), `./scripts/quality-gates.sh`, and pre-commit.
 
-### Pre-commit
+### Git hooks (commit + push)
 
 ```bash
 uv pip install -e ".[dev]"
-pre-commit install
+bash scripts/install-git-hooks.sh
+# equivalent:
+# pre-commit install --hook-type pre-commit --hook-type pre-push
 ```
 
-Hooks include Python (ruff, mypy, bandit), frontend (eslint, verify), secrets (gitleaks), hygiene, and repo lint above.
+| Hook | When | What runs |
+|------|------|-----------|
+| **pre-commit** | `git commit` | Staged-file checks: hygiene, gitleaks, repo lint, ruff, mypy, bandit, frontend eslint/verify (when paths match) |
+| **pre-push** | `git push` | `./scripts/quality-gates.sh --quick` — repo lint, ruff, format, mypy, bandit, unit tests, eslint, tsc |
+
+**pre-push** skips coverage threshold, pip-audit, npm audit, and production build (those run in CI on PR / push to `main`). Run `./scripts/quality-gates.sh` before opening a PR for full parity.
+
+Emergency bypass (use sparingly): `git push --no-verify`
+
+Test push hook without pushing:
+
+```bash
+pre-commit run --hook-stage pre-push --all-files
+```
+
+### When checks run (local vs GitHub)
+
+| Trigger | What runs |
+|---------|-----------|
+| `git commit` | **pre-commit** — staged files (hygiene, secrets, repo lint, ruff, mypy, bandit, frontend when touched) |
+| `git push` | **pre-push** — `./scripts/quality-gates.sh --quick` (repo lint + lint + unit tests + eslint + tsc) |
+| PR or push to `main` | **GitHub Actions** — full CI (four jobs; includes coverage, pip-audit, npm audit, build) |
+| Manual | `./scripts/quality-gates.sh` — full local mirror of CI before opening a PR |
 
 ---
 
@@ -212,6 +239,7 @@ rag-params-finder/
 ```
 [ ] Read docs/_internal/PROGRESS.md — confirm current state and which slice is next
 [ ] Read or create the slice spec in docs/slices/SLICE-XX-*.md
+[ ] bash scripts/install-git-hooks.sh (once per machine if not already installed)
 [ ] Run all quality gates — confirm zero regressions before starting
 [ ] Note the exact acceptance criteria — these are the exit conditions
 ```
@@ -228,7 +256,7 @@ Record every non-obvious choice in `docs/_internal/PROGRESS.md` → Decision Log
 
 ```
 [ ] All acceptance criteria checked ✅
-[ ] Quality gates pass (zero regressions)
+[ ] Quality gates pass — ./scripts/quality-gates.sh; git push exercised pre-push hook
 [ ] Slice status updated in docs/_internal/PROGRESS.md (🔨 → ✅ COMPLETE)
 [ ] Decisions logged in PROGRESS.md Decision Log
 [ ] Committed with a short, specific message
@@ -251,7 +279,7 @@ GitHub Actions runs on every push and PR to `main` (four jobs — see `.github/w
 
 Dependabot opens weekly PRs for pip, npm, and GitHub Actions (`.github/dependabot.yml`).
 
-Local mirror: `./scripts/quality-gates.sh` (default). Use `--quick` for lint/typecheck/tests only; `--full` adds local gitleaks + `pre-commit run --all-files`.
+**Local mirrors:** `./scripts/quality-gates.sh` (full, before PR). **`git push`** runs `--quick` automatically if `install-git-hooks.sh` was used. `--full` adds gitleaks + `pre-commit run --all-files` (manual).
 
 ---
 

--- a/docs/contributor-guide/extending.md
+++ b/docs/contributor-guide/extending.md
@@ -208,6 +208,6 @@ Engines (`orchestrator`, `retriever`, `embedder`) must not import from `api/` or
 ## 👉 See Also
 
 - [Architecture](architecture.md) — understand the module map and pipeline before extending
-- [Development Guide](development.md) — quality gates to run after making changes
+- [Development Guide](development.md) — git hooks (`install-git-hooks.sh`), quality gates, CI parity
 - [Configuration Reference](../user-guide/configuration.md) — user-facing impact of new models and methods
 - [Local Environment](local-environment.md) — Atlas index setup for new embedding dimensions

--- a/docs/contributor-guide/release-process.md
+++ b/docs/contributor-guide/release-process.md
@@ -43,7 +43,7 @@ Create a new release when:
 
 - Finish slice implementation
 - Git hooks installed: `bash scripts/install-git-hooks.sh`
-- All quality gates pass: `./scripts/quality-gates.sh` (full CI mirror; `git push` runs `--quick` via pre-push when hooks are on)
+- All quality gates pass: `./scripts/quality-gates.sh` (full CI mirror; `git push` runs essential pre-commit hooks when installed)
 - Update `docs/_internal/PROGRESS.md` to mark slice complete
 - Commit work with clear messages
 

--- a/docs/contributor-guide/release-process.md
+++ b/docs/contributor-guide/release-process.md
@@ -42,7 +42,8 @@ Create a new release when:
 ### 1. Complete the work
 
 - Finish slice implementation
-- All tests pass (`uv run pytest`, `npm run typecheck`)
+- Git hooks installed: `bash scripts/install-git-hooks.sh`
+- All quality gates pass: `./scripts/quality-gates.sh` (full CI mirror; `git push` runs `--quick` via pre-push when hooks are on)
 - Update `docs/_internal/PROGRESS.md` to mark slice complete
 - Commit work with clear messages
 

--- a/docs/slices/SLICE-01-SKATEBOARD.md
+++ b/docs/slices/SLICE-01-SKATEBOARD.md
@@ -182,10 +182,11 @@ All acceptance criteria checked ✅ AND:
 
 ## Quality gates (current project standard)
 
-This slice predates Slice 20 CI hardening. For any code or doc change today:
+This slice predates Slice 20. For any change today:
 
 ```bash
-./scripts/quality-gates.sh
+bash scripts/install-git-hooks.sh   # once — commit checks + quality-gates --quick on push
+./scripts/quality-gates.sh          # full CI mirror before opening a PR
 ```
 
-See [`docs/contributor-guide/development.md`](../contributor-guide/development.md) and [`SLICE-20-TOOLCHAIN-HARDENING.md`](./SLICE-20-TOOLCHAIN-HARDENING.md).
+See [`development.md`](../contributor-guide/development.md) § Git hooks and [`SLICE-20-TOOLCHAIN-HARDENING.md`](./SLICE-20-TOOLCHAIN-HARDENING.md).

--- a/docs/slices/SLICE-01-SKATEBOARD.md
+++ b/docs/slices/SLICE-01-SKATEBOARD.md
@@ -185,7 +185,7 @@ All acceptance criteria checked ✅ AND:
 This slice predates Slice 20. For any change today:
 
 ```bash
-bash scripts/install-git-hooks.sh   # once — commit checks + quality-gates --quick on push
+bash scripts/install-git-hooks.sh   # once — essential checks on commit and push
 ./scripts/quality-gates.sh          # full CI mirror before opening a PR
 ```
 

--- a/docs/slices/SLICE-01-SKATEBOARD.md
+++ b/docs/slices/SLICE-01-SKATEBOARD.md
@@ -179,3 +179,13 @@ All acceptance criteria checked ✅ AND:
 - Dashboard renders experiment row
 - MongoDB Atlas has 6 collections populated
 - README Quickstart tested end-to-end
+
+## Quality gates (current project standard)
+
+This slice predates Slice 20 CI hardening. For any code or doc change today:
+
+```bash
+./scripts/quality-gates.sh
+```
+
+See [`docs/contributor-guide/development.md`](../contributor-guide/development.md) and [`SLICE-20-TOOLCHAIN-HARDENING.md`](./SLICE-20-TOOLCHAIN-HARDENING.md).

--- a/docs/slices/SLICE-02-RERANK.md
+++ b/docs/slices/SLICE-02-RERANK.md
@@ -48,3 +48,11 @@ Add Voyage reranking to refine dense search results: top-`top_k_initial` candida
 - RERANKING phase appears in run_status progression
 - Results collection has both `dense_score` and `rerank_score`
 - Config with `rerank_model: null` completes without RERANKING phase
+
+## Quality gates (current project standard)
+
+```bash
+./scripts/quality-gates.sh
+```
+
+See [`docs/contributor-guide/development.md`](../contributor-guide/development.md) and [`SLICE-20-TOOLCHAIN-HARDENING.md`](./SLICE-20-TOOLCHAIN-HARDENING.md).

--- a/docs/slices/SLICE-02-RERANK.md
+++ b/docs/slices/SLICE-02-RERANK.md
@@ -52,7 +52,8 @@ Add Voyage reranking to refine dense search results: top-`top_k_initial` candida
 ## Quality gates (current project standard)
 
 ```bash
-./scripts/quality-gates.sh
+bash scripts/install-git-hooks.sh   # once — commit + pre-push (--quick)
+./scripts/quality-gates.sh          # full mirror before PR
 ```
 
-See [`docs/contributor-guide/development.md`](../contributor-guide/development.md) and [`SLICE-20-TOOLCHAIN-HARDENING.md`](./SLICE-20-TOOLCHAIN-HARDENING.md).
+See [`development.md`](../contributor-guide/development.md) § Git hooks.

--- a/docs/slices/SLICE-02-RERANK.md
+++ b/docs/slices/SLICE-02-RERANK.md
@@ -52,7 +52,7 @@ Add Voyage reranking to refine dense search results: top-`top_k_initial` candida
 ## Quality gates (current project standard)
 
 ```bash
-bash scripts/install-git-hooks.sh   # once — commit + pre-push (--quick)
+bash scripts/install-git-hooks.sh   # once — essential checks on commit and push
 ./scripts/quality-gates.sh          # full mirror before PR
 ```
 

--- a/docs/slices/SLICE-03-SWEEP-EXPANSION.md
+++ b/docs/slices/SLICE-03-SWEEP-EXPANSION.md
@@ -56,3 +56,11 @@ Cartesian product expansion: one YAML config with N models × M chunking methods
 - POST experiment with 3 chunk_sizes × 2 overlaps → exactly 6 run_ids in response
 - All 6 runs reach COMPLETE (or FAILED with `on_error: continue`)
 - Dashboard ExperimentsScreen shows run count per experiment
+
+## Quality gates (current project standard)
+
+```bash
+./scripts/quality-gates.sh
+```
+
+See [`docs/contributor-guide/development.md`](../contributor-guide/development.md) and [`SLICE-20-TOOLCHAIN-HARDENING.md`](./SLICE-20-TOOLCHAIN-HARDENING.md).

--- a/docs/slices/SLICE-03-SWEEP-EXPANSION.md
+++ b/docs/slices/SLICE-03-SWEEP-EXPANSION.md
@@ -60,7 +60,8 @@ Cartesian product expansion: one YAML config with N models × M chunking methods
 ## Quality gates (current project standard)
 
 ```bash
+bash scripts/install-git-hooks.sh
 ./scripts/quality-gates.sh
 ```
 
-See [`docs/contributor-guide/development.md`](../contributor-guide/development.md) and [`SLICE-20-TOOLCHAIN-HARDENING.md`](./SLICE-20-TOOLCHAIN-HARDENING.md).
+See [`development.md`](../contributor-guide/development.md) § Git hooks.

--- a/docs/slices/SLICE-04-LIVE-STATUS.md
+++ b/docs/slices/SLICE-04-LIVE-STATUS.md
@@ -55,3 +55,11 @@ Real-time phase tracking: CLI shows a live table while runs progress, and the Re
 - CLI `rag-params-finder run --config configs/example-local.yaml` shows live phase updates
 - Dashboard detail screen shows phase dots advancing in real time
 - All 8 phases (QUEUED through COMPLETE) appear correctly coloured
+
+## Quality gates (current project standard)
+
+```bash
+./scripts/quality-gates.sh
+```
+
+See [`docs/contributor-guide/development.md`](../contributor-guide/development.md) and [`SLICE-20-TOOLCHAIN-HARDENING.md`](./SLICE-20-TOOLCHAIN-HARDENING.md).

--- a/docs/slices/SLICE-04-LIVE-STATUS.md
+++ b/docs/slices/SLICE-04-LIVE-STATUS.md
@@ -59,7 +59,8 @@ Real-time phase tracking: CLI shows a live table while runs progress, and the Re
 ## Quality gates (current project standard)
 
 ```bash
+bash scripts/install-git-hooks.sh
 ./scripts/quality-gates.sh
 ```
 
-See [`docs/contributor-guide/development.md`](../contributor-guide/development.md) and [`SLICE-20-TOOLCHAIN-HARDENING.md`](./SLICE-20-TOOLCHAIN-HARDENING.md).
+See [`development.md`](../contributor-guide/development.md) § Git hooks.

--- a/docs/slices/SLICE-05-PERSONA-QUERIES.md
+++ b/docs/slices/SLICE-05-PERSONA-QUERIES.md
@@ -66,7 +66,8 @@ Load test queries from a persona-based JSON file and execute all queries within 
 ## Quality gates (current project standard)
 
 ```bash
+bash scripts/install-git-hooks.sh
 ./scripts/quality-gates.sh
 ```
 
-See [`docs/contributor-guide/development.md`](../contributor-guide/development.md) and [`SLICE-20-TOOLCHAIN-HARDENING.md`](./SLICE-20-TOOLCHAIN-HARDENING.md).
+See [`development.md`](../contributor-guide/development.md) § Git hooks.

--- a/docs/slices/SLICE-05-PERSONA-QUERIES.md
+++ b/docs/slices/SLICE-05-PERSONA-QUERIES.md
@@ -62,3 +62,11 @@ Load test queries from a persona-based JSON file and execute all queries within 
 - Config with 3 personas × 2 queries each → 6 `QueryResult` docs per run in results collection
 - `persona_id` and `focus` fields present on each result
 - URL queries file downloads on first use and uses cache on subsequent runs
+
+## Quality gates (current project standard)
+
+```bash
+./scripts/quality-gates.sh
+```
+
+See [`docs/contributor-guide/development.md`](../contributor-guide/development.md) and [`SLICE-20-TOOLCHAIN-HARDENING.md`](./SLICE-20-TOOLCHAIN-HARDENING.md).

--- a/docs/slices/SLICE-07-LOCAL-MODELS.md
+++ b/docs/slices/SLICE-07-LOCAL-MODELS.md
@@ -84,7 +84,8 @@ Name: `vector_index_384`
 ## Quality gates (current project standard)
 
 ```bash
+bash scripts/install-git-hooks.sh
 ./scripts/quality-gates.sh
 ```
 
-See [`docs/contributor-guide/development.md`](../contributor-guide/development.md) and [`SLICE-20-TOOLCHAIN-HARDENING.md`](./SLICE-20-TOOLCHAIN-HARDENING.md).
+See [`development.md`](../contributor-guide/development.md) § Git hooks.

--- a/docs/slices/SLICE-07-LOCAL-MODELS.md
+++ b/docs/slices/SLICE-07-LOCAL-MODELS.md
@@ -80,3 +80,11 @@ Name: `vector_index_384`
 - `rag-params-finder run --config configs/example-local.yaml` completes without `VOYAGE_API_KEY`
 - Results stored with 384-dim embeddings under `vector_index_384`
 - `provider: local` + Voyage model name → Pydantic validation error at config load
+
+## Quality gates (current project standard)
+
+```bash
+./scripts/quality-gates.sh
+```
+
+See [`docs/contributor-guide/development.md`](../contributor-guide/development.md) and [`SLICE-20-TOOLCHAIN-HARDENING.md`](./SLICE-20-TOOLCHAIN-HARDENING.md).

--- a/docs/slices/SLICE-10-RUN-RECOVERY.md
+++ b/docs/slices/SLICE-10-RUN-RECOVERY.md
@@ -102,7 +102,7 @@ Recovery should **reuse the same `run_id`** for a retried run so dashboards, URL
 ## Automated quality gates
 
 ```bash
-bash scripts/install-git-hooks.sh   # once — pre-commit on commit, quality-gates --quick on push
+bash scripts/install-git-hooks.sh   # once — essential checks on commit and push
 ./scripts/quality-gates.sh          # full CI mirror before PR
 ```
 

--- a/docs/slices/SLICE-10-RUN-RECOVERY.md
+++ b/docs/slices/SLICE-10-RUN-RECOVERY.md
@@ -99,6 +99,18 @@ Recovery should **reuse the same `run_id`** for a retried run so dashboards, URL
 
 ---
 
+## Automated quality gates
+
+Before merge, run the canonical gate stack (Slice 20):
+
+```bash
+./scripts/quality-gates.sh
+```
+
+See [`docs/contributor-guide/development.md`](../contributor-guide/development.md) for `--quick`, `scripts/repo-lint.sh`, and CI job breakdown.
+
+---
+
 ## See Also
 
 - [`docs/_internal/PROGRESS.md`](../_internal/PROGRESS.md) — roadmap

--- a/docs/slices/SLICE-10-RUN-RECOVERY.md
+++ b/docs/slices/SLICE-10-RUN-RECOVERY.md
@@ -101,13 +101,12 @@ Recovery should **reuse the same `run_id`** for a retried run so dashboards, URL
 
 ## Automated quality gates
 
-Before merge, run the canonical gate stack (Slice 20):
-
 ```bash
-./scripts/quality-gates.sh
+bash scripts/install-git-hooks.sh   # once — pre-commit on commit, quality-gates --quick on push
+./scripts/quality-gates.sh          # full CI mirror before PR
 ```
 
-See [`docs/contributor-guide/development.md`](../contributor-guide/development.md) for `--quick`, `scripts/repo-lint.sh`, and CI job breakdown.
+See [`development.md`](../contributor-guide/development.md) § Git hooks and § When checks run.
 
 ---
 

--- a/docs/slices/SLICE-16-PARALLEL-SWEEP-RUNS.md
+++ b/docs/slices/SLICE-16-PARALLEL-SWEEP-RUNS.md
@@ -87,6 +87,18 @@ Recommendation: prototype **Approach A** inside `orchestrator` first *(same Mong
 
 ---
 
+## Automated quality gates
+
+Before merge:
+
+```bash
+./scripts/quality-gates.sh
+```
+
+See [`docs/contributor-guide/development.md`](../contributor-guide/development.md).
+
+---
+
 ## See Also
 
 - `docs/_internal/PROGRESS.md` — roadmap row for this slice

--- a/docs/slices/SLICE-16-PARALLEL-SWEEP-RUNS.md
+++ b/docs/slices/SLICE-16-PARALLEL-SWEEP-RUNS.md
@@ -89,13 +89,12 @@ Recommendation: prototype **Approach A** inside `orchestrator` first *(same Mong
 
 ## Automated quality gates
 
-Before merge:
-
 ```bash
+bash scripts/install-git-hooks.sh
 ./scripts/quality-gates.sh
 ```
 
-See [`docs/contributor-guide/development.md`](../contributor-guide/development.md).
+See [`development.md`](../contributor-guide/development.md) § Git hooks.
 
 ---
 

--- a/docs/slices/SLICE-18-UNIFIED-RETRIEVER-CONFIG.md
+++ b/docs/slices/SLICE-18-UNIFIED-RETRIEVER-CONFIG.md
@@ -96,7 +96,7 @@ retrieval:
 ### Quality Gates
 - [ ] `bash scripts/install-git-hooks.sh` run on dev machine (commit + pre-push hooks)
 - [ ] `./scripts/quality-gates.sh` passes (full CI mirror before PR — see [`development.md`](../contributor-guide/development.md))
-- [ ] `git push` succeeds with pre-push hook (`quality-gates --quick`) or run `--quick` manually during iteration
+- [ ] `git push` succeeds with pre-push hook (essential checks) or run `./scripts/quality-gates.sh --quick` manually
 
 ### Manual Verification
 - [ ] Old YAML config → successful sweep

--- a/docs/slices/SLICE-18-UNIFIED-RETRIEVER-CONFIG.md
+++ b/docs/slices/SLICE-18-UNIFIED-RETRIEVER-CONFIG.md
@@ -94,8 +94,9 @@ retrieval:
 - [ ] Troubleshooting guide mentions old vs new format
 
 ### Quality Gates
-- [ ] `./scripts/quality-gates.sh` passes (repo lint + backend + frontend + audits — see [`development.md`](../contributor-guide/development.md))
-- [ ] Or `--quick` during iteration: repo lint + ruff + mypy + unit tests + eslint + tsc
+- [ ] `bash scripts/install-git-hooks.sh` run on dev machine (commit + pre-push hooks)
+- [ ] `./scripts/quality-gates.sh` passes (full CI mirror before PR — see [`development.md`](../contributor-guide/development.md))
+- [ ] `git push` succeeds with pre-push hook (`quality-gates --quick`) or run `--quick` manually during iteration
 
 ### Manual Verification
 - [ ] Old YAML config → successful sweep

--- a/docs/slices/SLICE-18-UNIFIED-RETRIEVER-CONFIG.md
+++ b/docs/slices/SLICE-18-UNIFIED-RETRIEVER-CONFIG.md
@@ -94,11 +94,8 @@ retrieval:
 - [ ] Troubleshooting guide mentions old vs new format
 
 ### Quality Gates
-- [ ] `uv run ruff check .` → 0 errors
-- [ ] `uv run mypy server/ cli/` → 0 errors
-- [ ] `uv run pytest --tb=short -q` → all tests pass
-- [ ] `npm run typecheck` → 0 errors
-- [ ] `npm run build` → successful build
+- [ ] `./scripts/quality-gates.sh` passes (repo lint + backend + frontend + audits — see [`development.md`](../contributor-guide/development.md))
+- [ ] Or `--quick` during iteration: repo lint + ruff + mypy + unit tests + eslint + tsc
 
 ### Manual Verification
 - [ ] Old YAML config → successful sweep
@@ -341,7 +338,7 @@ retrieval:
 - Zero regressions in existing experiments (old configs still run)
 - New config format validates without errors
 - Dashboard displays both old and new experiments correctly
-- All quality gates pass (ruff, mypy, pytest, tsc, build)
+- All quality gates pass (`./scripts/quality-gates.sh`)
 - Documentation updated and clear
 
 ---
@@ -349,7 +346,7 @@ retrieval:
 ## Completion Checklist
 
 - [ ] All acceptance criteria met
-- [ ] Quality gates pass
+- [ ] `./scripts/quality-gates.sh` passes
 - [ ] Manual verification complete
 - [ ] Documentation updated
 - [ ] Example configs updated

--- a/docs/slices/SLICE-19-STORAGE-QUOTA-GUARD.md
+++ b/docs/slices/SLICE-19-STORAGE-QUOTA-GUARD.md
@@ -137,13 +137,12 @@ DELETE /experiments/{id}?force=true
 
 ## Automated quality gates
 
-Before merge:
-
 ```bash
+bash scripts/install-git-hooks.sh
 ./scripts/quality-gates.sh
 ```
 
-See [`docs/contributor-guide/development.md`](../contributor-guide/development.md).
+See [`development.md`](../contributor-guide/development.md) § Git hooks.
 
 ---
 

--- a/docs/slices/SLICE-19-STORAGE-QUOTA-GUARD.md
+++ b/docs/slices/SLICE-19-STORAGE-QUOTA-GUARD.md
@@ -135,6 +135,18 @@ DELETE /experiments/{id}?force=true
 
 ---
 
+## Automated quality gates
+
+Before merge:
+
+```bash
+./scripts/quality-gates.sh
+```
+
+See [`docs/contributor-guide/development.md`](../contributor-guide/development.md).
+
+---
+
 ## Verification
 
 ```bash
@@ -147,5 +159,6 @@ uv run pytest tests/test_storage_preflight.py -q
 # 3. Trigger quota during sweep → runs fail with clear error_message
 # 4. Cancel fails with 507 → force delete frees space → cancel/delete work again
 
-uv run ruff check . && uv run mypy server/ cli/
+./scripts/quality-gates.sh
+# or during development: ./scripts/quality-gates.sh --quick
 ```

--- a/docs/slices/SLICE-20-TOOLCHAIN-HARDENING.md
+++ b/docs/slices/SLICE-20-TOOLCHAIN-HARDENING.md
@@ -34,6 +34,7 @@ Inherit proven hardening patterns from **price-analysis** and **pre-rag-explorer
 | Vitest frontend tests | pre-rag | ❌ — separate slice when UI test tier is planned |
 | Torch/transformers major upgrade | pip-audit findings | ❌ — tracked via `scripts/pip-audit.sh` ignores |
 | `scripts/repo-lint.sh` (shellcheck, actionlint, markdownlint) | governance (Serious tier) | ✅ *(2026-05-27 follow-on)* |
+| `install-git-hooks.sh` + pre-push `quality-gates --quick` | governance | ✅ *(2026-05-27 follow-on)* |
 | yamllint / stylelint / markdown “strict” rules | governance | ❌ — `check-yaml` + pragmatic `.markdownlint.json` suffice for now |
 
 ---
@@ -60,6 +61,7 @@ Inherit proven hardening patterns from **price-analysis** and **pre-rag-explorer
 - [x] Shellcheck on `scripts/*.sh` (`shellcheck-py`)
 - [x] Actionlint on `.github/workflows`
 - [x] Markdownlint on `*.md` (excludes `.claude/`)
+- [x] Pre-push hook runs `./scripts/quality-gates.sh --quick` (`scripts/install-git-hooks.sh`)
 
 ### Coverage scope (baseline-first)
 Measured baseline **83.6%** on:
@@ -99,6 +101,7 @@ Threshold set to **80%** (`--cov-fail-under=80` in CI and quality-gates).
 | `frontend/.eslintrc.cjs` | ESLint + security plugin |
 | `docs/slices/SLICE-20-TOOLCHAIN-HARDENING.md` | This spec |
 | `scripts/repo-lint.sh` | Shell + workflow + Markdown linters (pre-commit wrappers) |
+| `scripts/install-git-hooks.sh` | Installs pre-commit + pre-push hooks |
 | `.markdownlint.json` | Pragmatic Markdown rules for existing docs |
 
 ### Modified
@@ -181,6 +184,10 @@ python scripts/check_integrity.py
 **Decision:** Use `shellcheck-py` pre-commit repo (no Docker).
 **Rationale:** `koalaman/shellcheck-precommit` rev failed in CI; pip wheel hook matches Serious tier without Docker.
 
+### 8. Pre-push runs `--quick`, not full gates
+**Decision:** Pre-push hook calls `./scripts/quality-gates.sh --quick`; full gates remain manual + CI on PR.
+**Rationale:** Push is frequent; coverage, pip-audit, npm audit, and production build stay in CI. Still stronger than commit-only hooks.
+
 ---
 
 ## Deferred → future slices
@@ -217,6 +224,7 @@ Three-way comparison after inheriting patterns from **price-analysis** and **pre
 | pytest integration/slow markers | ✅ | N/A (vitest) | ✅ (markers defined) |
 | pre-commit (Python framework) | ✅ heavy | ✅ Serious-lite | ✅ |
 | shellcheck / actionlint / markdownlint | partial | partial | ✅ repo-lint job + hooks |
+| pre-push quality gate | ❌ | partial (husky) | ✅ `quality-gates --quick` |
 | Husky + lint-staged | ❌ | ✅ | ❌ (pre-commit instead) |
 | Prettier | ✅ black/isort | ✅ | ❌ (ruff + eslint) |
 | Xenon complexity | ✅ scoped | ❌ | ❌ deferred |
@@ -235,9 +243,9 @@ Three-way comparison after inheriting patterns from **price-analysis** and **pre
 ```
 chore(ci): slice 20 toolchain hardening from reference repos
 
-- Add quality-gates.sh, check_integrity.py, pip-audit.sh, repo-lint.sh
+- Add quality-gates.sh, check_integrity.py, pip-audit.sh, repo-lint.sh, install-git-hooks.sh
 - CI: repo-lint job; coverage 80% on scoped modules; eslint; pip-audit
-- Pre-commit: shellcheck, actionlint, markdownlint; ESLint+security; gitleaks
+- Git hooks: pre-commit + pre-push (quality-gates --quick); shellcheck, actionlint, markdownlint
 - Wire .gitleaks.toml, .nvmrc, dependabot, repo hygiene files
 - Upgrade urllib3/starlette/idna/langchain-core; document ML transitive audit ignores
 

--- a/docs/slices/SLICE-20-TOOLCHAIN-HARDENING.md
+++ b/docs/slices/SLICE-20-TOOLCHAIN-HARDENING.md
@@ -34,7 +34,7 @@ Inherit proven hardening patterns from **price-analysis** and **pre-rag-explorer
 | Vitest frontend tests | pre-rag | ❌ — separate slice when UI test tier is planned |
 | Torch/transformers major upgrade | pip-audit findings | ❌ — tracked via `scripts/pip-audit.sh` ignores |
 | `scripts/repo-lint.sh` (shellcheck, actionlint, markdownlint) | governance (Serious tier) | ✅ *(2026-05-27 follow-on)* |
-| `install-git-hooks.sh` + pre-push `quality-gates --quick` | governance | ✅ *(2026-05-27 follow-on)* |
+| `install-git-hooks.sh` + pre-push essential checks (`--all-files`) | governance | ✅ *(2026-05-27 follow-on)* |
 | yamllint / stylelint / markdown “strict” rules | governance | ❌ — `check-yaml` + pragmatic `.markdownlint.json` suffice for now |
 
 ---
@@ -61,7 +61,7 @@ Inherit proven hardening patterns from **price-analysis** and **pre-rag-explorer
 - [x] Shellcheck on `scripts/*.sh` (`shellcheck-py`)
 - [x] Actionlint on `.github/workflows`
 - [x] Markdownlint on `*.md` (excludes `.claude/`)
-- [x] Pre-push hook runs `./scripts/quality-gates.sh --quick` (`scripts/install-git-hooks.sh`)
+- [x] Pre-push hook runs same essential checks as commit on all files (`pre-commit run --all-files`)
 
 ### Coverage scope (baseline-first)
 Measured baseline **83.6%** on:
@@ -184,9 +184,9 @@ python scripts/check_integrity.py
 **Decision:** Use `shellcheck-py` pre-commit repo (no Docker).
 **Rationale:** `koalaman/shellcheck-precommit` rev failed in CI; pip wheel hook matches Serious tier without Docker.
 
-### 8. Pre-push runs `--quick`, not full gates
-**Decision:** Pre-push hook calls `./scripts/quality-gates.sh --quick`; full gates remain manual + CI on PR.
-**Rationale:** Push is frequent; coverage, pip-audit, npm audit, and production build stay in CI. Still stronger than commit-only hooks.
+### 8. Pre-push mirrors commit essential checks, not full gates
+**Decision:** Pre-push runs `pre-commit run --all-files` (same hooks as commit, whole repo); full `quality-gates.sh` stays manual + CI on PR.
+**Rationale:** Matches “essential checks like commit”; pytest, coverage, and dependency audits stay in CI / pre-PR script.
 
 ---
 
@@ -224,7 +224,7 @@ Three-way comparison after inheriting patterns from **price-analysis** and **pre
 | pytest integration/slow markers | ✅ | N/A (vitest) | ✅ (markers defined) |
 | pre-commit (Python framework) | ✅ heavy | ✅ Serious-lite | ✅ |
 | shellcheck / actionlint / markdownlint | partial | partial | ✅ repo-lint job + hooks |
-| pre-push quality gate | ❌ | partial (husky) | ✅ `quality-gates --quick` |
+| pre-push essential checks | ❌ | partial (husky) | ✅ `pre-commit --all-files` |
 | Husky + lint-staged | ❌ | ✅ | ❌ (pre-commit instead) |
 | Prettier | ✅ black/isort | ✅ | ❌ (ruff + eslint) |
 | Xenon complexity | ✅ scoped | ❌ | ❌ deferred |
@@ -245,7 +245,7 @@ chore(ci): slice 20 toolchain hardening from reference repos
 
 - Add quality-gates.sh, check_integrity.py, pip-audit.sh, repo-lint.sh, install-git-hooks.sh
 - CI: repo-lint job; coverage 80% on scoped modules; eslint; pip-audit
-- Git hooks: pre-commit + pre-push (quality-gates --quick); shellcheck, actionlint, markdownlint
+- Git hooks: pre-commit + pre-push (essential checks on all files); shellcheck, actionlint, markdownlint
 - Wire .gitleaks.toml, .nvmrc, dependabot, repo hygiene files
 - Upgrade urllib3/starlette/idna/langchain-core; document ML transitive audit ignores
 

--- a/docs/slices/SLICE-20-TOOLCHAIN-HARDENING.md
+++ b/docs/slices/SLICE-20-TOOLCHAIN-HARDENING.md
@@ -33,17 +33,21 @@ Inherit proven hardening patterns from **price-analysis** and **pre-rag-explorer
 | Xenon complexity gates | price-analysis | ❌ — defer until legacy debt warrants scoped gates |
 | Vitest frontend tests | pre-rag | ❌ — separate slice when UI test tier is planned |
 | Torch/transformers major upgrade | pip-audit findings | ❌ — tracked via `scripts/pip-audit.sh` ignores |
+| `scripts/repo-lint.sh` (shellcheck, actionlint, markdownlint) | governance (Serious tier) | ✅ *(2026-05-27 follow-on)* |
+| yamllint / stylelint / markdown “strict” rules | governance | ❌ — `check-yaml` + pragmatic `.markdownlint.json` suffice for now |
 
 ---
 
 ## Acceptance criteria
 
 ### Scripts & local gates
-- [x] `./scripts/quality-gates.sh` passes (mirrors `.github/workflows/ci.yml`)
+- [x] `./scripts/quality-gates.sh` passes (mirrors `.github/workflows/ci.yml`, including repo lint as step 1)
 - [x] `./scripts/quality-gates.sh --full` runs local gitleaks + `pre-commit run --all-files` (default mode already includes `pip-audit.sh`)
+- [x] `bash scripts/repo-lint.sh` passes (shellcheck, actionlint, markdownlint)
 - [x] `python scripts/check_integrity.py` passes (unit tests + import smoke)
 
 ### CI
+- [x] **Repo-lint job:** shellcheck (`scripts/*.sh`) → actionlint (workflows) → markdownlint (`*.md`, `.markdownlint.json`)
 - [x] Backend job: ruff → format check → mypy → **bandit** → pytest + **80% coverage** → `pip-audit.sh`
 - [x] Frontend job: **eslint** → typecheck → build → npm audit (high+)
 - [x] **Secrets job:** gitleaks-action with `.gitleaks.toml`
@@ -53,6 +57,9 @@ Inherit proven hardening patterns from **price-analysis** and **pre-rag-explorer
 - [x] Gitleaks uses `.gitleaks.toml`
 - [x] Frontend eslint hook on `frontend/**/*.{ts,tsx}`
 - [x] Bandit hook (medium+ via `uv run bandit … -ll`, same as CI)
+- [x] Shellcheck on `scripts/*.sh` (`shellcheck-py`)
+- [x] Actionlint on `.github/workflows`
+- [x] Markdownlint on `*.md` (excludes `.claude/`)
 
 ### Coverage scope (baseline-first)
 Measured baseline **83.6%** on:
@@ -91,12 +98,17 @@ Threshold set to **80%** (`--cov-fail-under=80` in CI and quality-gates).
 | `.github/dependabot.yml` | Weekly pip/npm/actions updates |
 | `frontend/.eslintrc.cjs` | ESLint + security plugin |
 | `docs/slices/SLICE-20-TOOLCHAIN-HARDENING.md` | This spec |
+| `scripts/repo-lint.sh` | Shell + workflow + Markdown linters (pre-commit wrappers) |
+| `.markdownlint.json` | Pragmatic Markdown rules for existing docs |
 
 ### Modified
 | File | Change |
 |------|--------|
-| `.github/workflows/ci.yml` | Coverage, eslint, pip-audit, .nvmrc |
-| `.pre-commit-config.yaml` | gitleaks config, frontend lint |
+| `.github/workflows/ci.yml` | Coverage, eslint, pip-audit, .nvmrc; **`repo-lint` job** |
+| `.pre-commit-config.yaml` | gitleaks, frontend lint, **shellcheck / actionlint / markdownlint** |
+| `scripts/quality-gates.sh` | Step 1/11 repo lint; renumbered steps |
+| `scripts/push_tags_incrementally.sh` | Shellcheck quote fix |
+| `scripts/release.sh` | Shellcheck `read -r` |
 | `pyproject.toml` | Coverage config, pytest markers, uv overrides, bandit/pip-audit dev deps |
 | `uv.lock` | Dependency overrides |
 | `frontend/package.json` / `package-lock.json` | eslint-plugin-security |
@@ -111,8 +123,11 @@ Threshold set to **80%** (`--cov-fail-under=80` in CI and quality-gates).
 ## Verification commands
 
 ```bash
-# Primary exit gate
+# Primary exit gate (includes repo lint)
 ./scripts/quality-gates.sh
+
+# Repo lint only (shell + workflows + Markdown)
+bash scripts/repo-lint.sh
 
 # Integrity smoke
 python scripts/check_integrity.py
@@ -125,6 +140,7 @@ python scripts/check_integrity.py
 
 | Gate | Result |
 |------|--------|
+| `bash scripts/repo-lint.sh` | shellcheck + actionlint + markdownlint pass |
 | `ruff check .` | 0 errors |
 | `mypy server/ cli/` | 0 errors |
 | `pytest` | 23 passed, 83.6% scoped coverage |
@@ -156,6 +172,14 @@ python scripts/check_integrity.py
 ### 5. Branch from `main`
 **Decision:** Slice branch targets `main`, not in-flight code-review-graph work.
 **Rationale:** Toolchain hardening is independent; keeps PR reviewable and revertable.
+
+### 6. Pragmatic markdownlint config
+**Decision:** `.markdownlint.json` disables noisy style rules (MD032, MD040, etc.) so legacy docs pass without a mass reformat.
+**Rationale:** Catch structural issues and regressions; tighten rules incrementally if desired.
+
+### 7. shellcheck-py over koalaman/shellcheck-precommit
+**Decision:** Use `shellcheck-py` pre-commit repo (no Docker).
+**Rationale:** `koalaman/shellcheck-precommit` rev failed in CI; pip wheel hook matches Serious tier without Docker.
 
 ---
 
@@ -192,6 +216,7 @@ Three-way comparison after inheriting patterns from **price-analysis** and **pre
 | `check_integrity.py` | ✅ | ❌ | ✅ |
 | pytest integration/slow markers | ✅ | N/A (vitest) | ✅ (markers defined) |
 | pre-commit (Python framework) | ✅ heavy | ✅ Serious-lite | ✅ |
+| shellcheck / actionlint / markdownlint | partial | partial | ✅ repo-lint job + hooks |
 | Husky + lint-staged | ❌ | ✅ | ❌ (pre-commit instead) |
 | Prettier | ✅ black/isort | ✅ | ❌ (ruff + eslint) |
 | Xenon complexity | ✅ scoped | ❌ | ❌ deferred |
@@ -210,9 +235,10 @@ Three-way comparison after inheriting patterns from **price-analysis** and **pre
 ```
 chore(ci): slice 20 toolchain hardening from reference repos
 
-- Add quality-gates.sh, check_integrity.py, pip-audit.sh
-- CI: coverage 80% on scoped modules, eslint, pip-audit; drop pytest exit-5 workaround
-- Wire ESLint+security; .gitleaks.toml, .nvmrc, dependabot, repo hygiene files
+- Add quality-gates.sh, check_integrity.py, pip-audit.sh, repo-lint.sh
+- CI: repo-lint job; coverage 80% on scoped modules; eslint; pip-audit
+- Pre-commit: shellcheck, actionlint, markdownlint; ESLint+security; gitleaks
+- Wire .gitleaks.toml, .nvmrc, dependabot, repo hygiene files
 - Upgrade urllib3/starlette/idna/langchain-core; document ML transitive audit ignores
 
 Refs: price-analysis, pre-rag-explorer-dashboard toolchain patterns

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -13,6 +13,19 @@ fi
 
 pre-commit install --hook-type pre-commit --hook-type pre-push
 
+HOOKS_DIR="$ROOT/.git/hooks"
+missing=()
+for hook in pre-commit pre-push; do
+  if [[ ! -x "$HOOKS_DIR/$hook" ]]; then
+    missing+=("$hook")
+  fi
+done
+if ((${#missing[@]} > 0)); then
+  echo "ERROR: expected executable hooks missing: ${missing[*]}" >&2
+  echo "Re-run from repo root with: bash scripts/install-git-hooks.sh" >&2
+  exit 1
+fi
+
 echo "✅ Git hooks installed:"
 echo "   pre-commit  → essential checks on staged files (hygiene, secrets, lint, types, …)"
 echo "   pre-push    → same essential checks on entire repo (pre-commit run --all-files)"

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Install pre-commit and pre-push hooks (commit checks + quality-gates --quick on push).
+# Install pre-commit and pre-push hooks (essential checks on commit and push).
 set -e
 set -o pipefail
 
@@ -14,7 +14,8 @@ fi
 pre-commit install --hook-type pre-commit --hook-type pre-push
 
 echo "✅ Git hooks installed:"
-echo "   pre-commit  → lint/format on commit (staged files)"
-echo "   pre-push    → ./scripts/quality-gates.sh --quick on every push"
+echo "   pre-commit  → essential checks on staged files (hygiene, secrets, lint, types, …)"
+echo "   pre-push    → same essential checks on entire repo (pre-commit run --all-files)"
 echo ""
+echo "Full CI mirror (pytest, coverage, audits, build): ./scripts/quality-gates.sh"
 echo "Bypass once (emergency only): git push --no-verify"

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Install pre-commit and pre-push hooks (commit checks + quality-gates --quick on push).
+set -e
+set -o pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if ! command -v pre-commit >/dev/null 2>&1; then
+  echo "pre-commit not found. Run: uv pip install -e \".[dev]\"" >&2
+  exit 1
+fi
+
+pre-commit install --hook-type pre-commit --hook-type pre-push
+
+echo "✅ Git hooks installed:"
+echo "   pre-commit  → lint/format on commit (staged files)"
+echo "   pre-push    → ./scripts/quality-gates.sh --quick on every push"
+echo ""
+echo "Bypass once (emergency only): git push --no-verify"

--- a/scripts/push_tags_incrementally.sh
+++ b/scripts/push_tags_incrementally.sh
@@ -106,7 +106,7 @@ for TAG_INFO in "${TAGS[@]}"; do
     echo "✅ Completed $TAG"
 
     # Pause between releases (except for the last one)
-    if [ $COUNT -lt $TOTAL ]; then
+    if [ "$COUNT" -lt "$TOTAL" ]; then
         echo ""
         read -p "Continue to next release? (y/N): " -n 1 -r
         echo

--- a/scripts/quality-gates.sh
+++ b/scripts/quality-gates.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Run all quality gates — mirrors .github/workflows/ci.yml exactly.
+# Run all quality gates — mirrors .github/workflows/ci.yml (repo-lint + backend + frontend + audits).
 # Usage:
 #   ./scripts/quality-gates.sh          # full CI mirror (default)
 #   ./scripts/quality-gates.sh --quick  # lint + typecheck + unit tests only
@@ -21,38 +21,42 @@ fi
 echo "=== Quality Gates (rag-params-finder) ==="
 
 echo ""
-echo "1/8 Backend lint (ruff)..."
+echo "1/11 Repo lint (shellcheck, actionlint, markdownlint)..."
+bash scripts/repo-lint.sh
+
+echo ""
+echo "2/11 Backend lint (ruff)..."
 uv run ruff check .
 
 echo ""
-echo "2/8 Backend format (ruff)..."
+echo "3/11 Backend format (ruff)..."
 uv run ruff format --check .
 
 echo ""
-echo "3/8 Backend type check (mypy)..."
+echo "4/11 Backend type check (mypy)..."
 uv run mypy server/ cli/
 
 echo ""
-echo "4/8 Backend SAST (bandit, medium+ severity)..."
+echo "5/11 Backend SAST (bandit, medium+ severity)..."
 uv run bandit -c pyproject.toml -r server/ cli/ -q -ll
 
 if [[ "${MODE}" == "quick" ]]; then
   echo ""
-  echo "5/8 Backend unit tests (no coverage)..."
+  echo "6/11 Backend unit tests (no coverage)..."
   uv run pytest --tb=short -q -m "not integration"
   echo ""
-  echo "6/8 Frontend lint (eslint)..."
+  echo "7/11 Frontend lint (eslint)..."
   npm --prefix frontend run lint
   echo ""
-  echo "7/8 Frontend typecheck..."
+  echo "8/11 Frontend typecheck..."
   npm --prefix frontend run typecheck
   echo ""
-  echo "✅ Quick quality gates passed (coverage, pip-audit, npm audit, build skipped)."
+  echo "✅ Quick quality gates passed (repo lint + lint/typecheck/tests; coverage, pip-audit, npm audit, build skipped)."
   exit 0
 fi
 
 echo ""
-echo "5/8 Backend tests + coverage..."
+echo "6/11 Backend tests + coverage..."
 uv run pytest --tb=short -q --cov=server.core.search_index_plan \
   --cov=server.core.search_index_guard \
   --cov=server.core.results_analyzer \
@@ -61,22 +65,22 @@ uv run pytest --tb=short -q --cov=server.core.search_index_plan \
   --cov-fail-under=80
 
 echo ""
-echo "6/8 Python dependency audit (pip-audit)..."
+echo "7/11 Python dependency audit (pip-audit)..."
 bash scripts/pip-audit.sh
 
 echo ""
-echo "7/8 Frontend lint + typecheck + build..."
+echo "8/11 Frontend lint + typecheck + build..."
 npm --prefix frontend run lint
 npm --prefix frontend run typecheck
 npm --prefix frontend run build
 
 echo ""
-echo "8/8 Frontend security audit..."
+echo "9/11 Frontend security audit..."
 npm --prefix frontend audit --audit-level=high
 
 if [[ "${MODE}" == "full" ]]; then
   echo ""
-  echo "9/9 Full: gitleaks (with .gitleaks.toml)..."
+  echo "10/11 Full: gitleaks (with .gitleaks.toml)..."
   if command -v gitleaks >/dev/null 2>&1; then
     gitleaks detect --config .gitleaks.toml --source . --verbose --no-git
   else
@@ -84,7 +88,7 @@ if [[ "${MODE}" == "full" ]]; then
   fi
 
   echo ""
-  echo "10/10 Full: pre-commit all files..."
+  echo "11/11 Full: pre-commit all files..."
   if command -v pre-commit >/dev/null 2>&1; then
     pre-commit run --all-files
   else

--- a/scripts/quality-gates.sh
+++ b/scripts/quality-gates.sh
@@ -2,7 +2,7 @@
 # Run all quality gates — mirrors .github/workflows/ci.yml (repo-lint + backend + frontend + audits).
 # Usage:
 #   ./scripts/quality-gates.sh          # full CI mirror (default)
-#   ./scripts/quality-gates.sh --quick  # lint + typecheck + unit tests only
+#   ./scripts/quality-gates.sh --quick  # also runs on git push via pre-push hook (install-git-hooks.sh)
 #   ./scripts/quality-gates.sh --full   # CI mirror + local gitleaks + pre-commit all-files
 
 set -e

--- a/scripts/quality-gates.sh
+++ b/scripts/quality-gates.sh
@@ -2,7 +2,7 @@
 # Run all quality gates — mirrors .github/workflows/ci.yml (repo-lint + backend + frontend + audits).
 # Usage:
 #   ./scripts/quality-gates.sh          # full CI mirror (default)
-#   ./scripts/quality-gates.sh --quick  # also runs on git push via pre-push hook (install-git-hooks.sh)
+#   ./scripts/quality-gates.sh --quick  # manual fast check (not run on git push; push uses pre-commit --all-files)
 #   ./scripts/quality-gates.sh --full   # CI mirror + local gitleaks + pre-commit all-files
 
 set -e

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -48,7 +48,7 @@ echo "### Fixed"
 echo "- "
 echo ""
 echo "Press ENTER when you've updated CHANGELOG.md..."
-read
+read -r
 
 # 5. Extract changelog for this version (between this version and next section)
 CHANGELOG_EXCERPT=$(awk "/^## \[$NEW_VERSION\]/,/^## \[/" CHANGELOG.md | head -n -1)

--- a/scripts/repo-lint.sh
+++ b/scripts/repo-lint.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Repo-wide linters (shell, GitHub Actions, Markdown) — same hooks as pre-commit / CI.
+set -e
+set -o pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+run_precommit_hook() {
+  local hook_id="$1"
+  if command -v pre-commit >/dev/null 2>&1; then
+    pre-commit run "$hook_id" --all-files
+  elif uv run pre-commit run "$hook_id" --all-files 2>/dev/null; then
+    :
+  else
+    echo "pre-commit is required for repo lint (uv pip install -e \".[dev]\")" >&2
+    exit 1
+  fi
+}
+
+echo "=== Repo lint (shellcheck, actionlint, markdownlint) ==="
+
+echo ""
+echo "Shellcheck (scripts/*.sh)..."
+run_precommit_hook shellcheck
+
+echo ""
+echo "Actionlint (.github/workflows)..."
+run_precommit_hook actionlint
+
+echo ""
+echo "Markdownlint (*.md)..."
+run_precommit_hook markdownlint
+
+echo ""
+echo "✅ Repo lint passed."


### PR DESCRIPTION
Wire shellcheck, actionlint, and markdownlint into pre-commit, CI repo-lint job, and quality-gates step 1 so shell scripts, workflows, and Markdown stay checked locally and in CI. Update slice specs and contributor docs to reference the unified gate stack.