### PR TITLE
fix(frontend): update lockfile and enable on-demand nightly dependency audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,13 @@ on:
     branches: [main]
   schedule:
     - cron: "0 2 * * *"
+  workflow_dispatch:
+    inputs:
+      run_full_dependency_audit:
+        description: "Run the full dependency audit job (previously schedule-only)"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   changes:
@@ -216,7 +223,7 @@ jobs:
   nightly-dependency-audit:
     name: Nightly dependency audit (full lockfile sweep)
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'schedule' }}
+    if: ${{ github.event_name == 'schedule' || github.event.inputs.run_full_dependency_audit == 'true' }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1076,9 +1076,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1161,9 +1161,9 @@
       "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2992,9 +2992,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3334,9 +3334,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Resolve a high-severity frontend dependency vulnerability by updating the lockfile (brace-expansion package issue).
- Add a manual dispatch option to the nightly dependency audit workflow path so the same dependency checks can be triggered outside schedule events.
- Keep scheduled nightly behavior unchanged while enabling controlled on-demand runs.

## Outcome
- PR includes two commits:
  - `fix(frontend): update lockfile to resolve brace-expansion high-sev vuln`
  - `chore(ci): add manual trigger for nightly dependency audit`
- Scope is intentionally narrow and backward-compatible:
  - CI logic remains stable for scheduled runs.
  - Added `workflow_dispatch` + boolean input for explicit manual execution.
  - Added guard so the full lockfile sweep runs for manual trigger or schedule.

## Verification
- Local (subset): `UV_CACHE_DIR=/tmp/rag-slice39-uv CACHE_DIR=/tmp/rag-slice39-cache bash scripts/quality-gates.sh --quick`
- Targeted CI validation: manual workflow run at `https://github.com/neomatrix369/rag-params-finder/actions/runs/29822458362` executed successfully.
- PR checks were refreshed after applying changes.

## Notes
- This was opened as a follow-up to the previous dependency vulnerability fix to reduce recurrence risk and provide a reliable on-demand path for the audit.
