### PR TITLE
docs(slice-16): align parallelism and retry guidance with implemented behavior

### DIFF
--- a/docs/plan/slices/SLICE-16-PARALLEL-SWEEP-RUNS.md
+++ b/docs/plan/slices/SLICE-16-PARALLEL-SWEEP-RUNS.md
@@ -62,7 +62,7 @@ Recommendation: prototype **Approach A** inside `orchestrator` first *(same Mong
 ### Re-apply planning note (threading + rate-limit strategy review)
 
 - **Threading model re-evaluated**: thread-based bounded scheduling via `ThreadPoolExecutor` + bounded futures was re-affirmed over process-based pools. The thread model keeps existing in-process cancellation/error semantics and minimal scheduler state for run-phase accounting; process pools would add pickling and lifecycle coupling without material throughput benefit for local sentence-transformers sweeps.
-- **Rate-limit protection re-evaluated**: shared provider limiter designs were reviewed, but this demo session intentionally defers cross-experiment/cluster-scoped rate limiting as out-of-scope. SIE protection remains **hardcoded in-process encoding permit cap + transient-503 retry/backoff**, because this slice is scoped to local provider runs and avoids extra infra coupling.
+- **Rate-limit protection re-evaluated**: shared provider limiter designs were reviewed, but this demo session intentionally defers cross-experiment/cluster-scoped rate limiting as out-of-scope. SIE protection remains **hardcoded in-process encoding permit cap + transient retry/backoff for 503/429/rate-limit failures**, with `Retry-After` honored when present.
 
 ---
 
@@ -83,7 +83,7 @@ Recommendation: prototype **Approach A** inside `orchestrator` first *(same Mong
 | Approach A vs B | **A only** (`ThreadPoolExecutor` + bounded in-process scheduler) implemented for this slice; B explicitly out of scope today |
 | SIE saturation handling | **Hardcoded in-process permit cap** + exponential backoff retries on transient 503-style SIE failures, no cross-process limiter |
 | `on_error: stop` vs in-flight runs | `on_error: stop` means stop scheduling new `_run_single` runs after first failure; in-flight runs are allowed to finish |
-| Voyage limiting: centralized vs per-run | Skipped for this demo slice because runs are local sentence-transformers only |
+| Voyage limiting: centralized vs per-run | Skipped for this slice; shared limiter designs are deferred in favor of in-process provider caps + retry safety (with 503/429 handling) |
 
 ---
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -77,6 +77,7 @@ execution:
 - **Local-provider guidance**: local `sentence-transformers` runs are CPU-bound; when `parallelism > 1`, in-process worker threads should each use a reduced thread budget so they don’t each consume all CPU cores.
 - **Local runtime note**: set `parallelism` based on available cores and desired utilization (for example, with 8 cores and `parallelism=4`, each local embedding worker runs with ~2 intra-op threads).
 - **Voyage / remote providers**: larger parallelism can hit external RPM/TPM quotas; for that path, use cautious values and dedicated throttling (not part of this slice).
+- **SIE**: transient retry protection is in-process in this demo path (e.g., `503`, `429`, and `rate-limit` style failures), with `Retry-After` honored where available. SIE requests remain capped in-process to avoid runaway fan-out.
 - **Slice 16 implemented**: **[Slice 16 — Parallel Sweep Runs](../plan/slices/SLICE-16-PARALLEL-SWEEP-RUNS.md)** adds bounded concurrent `_run_single` scheduling with current `on_error` and cancellation semantics; optional queue-based rollout remains out of scope.
 
 ### Example config files


### PR DESCRIPTION
## Summary
- docs(slice-16): align parallelism and retry guidance with implemented behavior

## Closes
Closes #16

## Test plan
- ./scripts/quality-gates.sh --quick
- python and frontend checks via quick gates in this PR pass
- PR-only docs change; no runtime behavior changes