### PR TITLE
docs: reorganize navigation like playgroup — QUICKSTART, doc map, PROGRESS in slices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,10 @@ Agent session entry point for `rag-params-finder`.
 ## Start here
 
 1. Read [`CLAUDE.md`](CLAUDE.md) — project overview, architecture, commands, quality gates, and slice playbook.
-2. Read [`docs/_internal/PROGRESS.md`](docs/_internal/PROGRESS.md) — current slice status, forward roadmap, and interrupt recovery checklist.
-3. If continuing a slice: read the slice spec in [`docs/slices/`](docs/slices/).
-4. If starting a new slice: check the forward roadmap in `docs/_internal/PROGRESS.md` and create a spec before writing code.
+2. Read [`docs/README.md`](docs/README.md) — documentation map by persona and topic.
+3. Read [`docs/slices/PROGRESS.md`](docs/slices/PROGRESS.md) — current slice status, forward roadmap, and interrupt recovery checklist.
+4. If continuing a slice: read the slice spec in [`docs/slices/`](docs/slices/).
+5. If starting a new slice: check the forward roadmap in `docs/slices/PROGRESS.md` and create a spec before writing code.
 
 ## Key rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,24 +13,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Documentation navigation** — root [QUICKSTART.md](QUICKSTART.md), [docs/README.md](docs/README.md) persona index; slice tracker at [docs/slices/PROGRESS.md](docs/slices/PROGRESS.md)
 - **Slice 14 Docker Compose** — `./start-services.sh`, `stop-services.sh`, `setup.sh`; `docker-compose.yml` + `docker-compose.dev.yml`; server/frontend Dockerfiles; `/healthz` MongoDB ping; `scripts/health-check.sh`
 - **Contributor docs:** Optional `code-review-graph` MCP guidance in [Development Guide](docs/contributor-guide/development.md) and README Contributing section (not required for end users)
 - **Agent docs:** Graph-first exploration workflow in [AGENTS.md](AGENTS.md) and [CLAUDE.md](CLAUDE.md)
 - **Slice 20 toolchain hardening** — unified `./scripts/quality-gates.sh` mirroring CI; `check_integrity.py`, `pip-audit.sh`
 - **CI:** scoped 80% coverage gate, ESLint, bandit SAST, pip-audit, gitleaks secrets scan job
 - **Repo lint:** shellcheck (`scripts/*.sh`), actionlint (GitHub Actions), markdownlint (`.markdownlint.json`) in pre-commit, `scripts/repo-lint.sh`, and CI `repo-lint` job
-- **Pre-push hook:** same essential pre-commit checks on every `git push` (`pre-commit run --all-files` via `install-git-hooks.sh`)
+- **Pre-push hook:** fast gates on every `git push` (`scripts/pre-push-gates.sh` → `quality-gates.sh --quick`: pytest, frontend verify, gitleaks; via `install-git-hooks.sh`)
 - **Repo hygiene:** `.gitleaks.toml`, `.nvmrc`, `.editorconfig`, `.gitattributes`, Dependabot
 - **Frontend:** ESLint + `eslint-plugin-security` wired in CI and pre-commit
 
 ### Changed
 
+- **Pre-push hook** (2026-05-28): replaced `pre-commit run --all-files` on push with `quality-gates.sh --quick` so push runs pytest and frontend verify, not only lint hooks
 - Upgraded urllib3, starlette, idna, langchain-core via uv dependency overrides
 - Pre-commit: gitleaks config, frontend lint hook, bandit hook (`uv run bandit … -ll`, aligned with CI)
 
 ### Fixed
 
+- **Frontend:** pin `@rollup/rollup-darwin-arm64` and `@rollup/rollup-darwin-x64` optional deps so `vite build` works on Apple Silicon and Rosetta x64 Node
 - CI: read Node version from repo-root `.nvmrc` (`setup-node` resolves paths from checkout root, not `frontend/` working directory)
+- CI: `astral-sh/setup-uv` v4 → v7 (Dependabot)
 - CLI: `httpx.Client(timeout=…)` default timeout on constructor (SAST/runtime parity)
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,7 +217,7 @@ cd frontend && npm run lint && npm run typecheck && npm run build
 **Backend** (2026-05-27):
 - `ruff check .` → 0 errors
 - `mypy server/ cli/` → 0 errors
-- `pytest` → 23 tests, 83.6% coverage on scoped modules (80% threshold)
+- `pytest` → 26 tests, 83.6% coverage on scoped modules (80% threshold)
 
 **Frontend** (2026-05-27):
 - `npm run lint` → 0 errors (eslint + security plugin)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Agent guidance for `rag-params-finder`. Start with `AGENTS.md` → this file → `docs/_internal/PROGRESS.md`.
+Agent guidance for `rag-params-finder`. Start with `AGENTS.md` → this file → `docs/README.md` → `docs/slices/PROGRESS.md`.
 
 ## Project Overview
 
@@ -162,7 +162,7 @@ Provider/model must match — registry in `model_registry.py` validates at confi
 
 ### Pre-slice checklist
 ```
-[ ] Read docs/_internal/PROGRESS.md — confirm current state and which slice is next
+[ ] Read docs/slices/PROGRESS.md — confirm current state and which slice is next
 [ ] Read or create the slice spec in docs/slices/SLICE-XX-*.md
 [ ] bash scripts/install-git-hooks.sh (once per machine — commit + pre-push checks)
 [ ] Run all quality gates — confirm zero regressions before starting
@@ -170,7 +170,7 @@ Provider/model must match — registry in `model_registry.py` validates at confi
 ```
 
 ### Decision log template
-Record every non-obvious choice in `docs/_internal/PROGRESS.md` → Decision Log:
+Record every non-obvious choice in `docs/slices/PROGRESS.md` → Decision Log:
 ```
 | <date> | <slice> | <decision> | <why> |
 ```
