### PR TITLE
ci: harden gitleaks diff range resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,8 @@ jobs:
     if: ${{ github.event_name != 'schedule' }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
 
       - name: Fetch base ref for PR
         if: github.event_name == 'pull_request'
@@ -270,12 +272,28 @@ jobs:
       - name: Configure gitleaks diff range
         id: gitleaks-range
         run: |
+          set -euo pipefail
+
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "range=origin/${{ github.base_ref }}..${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            if git show-ref --verify --quiet "refs/remotes/origin/${{ github.base_ref }}"; then
+              echo "range=origin/${{ github.base_ref }}..${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            else
+              echo "::warning::Base ref origin/${{ github.base_ref }} not available; running full tree scan."
+              echo "range=" >> "$GITHUB_OUTPUT"
+            fi
           elif [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
             echo "range=" >> "$GITHUB_OUTPUT"
           else
-            echo "range=${{ github.event.before }}..${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            RANGE="${{ github.event.before }}..${{ github.sha }}"
+            if ! git cat-file -e "${{ github.event.before }}^{commit}"; then
+              echo "::warning::Base commit ${{ github.event.before }} is missing from checkout; running full tree scan."
+              echo "range=" >> "$GITHUB_OUTPUT"
+            elif ! git rev-list -n 1 $RANGE -- >/dev/null 2>&1; then
+              echo "::warning::Gitleaks range '$RANGE' is not available in checkout; running full tree scan."
+              echo "range=" >> "$GITHUB_OUTPUT"
+            else
+              echo "range=$RANGE" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
       - name: Fast diff-only gitleaks (incremental range)


### PR DESCRIPTION
## What
- Fix Secrets scan job failures when gitleaks gets a commit range whose base commit is missing from the shallow checkout (for example, merge/push with minimal fetch depth).
- Add guarded range validation in CI:
  - verify base ref exists for PR scans
  - verify base commit exists locally for push scans
  - verify the git range is valid before passing it to gitleaks
  - fall back to full-tree fast scan when incremental range is unavailable
- Set checkout depth to 2 in the secrets job to reduce fetch cost while retaining parent commit availability.

## Why
This avoids flaky `Invalid revision range` errors in CI while preserving diff-first secrets scanning behavior.
