### PR TITLE
docs(slice-21-25b): complete MongoDB Local + SIE doc sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white)
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.8-3178C6?logo=typescript&logoColor=white)
 ![MongoDB](https://img.shields.io/badge/MongoDB-Atlas-47A248?logo=mongodb&logoColor=white)
+![SIE](https://img.shields.io/badge/SIE-Superlinked_Inference_Engine-blue)
 ![Vite](https://img.shields.io/badge/Vite-6-646CFF?logo=vite&logoColor=white)
 ![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-3-06B6D4?logo=tailwindcss&logoColor=white)
 

--- a/VERIFICATION_CHECKLIST.md
+++ b/VERIFICATION_CHECKLIST.md
@@ -16,6 +16,11 @@
    - At least one experiment in the database
    - Experiment with multiple queries for SearchExplorer testing
 
+**Optional smoke checks** (backend + data prerequisites):
+
+- **Atlas Local:** [MongoDB Setup → Path B](docs/user-guide/mongodb-setup.md#path-b--atlas-local-docker) — `./start-services.sh --local`, then submit `example-mongodb-local.yaml`
+- **SIE sweep:** [SIE Setup → verification](docs/user-guide/sie-setup.md#6-verify-the-sie-sweep) — gateway or Docker warm, then `example-mongodb-sie.yaml`
+
 ## Test Cases
 
 ### ✅ Test 1: SearchExplorerScreen Re-Query Progress

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,3 +1,5 @@
 # Architecture
 
 > This document has moved to [`contributor-guide/architecture.md`](contributor-guide/architecture.md).
+
+The contributor guide covers the full system design: two-process CLI + server architecture, three embedding providers (Voyage, local, SIE via `embedder_factory`), MongoDB backends (Atlas cloud and Atlas Local Docker), pipeline phases, and module map.

--- a/docs/_internal/DOC-GAPS.md
+++ b/docs/_internal/DOC-GAPS.md
@@ -1,7 +1,7 @@
 # Documentation Gap Tracker
 
 **Created**: 2026-05-05
-**Last Updated**: 2026-06-29 (Slice 21 doc sync, 58 tests)
+**Last Updated**: 2026-07-01 (Slice 21–25B doc sweep, 78 tests)
 **Reference**: Gap analysis vs [pre-rag-explorer-dashboard](https://github.com/neomatrix369/pre-rag-explorer-dashboard)
 
 Each item below is a concrete, actionable doc gap. Check the box when done and record the date.
@@ -104,7 +104,7 @@ Each item below is a concrete, actionable doc gap. Check the box when done and r
   - [x] `bash scripts/repo-lint.sh` → shellcheck + actionlint + markdownlint pass
   - [x] `ruff check .` → 0 errors
   - [x] `mypy server/ cli/` → 0 errors
-  - [x] `pytest` → **58 tests** (2026-06-29): search-index, sweep, SIE, config examples, health, db indexes; 80% coverage on scoped modules
+  - [x] `pytest` → **78 tests** (2026-07-01): search-index, sweep, SIE, config examples, health, db indexes; 80% coverage on scoped modules
   - [x] `npm run lint` → 0 errors (ESLint + security plugin, Slice 20)
   - [x] `npm run typecheck` → 0 errors
   - [x] `npm run build` → ~4 s, 49 modules
@@ -191,3 +191,14 @@ README was simplified for quick scanning (aligned with pre-rag-explorer-dashboar
 - [x] MongoDB Atlas collections table with cleanup instructions
 - [x] Atlas vector index JSON for both 384-dim and 1024-dim (with all filter fields)
 - [x] README → Documentation table updated to link to `docs/REFERENCE.md`
+
+---
+
+## Gap 12 — Contributor architecture + local-environment drift (closed 2026-07-01)
+
+**Priority**: Medium (contributor onboarding accuracy)
+
+- [x] `architecture.md`: SIE provider, `embedder_factory`, `mongodb_uri`, `bootstrap_indexes`, sweep API
+- [x] `local-environment.md`: Path B Atlas Local, SIE env block, `.env` snippet synced with `.env.example`
+- [x] ADR-002 evolution note (SIE third provider); ADR-003 Atlas Local footnote
+- [x] SIE shields.io badge in all user/contributor guides with Voyage badge rows

--- a/docs/_internal/DOCS-CODE-AUDIT.md
+++ b/docs/_internal/DOCS-CODE-AUDIT.md
@@ -1,6 +1,6 @@
 # Documentation vs Code Audit
 
-**Audit date**: 2026-05-23 (full pass) · **Supplements**: 2026-05-27 (Slice 20) · 2026-05-28 (doc nav) · **2026-06-29 (Slice 21 SIE doc sync)**
+**Audit date**: 2026-05-23 (full pass) · **Supplements**: 2026-05-27 (Slice 20) · 2026-05-28 (doc nav) · **2026-06-29 (Slice 21 SIE doc sync)** · **2026-07-01 (Slices 25/25B Atlas Local + doc sweep)**
 **Auditor**: Claude (automated verification)
 **Scope**: README.md, user guides, contributor guides, code implementation
 
@@ -17,7 +17,7 @@
 | `quality-gates.sh` ↔ `ci.yml` | ✅ Aligned (repo-lint, bandit, coverage, pip-audit, eslint, gitleaks) |
 | `repo-lint.sh` ↔ pre-commit hooks | ✅ shellcheck, actionlint, markdownlint (same revs via pre-commit) |
 | pre-push hook ↔ `pre-push-gates.sh` | ✅ `quality-gates.sh --quick` (pytest + frontend verify + gitleaks); not `pre-commit --all-files` |
-| Test count in contributor docs | ✅ **58** pytest tests (2026-06-29; was 26 → 46 → 50) |
+| Test count in contributor docs | ✅ **78** pytest tests (2026-07-01; was 58 → 78) |
 | Doc entry points | ✅ `QUICKSTART.md`, `docs/README.md`, `docs/slices/PROGRESS.md` (2026-05-28 nav reorg) |
 | Kimchi provider | ⚠️ `Provider` type includes `kimchi`; embedder/registry on `tessl-hackathon-kimchi-integration` branch only — not on main |
 | `development.md` testing section | ✅ Updated (was "no suite yet") |
@@ -39,6 +39,19 @@
 | README Voyage model count (13) | ✅ **RESOLVED** |
 | Voyage example run count | ✅ **40 runs** (was incorrectly "90-run" in cloud-setup links — fixed 2026-06-29) |
 | `docs/plan/GAP_ANALYSIS.md` | ⚠️ Historical pre-slice snapshot — banner added |
+
+**2026-07-01 supplement** (Slices 25/25B Atlas Local + full doc sweep):
+
+| Area | Status |
+|------|--------|
+| `./start-services.sh --local` / `RAG_LOCAL_ATLAS=1` | ✅ README, QUICKSTART, mongodb-setup Path B, CLAUDE.md, development.md |
+| `mongodb start\|stop\|reset\|status` subcommands | ✅ mongodb-setup, scripts/lib/compose.sh referenced in user guides |
+| Local URI auto-provision (`bootstrap_indexes`) | ✅ mongodb-setup, architecture.md, local-environment.md, ADR-003 footnote |
+| Cloud vs local URI detection (`mongodb_uri.py`) | ✅ architecture.md module map |
+| SIE shields.io badge in user/contributor guides | ✅ 9 files aligned with sie-setup.md canonical badge |
+| architecture.md SIE + embedder_factory + sweep API | ✅ Provider section + module tree updated |
+| DOCS-CODE-AUDIT / DOC-GAPS test count | ✅ **78** tests |
+| Internal audit stale architecture gaps | ✅ Closed in architecture.md + local-environment.md |
 
 ---
 

--- a/docs/adr/ADR-002-voyage-and-local-providers.md
+++ b/docs/adr/ADR-002-voyage-and-local-providers.md
@@ -43,7 +43,15 @@ The `provider` field is the **single source of truth** for routing — the serve
 - **`numpy<2` pin required**: PyTorch (used by sentence-transformers) was compiled against NumPy 1.x ABI. NumPy 2.x causes `_ARRAY_API not found` crashes.
 - **Model download on first use**: Local models are ~23 MB each, cached in `~/.cache/huggingface/hub/`. First run may be slow on cold cache.
 - **`voyage-context-3` uses a different API**: Registered with `contextualized: True` in `model_registry.py`; routed to `contextualized_embed()` with automatic segment splitting for documents exceeding 32K tokens. All other Voyage models use standard `embed()`.
-- **Provider flows end-to-end**: `EmbeddingConfig.provider` → `RunParams.embedding_provider` → `embedder.py` dispatcher. No runtime inference; server restart issues cannot mis-route.
+- **Provider flows end-to-end**: `EmbeddingConfig.provider` → `RunParams.embedding_provider` → `embedder_factory.get_embedder()`. No runtime inference; server restart issues cannot mis-route.
+
+---
+
+## Evolution (Slice 21 — SIE third provider)
+
+**2026-06-29**: Added `provider: sie` as a third embedding provider without a new ADR. Dispatch moved to `server/core/embedder_factory.py` (`get_embedder(provider)` returns voyage | local | sie functions). Models: BGE-M3, Stella-v5 (1024-dim dense), SPLADE-v3 (30522-dim sparse) in `server/core/sie_embedder.py`. Preflight: `server/core/sie_guard.py`. Env: `SIE_ENABLED`, `SIE_ENDPOINT`, `SIE_API_KEY`. See [extending.md](../contributor-guide/extending.md) and [sie-setup.md](../user-guide/sie-setup.md).
+
+Reranking providers remain **dual** (`local` | `voyage`) — SIE is embedding-only in Slice 21.
 
 ---
 

--- a/docs/adr/ADR-003-mongodb-atlas-vector-store.md
+++ b/docs/adr/ADR-003-mongodb-atlas-vector-store.md
@@ -37,6 +37,7 @@ Use **MongoDB Atlas** for all storage — both vector embeddings and structured 
 - **Dimension-specific indexes**: Each embedding dimension (384, 1024) requires its own index. Mixed-dimension queries fail silently or error.
 - **M0 storage limit**: 512 MB on the free tier. A typical sweep (36 runs × 1000 chunks × 1024-dim × 4 bytes) uses ~147 MB. Large experiments or many sweeps may exhaust the free tier.
 - **Shared CPU on M0**: Free-tier clusters share compute. Vector search latency may be higher during peak Atlas usage.
+- **Local dev with Atlas Local Docker** (Slice 25): Developers may use `mongodb/mongodb-atlas-local` via `./start-services.sh --local` with the same `$vectorSearch` / `$search` syntax. Index creation is automatic on boot (`bootstrap_indexes()`); the manual UI steps above apply to cloud M0/M2/M5 only.
 
 ---
 

--- a/docs/contributor-guide/architecture.md
+++ b/docs/contributor-guide/architecture.md
@@ -8,6 +8,7 @@
 ![Vite](https://img.shields.io/badge/Vite_6-646CFF?logo=vite&logoColor=white)
 ![Voyage AI](https://img.shields.io/badge/Voyage_AI-embeddings_%26_reranking-FF6B6B)
 ![sentence-transformers](https://img.shields.io/badge/sentence--transformers-FF9D00?logo=huggingface&logoColor=white)
+![SIE](https://img.shields.io/badge/SIE-Superlinked_Inference_Engine-blue)
 
 System design, data flow, module structure, and design decisions for `rag-params-finder`.
 
@@ -45,7 +46,7 @@ FastAPI Server
 └──────────────┬───────────────────────────┘
                │
                ▼
-         MongoDB Atlas
+    MongoDB (Atlas cloud or Atlas Local)
          ┌────────────┐
          │ chunks     │  ← embeddings + vector index
          │ experiments│
@@ -70,7 +71,8 @@ FastAPI Server
 | Python 3.12 | Language runtime |
 | Voyage AI SDK | Embeddings + reranking (hosted) |
 | sentence-transformers | Local embeddings + reranking (offline) |
-| MongoDB Atlas / PyMongo | Vector storage + search |
+| SIE (Superlinked Inference Engine) | Open-source embeddings via remote gateway or optional Docker (`sie_embedder.py`) |
+| MongoDB Atlas / PyMongo | Vector storage + search (cloud or Atlas Local Docker) |
 | LangChain text splitters | Recursive, fixed, token chunking |
 | NLTK | Sentence chunking |
 | tiktoken | Token-based chunking |
@@ -100,9 +102,14 @@ rag-params-finder/
 │   ├── api/
 │   │   ├── experiments.py   # CRUD, explore, db-stats, pause, resume, cancel, delete
 │   │   ├── experiments_shared.py  # Mongo helpers incl. db-stats aggregation
+│   │   ├── sweep.py         # POST /api/v1/sweep, GET /api/v1/best-config (Tier 1 ranked sweep)
 │   │   └── runs.py          # GET /runs/{id}/status
 │   ├── core/
 │   │   ├── orchestrator.py  # run_sweep(), resume_sweep(), run_single() pipeline; index preflight
+│   │   ├── embedder_factory.py  # get_embedder(provider) — voyage | local | sie dispatch
+│   │   ├── sie_embedder.py  # SIE embeddings (BGE-M3, Stella-v5, SPLADE-v3)
+│   │   ├── sie_guard.py     # SIE preflight — SIE_ENABLED + gateway reachability
+│   │   ├── aim_logger.py    # Aim experiment run logging (no-op on init failure)
 │   │   ├── executors.py     # SWEEP_EXECUTOR + HEAVY_READ_EXECUTOR (isolate long work from API pool)
 │   │   ├── search_index_plan.py  # required indexes from config; capacity assessment (pure)
 │   │   ├── search_index_guard.py # cluster snapshot + ensure retry; SearchIndexMismatchError
@@ -129,8 +136,9 @@ rag-params-finder/
 │   │   ├── status.py        # RunStatus model
 │   │   └── results.py       # QueryResult, SearchResult, Chunk
 │   └── db/
-│       ├── atlas.py         # MongoDB connection singleton
-│       └── indexes.py       # collection + search index creation; list_cluster_search_indexes()
+│       ├── atlas.py         # MongoDB connection singleton (TLS for cloud URIs only)
+│       ├── mongodb_uri.py   # is_atlas_uri(), parse_atlas_cluster_name() — cloud vs local detection
+│       └── indexes.py       # collection + search index creation; bootstrap_indexes() on local URI
 ├── cli/
 │   ├── main.py              # Typer app (run, cancel, pause, resume, delete, indexes, version)
 │   ├── indexes_cmd.py       # indexes list | reset subcommands
@@ -175,8 +183,8 @@ Each run progresses through phases tracked in the `run_status` collection:
 | `QUEUED` | Run created, waiting to start |
 | `PARSING` | Source files (PDF/TXT/MD/CSV) → plain text |
 | `CHUNKING` | Text → chunks (per the configured method and params) |
-| `EMBEDDING` | Chunks → embedding vectors (Voyage API or local model) |
-| `STORING` | Write chunks + embeddings to Atlas |
+| `EMBEDDING` | Chunks → embedding vectors (Voyage API, local model, or SIE gateway) |
+| `STORING` | Write chunks + embeddings to MongoDB |
 | `QUERYING` | Execute all test queries against the vector index |
 | `RERANKING` | Cross-encoder reranks top-K initial results to top-K final |
 | `COMPLETE` / `FAILED` / `INTERRUPTED` | Terminal state |
@@ -185,11 +193,12 @@ Each run progresses through phases tracked in the `run_status` collection:
 
 ## 🤖 Provider System
 
-Two independent provider settings in each experiment config:
+Three embedding providers routed via `embedder_factory.get_embedder(provider)` — the orchestrator never branches on provider directly.
 
 **Embedding provider** (`embedding.provider`):
 - `local` → `server/core/local_embedder.py` → sentence-transformers `all-MiniLM-L6-v2` (384-dim)
 - `voyage` → `server/core/embedder.py` → Voyage AI API (1024-dim); `voyage-context-3` uses `contextualized_embed()` with per-document segment splitting (32K-token window)
+- `sie` → `server/core/sie_embedder.py` → BGE-M3, Stella-v5 (1024-dim dense), SPLADE-v3 (30522-dim sparse); preflight via `sie_guard.py`; see [SIE setup](../user-guide/sie-setup.md)
 
 **Retrieval configuration** (`retrieval.retrievers`):
 - List of retriever types to sweep — each entry becomes one run (never combined)
@@ -200,11 +209,26 @@ Two independent provider settings in each experiment config:
   - Reranker runs fetch dense candidates internally before reranking
 - Old format (`methods` + `retrieval_provider`/`retrieval_model`) auto-migrates to `retrievers` via Pydantic validator
 
-Provider flows explicitly through `RunParams` → `orchestrator` → embedder/reranker. The `model_registry.py` validates that model names match the declared provider at config load time.
+Provider flows explicitly through `RunParams` → `orchestrator` → `embedder_factory` → embedder/reranker. The `model_registry.py` validates that model names match the declared provider at config load time.
+
+**Tier 1 sweep API**: `POST /api/v1/sweep` accepts a ranked sweep request (caller supplies corpus list); `GET /health` includes `sie` and `version` fields when SIE is configured.
 
 ---
 
-## 🗄️ MongoDB Atlas Collections
+## 🗄️ MongoDB Backend
+
+Two deployment modes share identical query syntax (`$vectorSearch`, `$search`):
+
+| Mode | URI pattern | Index provisioning |
+|------|-------------|-------------------|
+| **Atlas cloud** | `mongodb+srv://...` | Manual in Atlas UI on M0/M2/M5; server preflights on submit |
+| **Atlas Local (Docker)** | `mongodb://localhost:27017/...?directConnection=true` | `bootstrap_indexes()` on server boot — no UI steps |
+
+Detection: `server/db/mongodb_uri.py` (`is_atlas_uri`). TLS enabled only for cloud URIs (`server/db/atlas.py`). Docker: `./start-services.sh --local` or `RAG_LOCAL_ATLAS=1`. See [MongoDB Setup](../user-guide/mongodb-setup.md).
+
+---
+
+## 🗄️ MongoDB Collections
 
 | Collection | Purpose | Key Indexes |
 |---|---|---|
@@ -260,10 +284,11 @@ See `docs/adr/` for Architecture Decision Records:
 | Mode | Command | Notes |
 |------|---------|-------|
 | Manual (default dev) | `uvicorn` + `npm run dev` | Two terminals; hot reload |
-| Docker (prod profile) | `./start-services.sh` | Server + dashboard containers; host CLI |
+| Docker (prod profile) | `./start-services.sh` | Server + dashboard containers; Atlas cloud from `.env` |
+| Docker + Atlas Local | `./start-services.sh --local` | Adds `mongodb-atlas-local` container; auto-provisions search indexes |
 | Docker (dev profile) | `docker compose --profile dev up` | Bind mounts + HMR |
 
-Atlas connection string and API keys live in `.env` on the host (mounted into the server container). See [SLICE-14-DOCKER-COMPOSE.md](../slices/SLICE-14-DOCKER-COMPOSE.md).
+Atlas connection string and API keys live in `.env` on the host (mounted into the server container). See [SLICE-14-DOCKER-COMPOSE.md](../slices/SLICE-14-DOCKER-COMPOSE.md) and [MongoDB Setup](../user-guide/mongodb-setup.md).
 
 ---
 

--- a/docs/contributor-guide/extending.md
+++ b/docs/contributor-guide/extending.md
@@ -4,6 +4,7 @@
 ![FastAPI](https://img.shields.io/badge/FastAPI-009688?logo=fastapi&logoColor=white)
 ![Voyage AI](https://img.shields.io/badge/Voyage_AI-FF6B6B)
 ![sentence-transformers](https://img.shields.io/badge/sentence--transformers-FF9D00?logo=huggingface&logoColor=white)
+![SIE](https://img.shields.io/badge/SIE-Superlinked_Inference_Engine-blue)
 
 How to add new embedding models, chunking methods, retrieval methods, and API endpoints.
 

--- a/docs/contributor-guide/local-environment.md
+++ b/docs/contributor-guide/local-environment.md
@@ -2,6 +2,7 @@
 
 ![MongoDB](https://img.shields.io/badge/MongoDB_Atlas-47A248?logo=mongodb&logoColor=white)
 ![Voyage AI](https://img.shields.io/badge/Voyage_AI-FF6B6B)
+![SIE](https://img.shields.io/badge/SIE-Superlinked_Inference_Engine-blue)
 ![Python](https://img.shields.io/badge/Python-3.12+-3776AB?logo=python&logoColor=white)
 
 Internal notes for local setup, debugging, and maintenance. Not required for basic contribution — see [development.md](development.md) for the standard dev workflow.
@@ -13,6 +14,21 @@ Internal notes for local setup, debugging, and maintenance. Not required for bas
 **User-facing guide:** [MongoDB Setup](../user-guide/mongodb-setup.md#mongodb-atlas-required) — account, cluster, connection string, and search indexes with official MongoDB doc links.
 
 The sections below are contributor/debugging notes. Prefer the mongodb-setup guide for onboarding.
+
+### Path B — Atlas Local (Docker)
+
+For offline development without a cloud Atlas account, use Atlas Local via Docker. Search indexes are **auto-provisioned on server boot** — skip the manual UI steps below.
+
+→ [MongoDB Setup → Path B](../user-guide/mongodb-setup.md#path-b--atlas-local-docker)
+
+```bash
+./start-services.sh --local          # server + dashboard + mongodb-atlas-local
+./start-services.sh mongodb status     # container health only
+```
+
+Local URI (from `.env.example`): `mongodb://localhost:27017/rag_params_finder?directConnection=true`
+
+**Cloud Path A only:** the manual index JSON definitions below apply when using `mongodb+srv://...` on M0/M2/M5.
 
 ### Connection String Format
 
@@ -70,14 +86,38 @@ The `text_search_index`, `vector_index_384`, and `vector_index_1024` all coexist
 
 ---
 
+## 🔬 SIE (Superlinked Inference Engine)
+
+**User-facing guide:** [SIE Setup](../user-guide/sie-setup.md) — remote gateway (preferred) or optional self-hosted Docker.
+
+Env vars (see [`.env.example`](../../.env.example) for full comments):
+
+```bash
+SIE_ENABLED=true
+SIE_ENDPOINT=https://your-sie-gateway.example.com   # or http://localhost:8720 for local Docker
+SIE_API_KEY=your_gateway_token                      # omit when gateway has no auth
+AIM_REPO=./.aim                                     # optional — Aim UI via ./scripts/aim-ui.sh
+```
+
+Example sweep: `rag-params-finder run --config configs/example-mongodb-sie.yaml`
+
+---
+
 ## 🔑 Full .env Reference
 
 ```bash
-# MongoDB Atlas (REQUIRED)
+# MongoDB Atlas (REQUIRED — cloud or Atlas Local)
 MONGODB_URI=mongodb+srv://<user>:<pass>@<cluster>.mongodb.net/rag_params_finder?retryWrites=true&w=majority
+# Atlas Local alternative:
+# MONGODB_URI=mongodb://localhost:27017/rag_params_finder?directConnection=true
 
 # Voyage AI (OPTIONAL — only if using Voyage models)
 VOYAGE_API_KEY=vo-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# SIE (OPTIONAL — only if using provider: sie)
+# SIE_ENABLED=true
+# SIE_ENDPOINT=https://your-sie-gateway.example.com
+# SIE_API_KEY=
 
 # Server URL (used by CLI, default is localhost:8001)
 SERVER_URL=http://localhost:8001

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -2,6 +2,7 @@
 
 ![Python](https://img.shields.io/badge/Python-3.12+-3776AB?logo=python&logoColor=white)
 ![FastAPI](https://img.shields.io/badge/FastAPI-009688?logo=fastapi&logoColor=white)
+![SIE](https://img.shields.io/badge/SIE-Superlinked_Inference_Engine-blue)
 
 All `rag-params-finder` commands and flags. The server must be running at `SERVER_URL` (default: `http://localhost:8001`) for commands that call the API.
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -3,6 +3,7 @@
 ![Python](https://img.shields.io/badge/Python-3.12+-3776AB?logo=python&logoColor=white)
 ![Voyage AI](https://img.shields.io/badge/Voyage_AI-FF6B6B)
 ![sentence-transformers](https://img.shields.io/badge/sentence--transformers-FF9D00?logo=huggingface&logoColor=white)
+![SIE](https://img.shields.io/badge/SIE-Superlinked_Inference_Engine-blue)
 
 All YAML fields, sweep expansion rules, and queries file format.
 

--- a/docs/user-guide/dashboard-guide.md
+++ b/docs/user-guide/dashboard-guide.md
@@ -7,6 +7,8 @@
 
 The React dashboard at `http://localhost:5374` visualizes experiments and results. Experiments are **submitted from the CLI**; the dashboard can **pause, resume, cancel, and delete** active sweeps. It polls the server every 2 seconds while any experiment is `running` or `paused`.
 
+**Prerequisites:** MongoDB backend ready ([MongoDB Setup](mongodb-setup.md)) and server running. Optional SIE sweeps require [SIE Setup](sie-setup.md) before submitting `example-mongodb-sie.yaml`.
+
 All screens feature:
 - **Loading feedback panels** with progress bars during initial data loads
 - **Polling indicators** (subtle "Syncing..." badge) during background refreshes

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -5,6 +5,7 @@
 ![MongoDB](https://img.shields.io/badge/MongoDB_Atlas-47A248?logo=mongodb&logoColor=white)
 ![Voyage AI](https://img.shields.io/badge/Voyage_AI-FF6B6B)
 ![sentence-transformers](https://img.shields.io/badge/sentence--transformers-FF9D00?logo=huggingface&logoColor=white)
+![SIE](https://img.shields.io/badge/SIE-Superlinked_Inference_Engine-blue)
 
 Everything you need to run your first RAG parameter sweep experiment.
 

--- a/docs/user-guide/mongodb-setup.md
+++ b/docs/user-guide/mongodb-setup.md
@@ -2,6 +2,7 @@
 
 ![MongoDB](https://img.shields.io/badge/MongoDB_Atlas-47A248?logo=mongodb&logoColor=white)
 ![Voyage AI](https://img.shields.io/badge/Voyage_AI-FF6B6B)
+![SIE](https://img.shields.io/badge/SIE-Superlinked_Inference_Engine-blue)
 
 **Essential, minimal steps** to run the example sweep commands on **Atlas Cloud** or **Atlas Local (Docker)**. Official vendor docs are linked; details you can skip are marked *optional*.
 
@@ -135,6 +136,8 @@ The server **preflights** required indexes on experiment submit — missing inde
 ---
 
 ## Path B — Atlas Local (Docker)
+
+![MongoDB Atlas Local](https://img.shields.io/badge/MongoDB_Atlas_Local-Docker-47A248?logo=mongodb&logoColor=white)
 
 Run the full RAG pipeline — including `$vectorSearch` and `$search` (BM25) — on your laptop using the official `mongodb/mongodb-atlas-local` Docker image. No Atlas cloud account, no 512 MB storage ceiling, no manual UI index creation.
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -2,6 +2,7 @@
 
 ![MongoDB](https://img.shields.io/badge/MongoDB_Atlas-47A248?logo=mongodb&logoColor=white)
 ![Voyage AI](https://img.shields.io/badge/Voyage_AI-FF6B6B)
+![SIE](https://img.shields.io/badge/SIE-Superlinked_Inference_Engine-blue)
 ![FastAPI](https://img.shields.io/badge/FastAPI-009688?logo=fastapi&logoColor=white)
 
 Common errors and how to fix them.


### PR DESCRIPTION
## Summary
- docs(slice-21-25b): complete MongoDB Local + SIE doc sweep

## Test plan
- [x] 78 pytest tests pass
- [x] SIE badge present in all user/contributor guides with Voyage badge rows
- [x] `architecture.md` documents SIE, `embedder_factory`, Atlas Local, and sweep API
- [x] `local-environment.md` Path B + SIE env synced with `.env.example`
- [x] ADR-002 evolution note and ADR-003 Atlas Local footnote added
- [x] DOCS-CODE-AUDIT and DOC-GAPS refreshed (78 tests)
- [x] No stale `cloud-setup.md` refs in user/contributor entry points
- [x] markdownlint passes on changed files

**Note:** Squash merge recommended — branch may show 2 commits due to clean-commit hook history rewrite; file delta is 16 docs only.

Made with [Cursor](https://cursor.com)