### PR TITLE
ci: grant gitleaks pull-request permissions on PR scans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,9 @@ jobs:
   secrets:
     name: Secrets scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Summary
- Grant the secrets job explicit `pull-requests: write` and `contents: read` permissions so gitleaks can list PR commits under GitHub's read-only default `GITHUB_TOKEN` policy

## Why
`gitleaks/gitleaks-action` calls `GET /repos/.../pulls/{n}/commits` during PR scans. Without explicit permissions this returns HTTP 403 `Resource not accessible by integration`.

## Test plan
- [ ] Open or re-run CI on this PR — secrets job completes without 403
- [ ] Other CI jobs (repo-lint, backend, frontend) remain green

Made with [Cursor](https://cursor.com)