@@ -196,7 +196,7 @@ cd frontend && npm run lint && npm run typecheck && npm run build
 ```
 [ ] All acceptance criteria checked ✅
 [ ] Quality gates pass (zero regressions) — ./scripts/quality-gates.sh; git push runs pre-push-gates when hooks installed
-[ ] Slice status updated in docs/_internal/PROGRESS.md (🔨 → ✅ COMPLETE)
+[ ] Slice status updated in docs/slices/PROGRESS.md (🔨 → ✅ COMPLETE)
 [ ] Decisions logged in PROGRESS.md Decision Log
 [ ] Committed with a short, specific message
 [ ] Consider release: ./scripts/release.sh minor (slices/features) or patch (fixes/polish)
@@ -253,7 +253,8 @@ The project follows [Semantic Versioning](https://semver.org/). Release automati
 | `docs/contributor-guide/extending.md` | Contributors | Adding models, chunkers, endpoints |
 | `docs/contributor-guide/development.md` | Contributors | Dev loop, quality gates |
 | `docs/contributor-guide/release-process.md` | Contributors | Creating releases, versioning strategy |
-| `docs/_internal/PROGRESS.md` | Agents | Slice status, decision log, roadmap |
+| `docs/slices/PROGRESS.md` | Agents | Slice status, decision log, roadmap |
+| `docs/README.md` | All | Documentation index (personas, topics, tasks) |
 | `docs/adr/` | All | Architecture Decision Records |
 
 <!-- code-review-graph MCP tools -->

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,53 @@
+# Quickstart
+
+> Once setup is done, head to the [README](README.md) for features, documentation paths, and contributing.
+
+---
+
+## 🚀 Quick Start
+
+**Prerequisites:** Python 3.12+, Node.js 22+, [MongoDB Atlas account](docs/user-guide/cloud-setup.md#mongodb-atlas-required) (free tier). [Voyage AI](docs/user-guide/cloud-setup.md#voyage-ai-optional) optional for local-only sweeps.
+
+```bash
+# Clone and install
+git clone https://github.com/neomatrix369/rag-params-finder.git
+cd rag-params-finder
+uv venv && source .venv/bin/activate
+uv pip install -e .
+cd frontend && npm install && cd ..
+
+# Configure — see docs/user-guide/cloud-setup.md for minimal Atlas + Voyage checklist
+cp .env.example .env
+
+# Start
+uvicorn server.main:app --reload --port 8001   # Terminal 1
+cd frontend && npm run dev                      # Terminal 2 (optional)
+
+# Sweeps — complete cloud-setup.md checklist first
+rag-params-finder run --config configs/example-mongodb-local.yaml   # 120 runs, no API key
+rag-params-finder run --config configs/example-mongodb-voyage.yaml  # 40 runs, Voyage + Tier 1
+```
+
+Open `http://localhost:5173` to watch live progress and explore results.
+
+### Docker Quick Start (optional)
+
+**Prerequisites:** [Docker Desktop](https://www.docker.com/products/docker-desktop/), MongoDB Atlas configured ([cloud-setup](docs/user-guide/cloud-setup.md)). Install the CLI on the host (`uv pip install -e .`).
+
+```bash
+cp .env.example .env   # set MONGODB_URI (and VOYAGE_API_KEY if needed)
+./start-services.sh    # server :8001 + dashboard :5173
+
+# Submit sweeps from the host (CLI is not containerized)
+rag-params-finder run --config configs/example-mongodb-local.yaml
+```
+
+Dev hot reload: `docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build`. Details: [Slice 14 spec](docs/slices/SLICE-14-DOCKER-COMPOSE.md) · [Development Guide → Docker](docs/contributor-guide/development.md#-docker-compose).
+
+---
+
+## Next steps
+
+- **First experiment walkthrough:** [Getting Started](docs/user-guide/getting-started.md)
+- **Full documentation map:** [docs/README.md](docs/README.md)
+- **Choose your path (lookup table):** [README → Choose Your Path](README.md#-choose-your-path)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ model × chunking method × retrieval method — stores the retrieval scores and
 shows you exactly which configuration performs best.
 **Before you write a single line of your RAG application.**
 
+**Jump to:** [Quickstart](QUICKSTART.md) | [Who is this for?](#who-is-this-for) | [Screenshots](#-screenshots) | [Key Features](#-key-features) | [Documentation](docs/README.md) | [Contributing](#-contributing)
+
 ## Why this matters
 
 | What you avoid | What you get instead |
@@ -48,6 +50,23 @@ shows you exactly which configuration performs best.
 
 One YAML. N experiments. Evidence-based decision. Ship the right config first.
 
+## Who is this for?
+
+> Pick the row that matches you — each links to a **first step**, not the whole README.
+
+| Persona | Start here | What you will do |
+|---------|------------|------------------|
+| **New user — cloud accounts** | [Cloud Account Setup](docs/user-guide/cloud-setup.md) | Atlas + optional Voyage, then [QUICKSTART](QUICKSTART.md) |
+| **New user — first sweep** | [QUICKSTART](QUICKSTART.md) | Install, run server + CLI, open dashboard |
+| **Operator — config & CLI** | [Configuration Reference](docs/user-guide/configuration.md) | YAML sweeps, env vars, `rag-params-finder` commands |
+| **Operator — dashboard** | [Dashboard Guide](docs/user-guide/dashboard-guide.md) | Live phases, Search Explorer, experiment controls |
+| **Operator — fixing errors** | [Troubleshooting](docs/user-guide/troubleshooting.md) | Indexes, Voyage limits, Docker, storage quota |
+| **Contributor — system design** | [Architecture](docs/contributor-guide/architecture.md) | Modules, data flow, ADRs |
+| **Contributor — dev setup** | [Development Guide](docs/contributor-guide/development.md) | Quality gates, slices, Docker, hooks |
+| **Agent / slice worker** | [AGENTS.md](AGENTS.md) · [CLAUDE.md](CLAUDE.md) | [PROGRESS](docs/slices/PROGRESS.md) → current slice spec |
+
+**All docs by topic:** [docs/README.md](docs/README.md)
+
 ---
 
 ## 📸 Screenshots
@@ -62,43 +81,7 @@ One YAML. N experiments. Evidence-based decision. Ship the right config first.
 
 ## 🚀 Quick Start
 
-**Prerequisites:** Python 3.12+, Node.js 22+, [MongoDB Atlas account](docs/user-guide/cloud-setup.md#mongodb-atlas-required) (free tier). [Voyage AI](docs/user-guide/cloud-setup.md#voyage-ai-optional) optional for local-only sweeps.
-
-```bash
-# Clone and install
-git clone https://github.com/neomatrix369/rag-params-finder.git
-cd rag-params-finder
-uv venv && source .venv/bin/activate
-uv pip install -e .
-cd frontend && npm install && cd ..
-
-# Configure — see docs/user-guide/cloud-setup.md for minimal Atlas + Voyage checklist
-cp .env.example .env
-
-# Start
-uvicorn server.main:app --reload --port 8001   # Terminal 1
-cd frontend && npm run dev                      # Terminal 2 (optional)
-
-# Sweeps — complete cloud-setup.md checklist first
-rag-params-finder run --config configs/example-mongodb-local.yaml   # 120 runs, no API key
-rag-params-finder run --config configs/example-mongodb-voyage.yaml  # 40 runs, Voyage + Tier 1
-```
-
-Open `http://localhost:5173` to watch live progress and explore results.
-
-### Docker Quick Start (optional)
-
-**Prerequisites:** [Docker Desktop](https://www.docker.com/products/docker-desktop/), MongoDB Atlas configured ([cloud-setup](docs/user-guide/cloud-setup.md)). Install the CLI on the host (`uv pip install -e .`).
-
-```bash
-cp .env.example .env   # set MONGODB_URI (and VOYAGE_API_KEY if needed)
-./start-services.sh    # server :8001 + dashboard :5173
-
-# Submit sweeps from the host (CLI is not containerized)
-rag-params-finder run --config configs/example-mongodb-local.yaml
-```
-
-Dev hot reload: `docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build`. Details: [Slice 14 spec](docs/slices/SLICE-14-DOCKER-COMPOSE.md) · [Development Guide → Docker](docs/contributor-guide/development.md#-docker-compose).
+See **[QUICKSTART.md](QUICKSTART.md)** for install, `.env`, server, dashboard, and first sweep commands (including optional Docker).
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,86 @@
+# Documentation index
+
+All guides for **rag-params-finder**, organized by **who you are** and **what you want to do**.
+
+**Repo entry:** [README.md](../README.md) · **Fastest run:** [QUICKSTART.md](../QUICKSTART.md)
+
+> **Who is this for?** Same personas as [README → Who is this for?](../README.md#who-is-this-for) — this page is the **doc map**; the README is the project entry.
+
+---
+
+## Who is this for?
+
+| Persona | Start here | Then |
+|---------|------------|------|
+| **New user — cloud accounts** | [user-guide/cloud-setup.md](./user-guide/cloud-setup.md) | [QUICKSTART.md](../QUICKSTART.md) → [user-guide/getting-started.md](./user-guide/getting-started.md) |
+| **New user — first sweep** | [QUICKSTART.md](../QUICKSTART.md) | [user-guide/getting-started.md](./user-guide/getting-started.md) → dashboard at `http://localhost:5173` |
+| **Operator — config & CLI** | [user-guide/configuration.md](./user-guide/configuration.md) | [user-guide/cli-reference.md](./user-guide/cli-reference.md) |
+| **Operator — dashboard** | [user-guide/dashboard-guide.md](./user-guide/dashboard-guide.md) | [user-guide/configuration.md](./user-guide/configuration.md) (tiebreaker, env vars) |
+| **Operator — fixing errors** | [user-guide/troubleshooting.md](./user-guide/troubleshooting.md) | [user-guide/cloud-setup.md](./user-guide/cloud-setup.md) (indexes, Voyage tiers) |
+| **Contributor — system design** | [contributor-guide/architecture.md](./contributor-guide/architecture.md) | [adr/](./adr/) |
+| **Contributor — extending** | [contributor-guide/extending.md](./contributor-guide/extending.md) | [contributor-guide/development.md](./contributor-guide/development.md) |
+| **Contributor — dev environment** | [contributor-guide/development.md](./contributor-guide/development.md) | [slices/PROGRESS.md](./slices/PROGRESS.md) · [slices/](./slices/) specs |
+| **Agent / slice worker** | [AGENTS.md](../AGENTS.md) · [CLAUDE.md](../CLAUDE.md) | [slices/PROGRESS.md](./slices/PROGRESS.md) → current `SLICE-XX-*.md` |
+
+---
+
+## User guide
+
+| Doc | What it covers |
+|-----|----------------|
+| [user-guide/cloud-setup.md](./user-guide/cloud-setup.md) | MongoDB Atlas + optional Voyage AI accounts, search indexes |
+| [user-guide/getting-started.md](./user-guide/getting-started.md) | Install, configure, first experiment (step-by-step) |
+| [user-guide/configuration.md](./user-guide/configuration.md) | Full YAML config reference, env vars, sweep dimensions |
+| [user-guide/cli-reference.md](./user-guide/cli-reference.md) | All CLI commands (`run`, `pause`, `resume`, `delete`, `indexes`, …) |
+| [user-guide/dashboard-guide.md](./user-guide/dashboard-guide.md) | Experiments list, detail, Search Explorer |
+| [user-guide/troubleshooting.md](./user-guide/troubleshooting.md) | Common errors, Docker, index preflight, storage quota |
+
+---
+
+## Contributor guide
+
+| Doc | What it covers |
+|-----|----------------|
+| [contributor-guide/architecture.md](./contributor-guide/architecture.md) | Two-process design, modules, data flow, collections |
+| [contributor-guide/development.md](./contributor-guide/development.md) | Dev loop, quality gates, Docker, slice playbook |
+| [contributor-guide/extending.md](./contributor-guide/extending.md) | New models, chunkers, retrieval methods, API endpoints |
+| [contributor-guide/release-process.md](./contributor-guide/release-process.md) | Versioning, `scripts/release.sh`, CHANGELOG |
+| [contributor-guide/local-environment.md](./contributor-guide/local-environment.md) | Private/machine-specific Atlas and Voyage notes |
+
+---
+
+## Architecture decisions & slices
+
+| Doc | What it covers |
+|-----|----------------|
+| [adr/ADR-001-two-process-architecture.md](./adr/ADR-001-two-process-architecture.md) | CLI + server separation |
+| [adr/ADR-002-voyage-and-local-providers.md](./adr/ADR-002-voyage-and-local-providers.md) | Dual embedding/rerank providers |
+| [adr/ADR-003-mongodb-atlas-vector-store.md](./adr/ADR-003-mongodb-atlas-vector-store.md) | MongoDB Atlas as vector store |
+| [slices/PROGRESS.md](./slices/PROGRESS.md) | Slice status, decision log, forward roadmap |
+| [slices/SLICE-*.md](./slices/) | Per-slice specs (acceptance criteria, verification) |
+
+---
+
+## Maintainer / internal
+
+| Doc | What it covers |
+|-----|----------------|
+| [_internal/DOC-GAPS.md](./_internal/DOC-GAPS.md) | Documentation gap tracker |
+| [_internal/DOCS-CODE-AUDIT.md](./_internal/DOCS-CODE-AUDIT.md) | Docs vs code audit |
+| [_internal/DOCS-CODE-AUDIT-FIXES.md](./_internal/DOCS-CODE-AUDIT-FIXES.md) | Audit remediation log |
+| [_internal/TIEBREAKER-EXPLANATION-FEATURE.md](./_internal/TIEBREAKER-EXPLANATION-FEATURE.md) | Tiebreaker UI feature notes |
+| [_internal/GRAPHITI-EXPORT-SLICE-1.md](./_internal/GRAPHITI-EXPORT-SLICE-1.md) | Graphiti export notes |
+| [ARCHITECTURE.md](./ARCHITECTURE.md) | Redirect stub → contributor-guide/architecture.md |
+
+---
+
+## Common tasks → doc
+
+| Task | Doc / command |
+|------|----------------|
+| Install and run first sweep | [QUICKSTART.md](../QUICKSTART.md) |
+| Atlas vector + text search indexes | [user-guide/cloud-setup.md](./user-guide/cloud-setup.md) |
+| Example YAML configs | `configs/example-mongodb-local.yaml`, `configs/example-mongodb-voyage.yaml` |
+| Quality gates before commit | [contributor-guide/development.md](./contributor-guide/development.md) · `./scripts/quality-gates.sh` |
+| Docker server + dashboard | [slices/SLICE-14-DOCKER-COMPOSE.md](./slices/SLICE-14-DOCKER-COMPOSE.md) |
+| Continue an in-flight slice | [slices/PROGRESS.md](./slices/PROGRESS.md) + matching `slices/SLICE-XX-*.md` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,8 @@ All guides for **rag-params-finder**, organized by **who you are** and **what yo
 
 **Repo entry:** [README.md](../README.md) · **Fastest run:** [QUICKSTART.md](../QUICKSTART.md)
 
+**Maintainers:** slice status and decision log live in [slices/PROGRESS.md](./slices/PROGRESS.md) (updated 2026-05-28 for doc nav, pre-push fast gates, 26 tests).
+
 > **Who is this for?** Same personas as [README → Who is this for?](../README.md#who-is-this-for) — this page is the **doc map**; the README is the project entry.
 
 ---

--- a/docs/_internal/DOC-GAPS.md
+++ b/docs/_internal/DOC-GAPS.md
@@ -1,7 +1,7 @@
 # Documentation Gap Tracker
 
 **Created**: 2026-05-05
-**Last Updated**: 2026-05-27 (baselines refreshed after Slice 20 + repo lint; gaps 7–8 notes superseded)
+**Last Updated**: 2026-05-28 (doc nav + pre-push fast gates + 26 tests)
 **Reference**: Gap analysis vs [pre-rag-explorer-dashboard](https://github.com/neomatrix369/pre-rag-explorer-dashboard)
 
 Each item below is a concrete, actionable doc gap. Check the box when done and record the date.
@@ -80,7 +80,7 @@ Each item below is a concrete, actionable doc gap. Check the box when done and r
 
 **Reference**: pre-rag has a standalone spec file per slice (`SLICE-07-SLIDING-WINDOW.md`, etc.).
 
-**2026-05-27 supplement:** All slice specs link to `./scripts/quality-gates.sh` / [`development.md`](../contributor-guide/development.md); Slice 20 documents repo lint + `scripts/install-git-hooks.sh` (essential pre-commit checks on commit and push).
+**2026-05-28 supplement:** All slice specs link to `./scripts/quality-gates.sh` / [`development.md`](../contributor-guide/development.md); Slice 20 documents repo lint + `install-git-hooks.sh` (staged pre-commit on commit; `pre-push-gates.sh` on push).
 
 ---
 
@@ -104,7 +104,7 @@ Each item below is a concrete, actionable doc gap. Check the box when done and r
   - [x] `bash scripts/repo-lint.sh` → shellcheck + actionlint + markdownlint pass
   - [x] `ruff check .` → 0 errors
   - [x] `mypy server/ cli/` → 0 errors
-  - [x] `pytest` → **23 tests** (2026-05-27): 17 search-index + 3 sweep + 3 tiebreaker; 80% coverage on 4 scoped modules
+  - [x] `pytest` → **26 tests** (2026-05-28): 17 search-index + 3 sweep + 3 tiebreaker + 3 health; 80% coverage on 4 scoped modules
   - [x] `npm run lint` → 0 errors (ESLint + security plugin, Slice 20)
   - [x] `npm run typecheck` → 0 errors
   - [x] `npm run build` → ~4 s, 49 modules
@@ -120,9 +120,9 @@ Each item below is a concrete, actionable doc gap. Check the box when done and r
 
 - [x] Add `.github/workflows/ci.yml` — repo-lint: shellcheck + actionlint + markdownlint; backend: ruff + format + mypy + bandit + pytest/coverage + pip-audit; frontend: eslint + tsc + build + npm audit; secrets: gitleaks
 - [x] CI documented in `CLAUDE.md`, `development.md`, Slice 20 spec
-- [x] Pre-push hook: essential pre-commit checks on every `git push` (`pre-commit run --all-files`)
+- [x] Pre-push hook: fast gates on every `git push` (`./scripts/pre-push-gates.sh` → `quality-gates.sh --quick`)
 
-**Superseded note (2026-05-27):** ESLint is wired (`frontend/.eslintrc.cjs`). Use `./scripts/quality-gates.sh` for full local/CI parity; `git push` runs essential pre-commit hooks when installed.
+**Note (2026-05-28):** ESLint is wired (`frontend/.eslintrc.cjs`). Use `./scripts/quality-gates.sh` for full local/CI parity before a PR; `git push` runs `--quick` when hooks are installed.
 
 **Reference**: pre-rag's Slice 1 established CI as a first-class deliverable; Slice 20 hardened to Serious tier.
 
@@ -132,7 +132,7 @@ Each item below is a concrete, actionable doc gap. Check the box when done and r
 
 **Priority**: Low (nice-to-have for agent session consistency)
 
-- [x] Add `AGENTS.md` (thin file) — entry point with links to `CLAUDE.md`, `PROGRESS.md`, and quick commands
+- [x] Add `AGENTS.md` (thin file) — entry point with links to `CLAUDE.md`, `docs/slices/PROGRESS.md`, and quick commands
 - [x] Add **slice execution playbook** block to `CLAUDE.md`:
   - [x] Pre-slice checklist (read PROGRESS, create/read spec, run quality gates)
   - [x] Verify-all commands before commit
@@ -155,8 +155,22 @@ Each item below is a concrete, actionable doc gap. Check the box when done and r
 | 8 | CI story (GitHub Actions) | ✅ Done |
 | 9 | AGENTS.md + slice playbook | ✅ Done |
 | 10 | README simplified; detail preserved in Reference Guide | ✅ Done |
+| 11 | Doc navigation (QUICKSTART + docs/README + PROGRESS in slices/) | ✅ Done (2026-05-28) |
 
 **Legend**: 📋 Open | 🔨 In Progress | ✅ Done
+
+---
+
+## Gap 11 — Documentation navigation (playgroup-style)
+
+**Priority**: Medium (onboarding + agent session entry)
+
+- [x] Root [QUICKSTART.md](../QUICKSTART.md) for fastest install/run path
+- [x] [docs/README.md](../README.md) persona + task index
+- [x] [docs/slices/PROGRESS.md](../slices/PROGRESS.md) beside slice specs (moved from `docs/_internal/`)
+- [x] README, AGENTS.md, CLAUDE.md, getting-started cross-links updated
+
+**Reference:** commit `86f2e61` — playgroup-style doc map without duplicating guide bodies.
 
 ---
 

--- a/docs/_internal/DOCS-CODE-AUDIT.md
+++ b/docs/_internal/DOCS-CODE-AUDIT.md
@@ -1,6 +1,6 @@
 # Documentation vs Code Audit
 
-**Audit date**: 2026-05-23 (full pass) · **Supplement**: 2026-05-27 (Slice 20 + repo lint + test counts)
+**Audit date**: 2026-05-23 (full pass) · **Supplements**: 2026-05-27 (Slice 20 + repo lint) · 2026-05-28 (doc nav + pre-push + test count)
 **Auditor**: Claude (automated verification)
 **Scope**: README.md, user guides, contributor guides, code implementation
 
@@ -16,8 +16,9 @@
 |------|--------|
 | `quality-gates.sh` ↔ `ci.yml` | ✅ Aligned (repo-lint, bandit, coverage, pip-audit, eslint, gitleaks) |
 | `repo-lint.sh` ↔ pre-commit hooks | ✅ shellcheck, actionlint, markdownlint (same revs via pre-commit) |
-| pre-commit `--all-files` ↔ pre-push hook | ✅ same essential hooks as commit; `install-git-hooks.sh` |
-| Test count in contributor docs | ✅ **23** pytest tests (was incorrectly cited as 39 in PROGRESS) |
+| pre-push hook ↔ `pre-push-gates.sh` | ✅ `quality-gates.sh --quick` (pytest + frontend verify + gitleaks); not `pre-commit --all-files` |
+| Test count in contributor docs | ✅ **26** pytest tests (17 search-index + 3 sweep + 3 tiebreaker + 3 health; was 39, then 23) |
+| Doc entry points | ✅ `QUICKSTART.md`, `docs/README.md`, `docs/slices/PROGRESS.md` (2026-05-28 nav reorg) |
 | Kimchi provider | ⚠️ `Provider` type includes `kimchi`; embedder/registry on `tessl-hackathon-kimchi-integration` branch only — not on main |
 | `development.md` testing section | ✅ Updated (was "no suite yet") |
 

--- a/docs/contributor-guide/development.md
+++ b/docs/contributor-guide/development.md
@@ -270,8 +270,9 @@ rag-params-finder/
 │   ├── user-guide/      # End-user documentation
 │   ├── contributor-guide/ # This directory
 │   ├── adr/             # Architecture Decision Records
-│   ├── slices/          # Slice specs (dev-internal)
-│   └── _internal/       # Dev log, gap tracker, Graphiti exports
+│   ├── slices/          # Slice specs + PROGRESS.md (status, roadmap)
+│   ├── _internal/       # Gap tracker, audits, Graphiti exports
+│   └── README.md        # Documentation index (doc map)
 └── .github/workflows/   # CI (see § CI — repo-lint, backend, frontend, secrets)
 ```
 
@@ -282,7 +283,7 @@ rag-params-finder/
 ### Pre-slice checklist
 
 ```
-[ ] Read docs/_internal/PROGRESS.md — confirm current state and which slice is next
+[ ] Read docs/slices/PROGRESS.md — confirm current state and which slice is next
 [ ] Read or create the slice spec in docs/slices/SLICE-XX-*.md
 [ ] bash scripts/install-git-hooks.sh (once per machine if not already installed)
 [ ] Run all quality gates — confirm zero regressions before starting
@@ -291,7 +292,7 @@ rag-params-finder/
 
 ### Decision log template
 
-Record every non-obvious choice in `docs/_internal/PROGRESS.md` → Decision Log:
+Record every non-obvious choice in `docs/slices/PROGRESS.md` → Decision Log:
 
 ```
 | <date> | <slice> | <decision> | <why> |
@@ -302,11 +303,11 @@ Record every non-obvious choice in `docs/_internal/PROGRESS.md` → Decision Log
 ```
 [ ] All acceptance criteria checked ✅
 [ ] Quality gates pass — ./scripts/quality-gates.sh; git push exercised essential pre-push hook
-[ ] Slice status updated in docs/_internal/PROGRESS.md (🔨 → ✅ COMPLETE)
+[ ] Slice status updated in docs/slices/PROGRESS.md (🔨 → ✅ COMPLETE)
 [ ] Decisions logged in PROGRESS.md Decision Log
 [ ] Committed with a short, specific message
 [ ] Consider release: ./scripts/release.sh minor (slices/features) or patch (fixes/polish)
-    See docs/_internal/PROGRESS.md § Release Cadence for guidance
+    See docs/slices/PROGRESS.md § Release Cadence for guidance
 ```
 
 ---
@@ -385,4 +386,5 @@ Please open an issue before starting work on large features to discuss the appro
 - [Local Environment](local-environment.md) — Atlas setup, debugging, and maintenance details
 - [Release Process](release-process.md) — creating releases, versioning strategy, when to release
 - [AGENTS.md](../../AGENTS.md) · [CLAUDE.md](../../CLAUDE.md) — agent entry points (incl. optional code-review-graph MCP)
-- [docs/_internal/PROGRESS.md](../_internal/PROGRESS.md) — slice status, decision log, forward roadmap
+- [docs/slices/PROGRESS.md](../slices/PROGRESS.md) — slice status, decision log, forward roadmap
+- [docs/README.md](../README.md) — documentation index by persona and topic

--- a/docs/contributor-guide/development.md
+++ b/docs/contributor-guide/development.md
@@ -133,10 +133,10 @@ uv run pytest --tb=short -q \
 bash scripts/pip-audit.sh
 ```
 
-**Baseline (as of 2026-05-27)**:
+**Baseline (as of 2026-05-28)**:
 - `ruff check .` → 0 errors
 - `mypy server/ cli/` → 0 errors
-- `pytest` → 23 tests, 83.6% coverage on scoped modules
+- `pytest` → 26 tests, 83.6% coverage on scoped modules
 
 ### Frontend
 
@@ -156,7 +156,7 @@ npm run build
 npm audit --audit-level=high
 ```
 
-**Baseline (as of 2026-05-27)**:
+**Baseline (as of 2026-05-28)**:
 - `npm run lint` → 0 errors
 - `npm run typecheck` → 0 errors
 - `npm run build` → built in ~4s, 49 modules
@@ -238,7 +238,7 @@ test -x .git/hooks/pre-push && echo "pre-push hook OK"
 | `test_expand_sweep.py` | 3 | Unified `retrievers` sweep expansion |
 | `test_tiebreaker_ranking.py` | 3 | Weighted ranking / tiebreaker logic |
 
-**Total:** 23 pytest tests (2026-05-27 baseline). Coverage is enforced at **80%** on four scoped server modules (see Quality Gates above).
+**Total:** 26 pytest tests (2026-05-28 baseline: 17 search-index + 3 sweep + 3 tiebreaker + 3 health). Coverage is enforced at **80%** on four scoped server modules (see Quality Gates above).
 
 **Still manual / not automated:**
 - End-to-end pipeline via CLI + dashboard (real Atlas + optional Voyage)
@@ -302,7 +302,7 @@ Record every non-obvious choice in `docs/slices/PROGRESS.md` → Decision Log:
 
 ```
 [ ] All acceptance criteria checked ✅
-[ ] Quality gates pass — ./scripts/quality-gates.sh; git push exercised essential pre-push hook
+[ ] Quality gates pass — ./scripts/quality-gates.sh; git push exercised pre-push fast gates (`pre-push-gates.sh`)
 [ ] Slice status updated in docs/slices/PROGRESS.md (🔨 → ✅ COMPLETE)
 [ ] Decisions logged in PROGRESS.md Decision Log
 [ ] Committed with a short, specific message

--- a/docs/contributor-guide/release-process.md
+++ b/docs/contributor-guide/release-process.md
@@ -33,7 +33,7 @@ Create a new release when:
 
 **Rule of thumb**: If it's worth announcing to users, it's worth a release. Bundle related changes; release when value is deliverable.
 
-**Reminder**: Mark slice ✅ COMPLETE in `docs/_internal/PROGRESS.md` before creating the release.
+**Reminder**: Mark slice ✅ COMPLETE in `docs/slices/PROGRESS.md` before creating the release.
 
 ---
 
@@ -44,7 +44,7 @@ Create a new release when:
 - Finish slice implementation
 - Git hooks installed: `bash scripts/install-git-hooks.sh`
 - All quality gates pass: `./scripts/quality-gates.sh` (full CI mirror; `git push` runs essential pre-commit hooks when installed)
-- Update `docs/_internal/PROGRESS.md` to mark slice complete
+- Update `docs/slices/PROGRESS.md` to mark slice complete
 - Commit work with clear messages
 
 ### 2. Update CHANGELOG.md

--- a/docs/slices/PROGRESS.md
+++ b/docs/slices/PROGRESS.md
@@ -1,7 +1,7 @@
 # rag-params-finder — Build Progress
 
-**Last Updated**: 2026-05-27 (Slice 14 ✅ Docker Compose)
-**Current**: **Slice 14 ✅ COMPLETE** — Docker Compose | Next: Slice 10 📋 · …
+**Last Updated**: 2026-05-28 (docs nav + pre-push fast gates)
+**Current**: Slices **14** ✅ Docker · **20** ✅ toolchain | Next: Slice **10** 📋 run recovery · **16** 📋 parallel · **19** 📋 storage quota
 
 ---
 
@@ -25,13 +25,13 @@
 | — — Scoped logging (Option A) | ✅ COMPLETE | ~1 h | `scope_log.py` server/CLI; `devLog.ts` dashboard dev console; Voyage error + dashboard failure visibility |
 | — — Dashboard polling + API responsiveness | ✅ COMPLETE | ~1 h | `executors.py` thread pools; list 2 s / stats 60 s / explore 15 s polls; batched db-stats; anti-jitter `PollingIndicator` |
 | — — Kimchi embedding provider | 🔀 BRANCH | ~2 h | Full CAST integration on `tessl-hackathon-kimchi-integration`; **main** has `kimchi` in `Provider` type only (no registry models / embedder yet) — v0.8.0 release notes are historical |
-| — — Unit pytest suite | ✅ COMPLETE | ~1 h | **23 tests** in `tests/` (17 search-index + 3 sweep expansion + 3 tiebreaker); CI + `quality-gates.sh` enforce 80% on 4 scoped modules |
+| — — Unit pytest suite | ✅ COMPLETE | ~1 h | **26 tests** in `tests/` (17 search-index + 3 sweep + 3 tiebreaker + 3 health); CI + `quality-gates.sh` enforce 80% on 4 scoped modules |
 | 18 — Unified retriever config | ✅ COMPLETE | ~4–6 h | Unified "retrievers" group (traditional search + rerankers); auto-migrate old format; multi-reranker chains; see [`SLICE-18-UNIFIED-RETRIEVER-CONFIG.md`](SLICE-18-UNIFIED-RETRIEVER-CONFIG.md) |
 | 10 — Run recovery (retry) | 📋 PLANNED | ~1–2 h | Retry FAILED `(± INTERRUPTED)` runs in-place; boot **reconciliation** done; pause/resume covers not-yet-started combos; **retry** not yet — see [`SLICE-10-RUN-RECOVERY.md`](SLICE-10-RUN-RECOVERY.md) |
 | 11 — Search Explorer enhancements | 📋 PLANNED | ~1 h | Better visualization, export results, query filtering improvements |
 | 16 — Parallel sweep execution | 📋 PLANNED | ~2–4 h | Bounded concurrent `_run_single`; see [`SLICE-16-PARALLEL-SWEEP-RUNS.md`](SLICE-16-PARALLEL-SWEEP-RUNS.md) |
 | 19 — Atlas storage quota guard | 📋 PLANNED | ~3–5 h | Preflight + runtime `OperationFailure` 8000 handling + force-delete recovery; M0 incident 2026-05-23 — see [`SLICE-19-STORAGE-QUOTA-GUARD.md`](SLICE-19-STORAGE-QUOTA-GUARD.md) |
-| 20 — Toolchain hardening | ✅ COMPLETE | ~2–3 h | quality-gates.sh, repo-lint, pre-push hook (`install-git-hooks.sh`), coverage CI, ESLint, bandit, pip-audit, gitleaks, dependabot — [`SLICE-20-TOOLCHAIN-HARDENING.md`](SLICE-20-TOOLCHAIN-HARDENING.md) |
+| 20 — Toolchain hardening | ✅ COMPLETE | ~2–3 h | `quality-gates.sh`, `repo-lint.sh`, `pre-push-gates.sh` (`--quick` on push), `install-git-hooks.sh`, coverage CI, ESLint, bandit, pip-audit, gitleaks, dependabot — [`SLICE-20-TOOLCHAIN-HARDENING.md`](SLICE-20-TOOLCHAIN-HARDENING.md) |
 | 14 — Docker Compose | ✅ COMPLETE | ~2–3 h | `./start-services.sh`, prod + `docker-compose.dev.yml`, Atlas `/healthz` — [`SLICE-14-DOCKER-COMPOSE.md`](SLICE-14-DOCKER-COMPOSE.md) |
 | ~~15 — CI/CD~~ | ✅ (via 20) | — | Superseded by Slice 20 — CI + `quality-gates.sh` + git hooks |
 
@@ -409,7 +409,7 @@ Implement comprehensive experiment deletion with confirmation flows and cascadin
 - [x] ConfirmDeleteModal shows experiment details and deletion warning
 - [x] Delete button disabled for running experiments with tooltip
 - [x] Success toast shows deletion statistics
-- [x] All pre-commit hooks pass (ruff, mypy, eslint, repo lint, tsc, build); pre-push runs same hooks on all files
+- [x] All pre-commit hooks pass (ruff, mypy, eslint, repo lint, tsc, build); pre-push runs `quality-gates.sh --quick` when hooks installed
 - [x] Documentation updated (CLI reference, troubleshooting guide)
 
 ### Testing Notes
@@ -620,11 +620,13 @@ Implement the 4 stubbed chunkers (fixed, token, sentence, semantic), add sparse/
 | 2026-05-23 | 18 | Auto-migrate old retrieval config format | Pydantic `@model_validator` converts `methods` + `retrieval_provider`/`retrieval_model` to separate `retrievers` sweep entries |
 | 2026-05-23 | 18 | Maintain old fields indefinitely | Keep `retrieval_method`, `retrieval_provider`, `retrieval_model` in DB — synthesized from single retriever for backward compat |
 | 2026-05-23 | 19 | Slice 19 spec for storage quota guard | M0 hit 515/512 MB; writes blocked (cancel/delete deadlock); `dbStats` understated cluster usage; mirror search-index preflight pattern — spec in [`SLICE-19-STORAGE-QUOTA-GUARD.md`](SLICE-19-STORAGE-QUOTA-GUARD.md) |
-| 2026-05-27 | 20 | Docs synced to toolchain + test reality | 23 pytest tests (not 39); Kimchi on integration branch only; `quality-gates.sh` in interrupt recovery; CI/bandit/gitleaks documented |
+| 2026-05-27 | 20 | Docs synced to toolchain + test reality | pytest count corrected (was 39); Kimchi on integration branch only; `quality-gates.sh` in interrupt recovery; CI/bandit/gitleaks documented |
 | 2026-05-27 | 20 | Repo lint in CI + pre-commit | shellcheck (`scripts/*.sh`), actionlint, markdownlint; `scripts/repo-lint.sh`; pragmatic `.markdownlint.json`; CI `repo-lint` job (4 jobs total) |
-| 2026-05-27 | 20 | Pre-push = essential pre-commit checks | Every `git push` runs `pre-commit --all-files` (same hooks as commit); full `quality-gates.sh` + CI on PR |
+| 2026-05-28 | — | Docs navigation (playgroup-style) | Root `QUICKSTART.md`; `docs/README.md` index; `PROGRESS.md` lives under `docs/slices/` beside slice specs |
+| 2026-05-28 | 20 | Pre-push = fast gates (`--quick`) | `git push` → `pre-push-gates.sh` (repo lint, ruff, mypy, bandit, pytest, frontend verify, gitleaks); commit hook stays staged pre-commit only |
 | 2026-05-27 | 14 | Docker Compose (AIE7-adapted) | 2-service stack (no local vector DB); host CLI; prod default + `docker-compose.dev.yml`; `/healthz` MongoDB ping; `hf_cache` volume |
 | 2026-05-27 | 14 | Dev overlay vs Compose profiles | `docker-compose.dev.yml` merge (not named profiles) — avoids port conflicts between prod/dev frontends |
+| 2026-05-27 | 20 | Pre-push (superseded 2026-05-28) | Was `pre-commit --all-files` on push — replaced by `quality-gates.sh --quick` for pytest + frontend verify |
 
 ---
 
@@ -698,7 +700,7 @@ Use this when resuming a session mid-slice:
 [ ] Git hooks installed: bash scripts/install-git-hooks.sh (once per machine)
 [ ] Run quality gates to confirm no regressions:
       ./scripts/quality-gates.sh          # full CI mirror before PR
-      # git push runs essential pre-commit hooks on all files when hooks installed
+      # git push runs ./scripts/pre-push-gates.sh (--quick) when hooks installed
 [ ] Check git status — any uncommitted changes?
 [ ] Read the current slice spec in docs/slices/SLICE-XX-*.md
 [ ] Resume from the last incomplete acceptance criterion

--- a/docs/slices/PROGRESS.md
+++ b/docs/slices/PROGRESS.md
@@ -26,13 +26,13 @@
 | — — Dashboard polling + API responsiveness | ✅ COMPLETE | ~1 h | `executors.py` thread pools; list 2 s / stats 60 s / explore 15 s polls; batched db-stats; anti-jitter `PollingIndicator` |
 | — — Kimchi embedding provider | 🔀 BRANCH | ~2 h | Full CAST integration on `tessl-hackathon-kimchi-integration`; **main** has `kimchi` in `Provider` type only (no registry models / embedder yet) — v0.8.0 release notes are historical |
 | — — Unit pytest suite | ✅ COMPLETE | ~1 h | **23 tests** in `tests/` (17 search-index + 3 sweep expansion + 3 tiebreaker); CI + `quality-gates.sh` enforce 80% on 4 scoped modules |
-| 18 — Unified retriever config | ✅ COMPLETE | ~4–6 h | Unified "retrievers" group (traditional search + rerankers); auto-migrate old format; multi-reranker chains; see [`SLICE-18-UNIFIED-RETRIEVER-CONFIG.md`](../slices/SLICE-18-UNIFIED-RETRIEVER-CONFIG.md) |
-| 10 — Run recovery (retry) | 📋 PLANNED | ~1–2 h | Retry FAILED `(± INTERRUPTED)` runs in-place; boot **reconciliation** done; pause/resume covers not-yet-started combos; **retry** not yet — see [`SLICE-10-RUN-RECOVERY.md`](../slices/SLICE-10-RUN-RECOVERY.md) |
+| 18 — Unified retriever config | ✅ COMPLETE | ~4–6 h | Unified "retrievers" group (traditional search + rerankers); auto-migrate old format; multi-reranker chains; see [`SLICE-18-UNIFIED-RETRIEVER-CONFIG.md`](SLICE-18-UNIFIED-RETRIEVER-CONFIG.md) |
+| 10 — Run recovery (retry) | 📋 PLANNED | ~1–2 h | Retry FAILED `(± INTERRUPTED)` runs in-place; boot **reconciliation** done; pause/resume covers not-yet-started combos; **retry** not yet — see [`SLICE-10-RUN-RECOVERY.md`](SLICE-10-RUN-RECOVERY.md) |
 | 11 — Search Explorer enhancements | 📋 PLANNED | ~1 h | Better visualization, export results, query filtering improvements |
-| 16 — Parallel sweep execution | 📋 PLANNED | ~2–4 h | Bounded concurrent `_run_single`; see [`SLICE-16-PARALLEL-SWEEP-RUNS.md`](../slices/SLICE-16-PARALLEL-SWEEP-RUNS.md) |
-| 19 — Atlas storage quota guard | 📋 PLANNED | ~3–5 h | Preflight + runtime `OperationFailure` 8000 handling + force-delete recovery; M0 incident 2026-05-23 — see [`SLICE-19-STORAGE-QUOTA-GUARD.md`](../slices/SLICE-19-STORAGE-QUOTA-GUARD.md) |
-| 20 — Toolchain hardening | ✅ COMPLETE | ~2–3 h | quality-gates.sh, repo-lint, pre-push hook (`install-git-hooks.sh`), coverage CI, ESLint, bandit, pip-audit, gitleaks, dependabot — [`SLICE-20-TOOLCHAIN-HARDENING.md`](../slices/SLICE-20-TOOLCHAIN-HARDENING.md) |
-| 14 — Docker Compose | ✅ COMPLETE | ~2–3 h | `./start-services.sh`, prod + `docker-compose.dev.yml`, Atlas `/healthz` — [`SLICE-14-DOCKER-COMPOSE.md`](../slices/SLICE-14-DOCKER-COMPOSE.md) |
+| 16 — Parallel sweep execution | 📋 PLANNED | ~2–4 h | Bounded concurrent `_run_single`; see [`SLICE-16-PARALLEL-SWEEP-RUNS.md`](SLICE-16-PARALLEL-SWEEP-RUNS.md) |
+| 19 — Atlas storage quota guard | 📋 PLANNED | ~3–5 h | Preflight + runtime `OperationFailure` 8000 handling + force-delete recovery; M0 incident 2026-05-23 — see [`SLICE-19-STORAGE-QUOTA-GUARD.md`](SLICE-19-STORAGE-QUOTA-GUARD.md) |
+| 20 — Toolchain hardening | ✅ COMPLETE | ~2–3 h | quality-gates.sh, repo-lint, pre-push hook (`install-git-hooks.sh`), coverage CI, ESLint, bandit, pip-audit, gitleaks, dependabot — [`SLICE-20-TOOLCHAIN-HARDENING.md`](SLICE-20-TOOLCHAIN-HARDENING.md) |
+| 14 — Docker Compose | ✅ COMPLETE | ~2–3 h | `./start-services.sh`, prod + `docker-compose.dev.yml`, Atlas `/healthz` — [`SLICE-14-DOCKER-COMPOSE.md`](SLICE-14-DOCKER-COMPOSE.md) |
 | ~~15 — CI/CD~~ | ✅ (via 20) | — | Superseded by Slice 20 — CI + `quality-gates.sh` + git hooks |
 
 **Legend**: 📋 PLANNED | 🔨 IN PROGRESS | ✅ COMPLETE | 🔀 BRANCH (implemented on named branch, not main)
@@ -130,7 +130,7 @@ cd frontend && npm run dev
 
 **Foundation** (7):
 - pyproject.toml, .env.example, .gitignore, README.md
-- docs/PROGRESS.md, docs/ARCHITECTURE.md, docs/slices/SLICE-01-SKATEBOARD.md
+- docs/slices/PROGRESS.md, docs/ARCHITECTURE.md, docs/slices/SLICE-01-SKATEBOARD.md
 
 **Server** (20):
 - server/{__init__.py, main.py, utils/logger.py}
@@ -218,7 +218,7 @@ Cartesian product expansion: one YAML config with N models × M methods × P siz
 | Decision | Why |
 |---|---|
 | `expand_sweep()` as pure function on config | Testable without side effects; called both in API (preview count) and orchestrator (execute) |
-| Sequential runs (not parallel) | `parallelism` stored on experiments but orchestrator ignores it pending [Slice 16](../slices/SLICE-16-PARALLEL-SWEEP-RUNS.md) |
+| Sequential runs (not parallel) | `parallelism` stored on experiments but orchestrator ignores it pending [Slice 16](SLICE-16-PARALLEL-SWEEP-RUNS.md) |
 | `run_sweep()` + `run_single()` split | Single Responsibility — sweep management vs pipeline execution |
 | `on_error: continue/stop` | Allows partial completion without losing all results |
 | `partial` status for mixed outcomes | Distinguishes "some failed" from "all failed" or "all complete" |
@@ -555,7 +555,7 @@ Implement the 4 stubbed chunkers (fixed, token, sentence, semantic), add sparse/
 
 ## Deferred
 
-- Parallel sweep concurrency *(Slice 16 — [`docs/slices/SLICE-16-PARALLEL-SWEEP-RUNS.md`](../slices/SLICE-16-PARALLEL-SWEEP-RUNS.md))*
+- Parallel sweep concurrency *(Slice 16 — [`docs/slices/SLICE-16-PARALLEL-SWEEP-RUNS.md`](SLICE-16-PARALLEL-SWEEP-RUNS.md))*
 - All SHOULD/COULD slices
 - Error handling (basic only in Slice 1)
 - Logging structure (prints for now)
@@ -591,8 +591,8 @@ Implement the 4 stubbed chunkers (fixed, token, sentence, semantic), add sparse/
 | 2026-05-17 | 6 | sparse/hybrid require text_search_index | Atlas $search is the BM25 engine; full-text + vector indexes can coexist on same collection |
 | 2026-05-17 | 6 | query_embedding optional in search() dispatcher | Avoids embedding API call for sparse retrieval runs |
 | 2026-05-17 | — | Reorganise configs: 1 file per DB×provider | Replaced 7 single-purpose example files with `example-mongodb-local.yaml` and `example-mongodb-voyage.yaml`; each covers all embedding models, all chunking methods, and all retrieval methods for that DB+provider |
-| 2026-05-17 | — | Slice 16 spec for parallel sweep runs | Formalized deferred work: bounded in-process parallelism vs Celery; honor `execution.parallelism`; specs in [`docs/slices/SLICE-16-PARALLEL-SWEEP-RUNS.md`](../slices/SLICE-16-PARALLEL-SWEEP-RUNS.md) |
-| 2026-05-17 | 10 | Slice 10 spec for run recovery | In-place retry for FAILED runs (`--include-interrupted` optional); reuse `run_id`; delete stale `chunks`/`results` for that run only; config from Mongo `experiments.config`; boot recovery scoped to INTERRUPTED only; spec in [`docs/slices/SLICE-10-RUN-RECOVERY.md`](../slices/SLICE-10-RUN-RECOVERY.md) |
+| 2026-05-17 | — | Slice 16 spec for parallel sweep runs | Formalized deferred work: bounded in-process parallelism vs Celery; honor `execution.parallelism`; specs in [`docs/slices/SLICE-16-PARALLEL-SWEEP-RUNS.md`](SLICE-16-PARALLEL-SWEEP-RUNS.md) |
+| 2026-05-17 | 10 | Slice 10 spec for run recovery | In-place retry for FAILED runs (`--include-interrupted` optional); reuse `run_id`; delete stale `chunks`/`results` for that run only; config from Mongo `experiments.config`; boot recovery scoped to INTERRUPTED only; spec in [`docs/slices/SLICE-10-RUN-RECOVERY.md`](SLICE-10-RUN-RECOVERY.md) |
 | 2026-05-17 | 8 | Dual loading indicators (panel + polling badge) | Full LoadingFeedbackPanel for initial loads provides detailed progress; subtle PollingIndicator for background refreshes avoids visual noise |
 | 2026-05-17 | 8 | fetchWithProgress with ReadableStream | Byte-level progress via `response.body.getReader()` enables real-time progress bars; better UX than spinners for large payloads |
 | 2026-05-17 | 8 | Shared DashboardShell + AppPageChrome components | Unified header/nav/layout across all screens; DRY principle, consistent UX, easier to maintain |
@@ -619,7 +619,7 @@ Implement the 4 stubbed chunkers (fixed, token, sentence, semantic), add sparse/
 | 2026-05-23 | 18 | Unified retriever configuration | Treat all retrieval strategies (dense/sparse/hybrid + rerankers) as unified `retrievers` list for sweep expansion |
 | 2026-05-23 | 18 | Auto-migrate old retrieval config format | Pydantic `@model_validator` converts `methods` + `retrieval_provider`/`retrieval_model` to separate `retrievers` sweep entries |
 | 2026-05-23 | 18 | Maintain old fields indefinitely | Keep `retrieval_method`, `retrieval_provider`, `retrieval_model` in DB — synthesized from single retriever for backward compat |
-| 2026-05-23 | 19 | Slice 19 spec for storage quota guard | M0 hit 515/512 MB; writes blocked (cancel/delete deadlock); `dbStats` understated cluster usage; mirror search-index preflight pattern — spec in [`SLICE-19-STORAGE-QUOTA-GUARD.md`](../slices/SLICE-19-STORAGE-QUOTA-GUARD.md) |
+| 2026-05-23 | 19 | Slice 19 spec for storage quota guard | M0 hit 515/512 MB; writes blocked (cancel/delete deadlock); `dbStats` understated cluster usage; mirror search-index preflight pattern — spec in [`SLICE-19-STORAGE-QUOTA-GUARD.md`](SLICE-19-STORAGE-QUOTA-GUARD.md) |
 | 2026-05-27 | 20 | Docs synced to toolchain + test reality | 23 pytest tests (not 39); Kimchi on integration branch only; `quality-gates.sh` in interrupt recovery; CI/bandit/gitleaks documented |
 | 2026-05-27 | 20 | Repo lint in CI + pre-commit | shellcheck (`scripts/*.sh`), actionlint, markdownlint; `scripts/repo-lint.sh`; pragmatic `.markdownlint.json`; CI `repo-lint` job (4 jobs total) |
 | 2026-05-27 | 20 | Pre-push = essential pre-commit checks | Every `git push` runs `pre-commit --all-files` (same hooks as commit); full `quality-gates.sh` + CI on PR |
@@ -645,11 +645,11 @@ Implement the 4 stubbed chunkers (fixed, token, sentence, semantic), add sparse/
 | ~~6 — Additional chunkers~~ | ~~Implement fixed, token, sentence, semantic~~ | ~~Should~~ | ✅ Done |
 | ~~8 — SPARSE/HYBRID retrieval~~ | ~~BM25 + hybrid RRF via Atlas FTS~~ | ~~Should~~ | ✅ Done (merged into Slice 6) |
 | 9 — Search Explorer dashboard | Best-params card, ranked configs, per-query results view | Should | ~30 min |
-| 10 — Run recovery | Spec: [`SLICE-10-RUN-RECOVERY.md`](../slices/SLICE-10-RUN-RECOVERY.md) — `recover` CLI + `POST /experiments/{id}/recover`; per-`run_id` scrub + retry (**FAILED** default; **INTERRUPTED** opt-in); **`RECOVER_ON_BOOT`** retries **INTERRUPTED** only *(not all FAILED)* | Could | ~1–2 h |
+| 10 — Run recovery | Spec: [`SLICE-10-RUN-RECOVERY.md`](SLICE-10-RUN-RECOVERY.md) — `recover` CLI + `POST /experiments/{id}/recover`; per-`run_id` scrub + retry (**FAILED** default; **INTERRUPTED** opt-in); **`RECOVER_ON_BOOT`** retries **INTERRUPTED** only *(not all FAILED)* | Could | ~1–2 h |
 | 11 — Dashboard-triggered runs | Submit experiments from the React UI, not just CLI | Could | ~45 min |
 | 12 — SSE live updates | Replace 2 s polling with Server-Sent Events | Could | ~20 min |
 | 13 — Experiment cleanup CLI | `rag-params-finder cleanup --older-than 30d` | Could | ~15 min |
-| 19 — Storage quota guard | Spec: [`SLICE-19-STORAGE-QUOTA-GUARD.md`](../slices/SLICE-19-STORAGE-QUOTA-GUARD.md) — preflight at submit (422); runtime `OperationFailure` 8000; HTTP 507 on control APIs; `?force=true` delete; dashboard ≥80% warning; smoke config for M0 | **Should** | ~3–5 h |
+| 19 — Storage quota guard | Spec: [`SLICE-19-STORAGE-QUOTA-GUARD.md`](SLICE-19-STORAGE-QUOTA-GUARD.md) — preflight at submit (422); runtime `OperationFailure` 8000; HTTP 507 on control APIs; `?force=true` delete; dashboard ≥80% warning; smoke config for M0 | **Should** | ~3–5 h |
 | ~~14 — Docker Compose~~ | ~~One-command local setup~~ | — | ✅ Delivered in Slice 14 |
 | ~~15 — CI/CD~~ | ~~GitHub Actions~~ | — | ✅ Delivered in Slice 20 |
 | 16 — Parallel sweep (`parallelism` > 1) | Bounded concurrent `_run_single` (+ optional Celery upgrade path); Atlas/Voyage-rate-limit aware | Should | ~2–4 h |
@@ -694,7 +694,7 @@ Implement the 4 stubbed chunkers (fixed, token, sentence, semantic), add sparse/
 Use this when resuming a session mid-slice:
 
 ```
-[ ] Read docs/_internal/PROGRESS.md — note current slice and last known state
+[ ] Read docs/slices/PROGRESS.md — note current slice and last known state
 [ ] Git hooks installed: bash scripts/install-git-hooks.sh (once per machine)
 [ ] Run quality gates to confirm no regressions:
       ./scripts/quality-gates.sh          # full CI mirror before PR

--- a/docs/slices/SLICE-10-RUN-RECOVERY.md
+++ b/docs/slices/SLICE-10-RUN-RECOVERY.md
@@ -69,7 +69,7 @@ Recovery should **reuse the same `run_id`** for a retried run so dashboards, URL
 | `server/core/startup_reconciliation.py` | ✅ Boot status fix *(shipped)* — mark orphans `interrupted`, recompute experiment status |
 | `server/api/experiments_shared.py` *(or new db helper)* | Bulk delete chunks/results by `run_id`; experiment status recomputation |
 | `docs/user-guide/cli-reference.md` | Document `recover` |
-| `docs/_internal/PROGRESS.md` | Mark slice complete; decision log |
+| `docs/slices/PROGRESS.md` | Mark slice complete; decision log |
 
 ---
 
@@ -112,6 +112,6 @@ See [`development.md`](../contributor-guide/development.md) § Git hooks and § 
 
 ## See Also
 
-- [`docs/_internal/PROGRESS.md`](../_internal/PROGRESS.md) — roadmap
+- [`docs/slices/PROGRESS.md`](./PROGRESS.md) — roadmap
 - [`SLICE-03-SWEEP-EXPANSION.md`](./SLICE-03-SWEEP-EXPANSION.md) — sweep expansion
 - [`SLICE-16-PARALLEL-SWEEP-RUNS.md`](./SLICE-16-PARALLEL-SWEEP-RUNS.md) — parallelism vs recovery

--- a/docs/slices/SLICE-16-PARALLEL-SWEEP-RUNS.md
+++ b/docs/slices/SLICE-16-PARALLEL-SWEEP-RUNS.md
@@ -100,6 +100,6 @@ See [`development.md`](../contributor-guide/development.md) § Git hooks.
 
 ## See Also
 
-- `docs/_internal/PROGRESS.md` — roadmap row for this slice
+- `docs/slices/PROGRESS.md` — roadmap row for this slice
 - [`SLICE-03-SWEEP-EXPANSION.md`](./SLICE-03-SWEEP-EXPANSION.md) — baseline sequential behavior
 - [`../contributor-guide/architecture.md`](../contributor-guide/architecture.md) — BackgroundTasks vs future Celery narrative

--- a/docs/slices/SLICE-18-UNIFIED-RETRIEVER-CONFIG.md
+++ b/docs/slices/SLICE-18-UNIFIED-RETRIEVER-CONFIG.md
@@ -96,7 +96,7 @@ retrieval:
 ### Quality Gates
 - [ ] `bash scripts/install-git-hooks.sh` run on dev machine (commit + pre-push hooks)
 - [ ] `./scripts/quality-gates.sh` passes (full CI mirror before PR — see [`development.md`](../contributor-guide/development.md))
-- [ ] `git push` succeeds with pre-push hook (essential checks) or run `./scripts/quality-gates.sh --quick` manually
+- [ ] `git push` succeeds with pre-push hook (`pre-push-gates.sh`) or run `./scripts/quality-gates.sh --quick` manually
 
 ### Manual Verification
 - [ ] Old YAML config → successful sweep

--- a/docs/slices/SLICE-19-STORAGE-QUOTA-GUARD.md
+++ b/docs/slices/SLICE-19-STORAGE-QUOTA-GUARD.md
@@ -58,7 +58,7 @@ On M0 (`TheSandboxCluster`), cluster storage reached **515 MB / 512 MB**. Atlas 
 ### Emergency recovery *(quota deadlock)*
 
 - [ ] **`DELETE /experiments/{id}?force=true`** — allow deleting a **running** experiment without prior cancel when storage is critical (deletes free space; confirmed working near quota in incident).
-- [ ] Cross-link [Slice 13](../_internal/PROGRESS.md) cleanup CLI for scheduled eviction of old **complete** experiments.
+- [ ] Cross-link [Slice 13](./PROGRESS.md) cleanup CLI for scheduled eviction of old **complete** experiments.
 - [ ] Optional **`POST /experiments/cleanup`** — delete oldest complete experiments until usage < threshold (shares logic with Slice 13).
 
 ### Dashboard & config guardrails

--- a/docs/slices/SLICE-20-TOOLCHAIN-HARDENING.md
+++ b/docs/slices/SLICE-20-TOOLCHAIN-HARDENING.md
@@ -81,7 +81,7 @@ Threshold set to **80%** (`--cov-fail-under=80` in CI and quality-gates).
 ### Docs
 - [x] `docs/contributor-guide/development.md` — quality gates section updated
 - [x] `CLAUDE.md` — verify-all commands + baseline metrics updated
-- [x] `docs/_internal/PROGRESS.md` — slice 20 row + decision log entry
+- [x] `docs/slices/PROGRESS.md` — slice 20 row + decision log entry
 
 ---
 
@@ -119,7 +119,7 @@ Threshold set to **80%** (`--cov-fail-under=80` in CI and quality-gates).
 | `frontend/src/services/fetchWithProgress.ts` | Stream loop lint fix |
 | `docs/contributor-guide/development.md` | Gate commands + baselines |
 | `CLAUDE.md` | Verify-all + baseline |
-| `docs/_internal/PROGRESS.md` | Slice 20 status |
+| `docs/slices/PROGRESS.md` | Slice 20 status |
 
 ---
 

--- a/docs/slices/SLICE-20-TOOLCHAIN-HARDENING.md
+++ b/docs/slices/SLICE-20-TOOLCHAIN-HARDENING.md
@@ -34,7 +34,7 @@ Inherit proven hardening patterns from **price-analysis** and **pre-rag-explorer
 | Vitest frontend tests | pre-rag | ❌ — separate slice when UI test tier is planned |
 | Torch/transformers major upgrade | pip-audit findings | ❌ — tracked via `scripts/pip-audit.sh` ignores |
 | `scripts/repo-lint.sh` (shellcheck, actionlint, markdownlint) | governance (Serious tier) | ✅ *(2026-05-27 follow-on)* |
-| `install-git-hooks.sh` + pre-push essential checks (`--all-files`) | governance | ✅ *(2026-05-27 follow-on)* |
+| `install-git-hooks.sh` + pre-push fast gates (`quality-gates.sh --quick`) | pre-rag | ✅ *(2026-05-28: superseded `--all-files` on push)* |
 | yamllint / stylelint / markdown “strict” rules | governance | ❌ — `check-yaml` + pragmatic `.markdownlint.json` suffice for now |
 
 ---
@@ -61,7 +61,7 @@ Inherit proven hardening patterns from **price-analysis** and **pre-rag-explorer
 - [x] Shellcheck on `scripts/*.sh` (`shellcheck-py`)
 - [x] Actionlint on `.github/workflows`
 - [x] Markdownlint on `*.md` (excludes `.claude/`)
-- [x] Pre-push hook runs same essential checks as commit on all files (`pre-commit run --all-files`)
+- [x] Pre-push hook runs fast CI gates (`./scripts/pre-push-gates.sh` → `quality-gates.sh --quick`: pytest, frontend verify, gitleaks)
 
 ### Coverage scope (baseline-first)
 Measured baseline **83.6%** on:
@@ -184,9 +184,10 @@ python scripts/check_integrity.py
 **Decision:** Use `shellcheck-py` pre-commit repo (no Docker).
 **Rationale:** `koalaman/shellcheck-precommit` rev failed in CI; pip wheel hook matches Serious tier without Docker.
 
-### 8. Pre-push mirrors commit essential checks, not full gates
-**Decision:** Pre-push runs `pre-commit run --all-files` (same hooks as commit, whole repo); full `quality-gates.sh` stays manual + CI on PR.
-**Rationale:** Matches “essential checks like commit”; pytest, coverage, and dependency audits stay in CI / pre-PR script.
+### 8. Pre-push fast gates (`--quick`), not full CI mirror
+**Decision (2026-05-28):** Pre-push runs `./scripts/pre-push-gates.sh` → `quality-gates.sh --quick` (repo lint, ruff, mypy, bandit, pytest without coverage, frontend lint+verify, gitleaks). Commit hook stays staged pre-commit only.
+**Rationale:** Mirrors pre-rag `npm run test:all` on push — catches test/build regressions before remote; coverage, pip-audit, and npm audit stay in full `quality-gates.sh` + CI.
+**Superseded:** 2026-05-27 choice of `pre-commit run --all-files` on push (lint-only, no pytest).
 
 ---
 
@@ -224,7 +225,7 @@ Three-way comparison after inheriting patterns from **price-analysis** and **pre
 | pytest integration/slow markers | ✅ | N/A (vitest) | ✅ (markers defined) |
 | pre-commit (Python framework) | ✅ heavy | ✅ Serious-lite | ✅ |
 | shellcheck / actionlint / markdownlint | partial | partial | ✅ repo-lint job + hooks |
-| pre-push essential checks | ❌ | partial (husky) | ✅ `pre-commit --all-files` |
+| pre-push fast test gates | ❌ | partial (husky) | ✅ `quality-gates.sh --quick` |
 | Husky + lint-staged | ❌ | ✅ | ❌ (pre-commit instead) |
 | Prettier | ✅ black/isort | ✅ | ❌ (ruff + eslint) |
 | Xenon complexity | ✅ scoped | ❌ | ❌ deferred |
@@ -245,7 +246,7 @@ chore(ci): slice 20 toolchain hardening from reference repos
 
 - Add quality-gates.sh, check_integrity.py, pip-audit.sh, repo-lint.sh, install-git-hooks.sh
 - CI: repo-lint job; coverage 80% on scoped modules; eslint; pip-audit
-- Git hooks: pre-commit + pre-push (essential checks on all files); shellcheck, actionlint, markdownlint
+- Git hooks: pre-commit (staged) + pre-push (`quality-gates.sh --quick`); shellcheck, actionlint, markdownlint
 - Wire .gitleaks.toml, .nvmrc, dependabot, repo hygiene files
 - Upgrade urllib3/starlette/idna/langchain-core; document ML transitive audit ignores
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -8,6 +8,10 @@
 
 Everything you need to run your first RAG parameter sweep experiment.
 
+> **Shortest path:** [QUICKSTART.md](../../QUICKSTART.md) — install and first sweep. This guide adds step-by-step detail.
+
+**Documentation map:** [docs/README.md](../README.md)
+
 ---
 
 ## ✅ Prerequisites


### PR DESCRIPTION
Move slice tracker beside specs, add root QUICKSTART and docs/README index, and refresh cross-links so audience-first README flow matches playgroup style without changing guide content.