### PR TITLE
feat(slice-41a): add Bayesian search strategy support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,28 +1,34 @@
+# Local Docker stack:
+# No values need to be changed. Run:
+#   ./start-services.sh --local
+#
+# Host CLI after the stack starts:
+#   export MONGODB_URI=mongodb://localhost:27017/rag_params_finder?directConnection=true
+MONGODB_URI=your_mongodb_atlas_uri_here
+
+# FastAPI Server URL (for CLI to connect to)
+SERVER_URL=http://localhost:8001
+
+SIE_ENABLED=false
+
+# MongoDB — Atlas Cloud (default) or Atlas Local Docker.
+# Atlas Cloud: replace the placeholder with your connection string.
+# Atlas Local: leave the placeholder unchanged; --local supplies the
+# container connection internally. Set the local URI only for the host CLI.
+# MONGODB_URI=mongodb://localhost:27017/rag_params_finder?directConnection=true
+#
+# MongoDB Atlas Local (local Docker, no cloud account needed):
+#   Start: ./start-services.sh --local
+#   Then set this URI for host CLI and local server:
+# MONGODB_URI=mongodb://localhost:27017/rag_params_finder?directConnection=true
+#   See docs/user-guide/mongodb-setup.md
+
 # ── Minimum for sweeps ────────────────────────────────────────────────────────
 # Local sweep (example-mongodb-local.yaml):  MONGODB_URI only
 # Voyage sweep (example-mongodb-voyage.yaml): MONGODB_URI + VOYAGE_API_KEY + Tier 1 limits below
 # SIE sweep (example-mongodb-sie.yaml):       MONGODB_URI + SIE_ENABLED=true + SIE_ENDPOINT
 #                                             (+ SIE_API_KEY when gateway auth is enabled)
-# Full checklist: docs/user-guide/mongodb-setup.md#before-you-run-a-sweep
-VOYAGE_API_KEY=your_voyage_api_key_here
-# Voyage rate limits — free tier defaults below; override for Tier 1 (Voyage sweep)
-VOYAGE_RPM_LIMIT=3
-VOYAGE_TPM_LIMIT=10000
 
-# Voyage rate limits - Tier 1
-# VOYAGE_RPM_LIMIT=2000
-# VOYAGE_TPM_LIMIT=16000000
-
-# MongoDB — Atlas cloud (default) OR Atlas Local Docker (zero-cloud dev mode)
-#
-# Option A — Atlas cloud (default):
-MONGODB_URI=your_mongodb_atlas_uri_here
-#
-# Option B — MongoDB Atlas Local (local Docker, no cloud account needed):
-#   Start: ./start-services.sh --local
-#   Then set this URI for host CLI and local server:
-# MONGODB_URI=mongodb://localhost:27017/rag_params_finder?directConnection=true
-#   See docs/user-guide/mongodb-setup.md
 
 # Optional — auto-detect cluster storage quota for the dashboard (Atlas Admin API).
 # Without these, set MONGODB_STORAGE_LIMIT_MB manually or quota UI stays hidden.
@@ -32,8 +38,15 @@ MONGODB_URI=your_mongodb_atlas_uri_here
 # ATLAS_CLUSTER_NAME=                     # omit to parse from MONGODB_URI host
 # MONGODB_STORAGE_LIMIT_MB=512            # manual override (MB); skips API lookup
 
-# FastAPI Server URL (for CLI to connect to)
-SERVER_URL=http://localhost:8001
+# Full checklist: docs/user-guide/mongodb-setup.md#before-you-run-a-sweep
+VOYAGE_API_KEY=your_voyage_api_key_here
+# Voyage rate limits — free tier defaults below; override for Tier 1 (Voyage sweep)
+VOYAGE_RPM_LIMIT=3
+VOYAGE_TPM_LIMIT=10000
+
+# Voyage rate limits - Tier 1
+# VOYAGE_RPM_LIMIT=2000
+# VOYAGE_TPM_LIMIT=16000000
 
 # ── SIE (opt-in — not started by ./start-services.sh) ────────────────────────
 # Three server vars — same for remote gateway AND local Docker:

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -39,7 +39,37 @@ CLI on the host always uses `SERVER_URL=http://localhost:8001` (default in `.env
 
 Pick **one** path. MongoDB must be reachable before the server health check passes (Docker waits for the server; the dashboard waits on the server).
 
-### Path A — Manual (two terminals, any MongoDB backend)
+### Path A — Docker + zero cloud (recommended offline)
+
+No Atlas account. MongoDB Atlas Local runs in Docker; indexes are auto-created on boot (~30–60 s first time).
+
+```bash
+./start-services.sh --local      # MongoDB + server + dashboard
+```
+
+For host CLI sweeps after Path A, use the local URI (also printed by the script):
+
+```bash
+export MONGODB_URI="mongodb://localhost:27017/rag_params_finder?directConnection=true"
+```
+
+Do **not** run `./start-services.sh` (without `--local`) while `.env` points at `localhost:27017` — the server container cannot reach the host’s `localhost`.
+
+If MongoDB stays unhealthy (`keyfile` / `Unable to acquire security key`), reset stale volumes once after upgrading:
+
+```bash
+./start-services.sh mongodb reset && ./start-services.sh --local
+```
+
+### Path B — Docker + Atlas cloud (one command)
+
+Requires a real `mongodb+srv://…` URI in `.env` (not the placeholder).
+
+```bash
+./start-services.sh              # server :8001 + dashboard :5374
+```
+
+### Path C — Manual (two terminals, any MongoDB backend)
 
 Set `MONGODB_URI` in `.env` first ([mongodb-setup.md](docs/user-guide/mongodb-setup.md)).
 
@@ -54,36 +84,6 @@ cd frontend && npm run dev                      # Terminal 2 (optional)
 ```
 
 **Atlas cloud:** create search indexes in the Atlas UI first (M0), then start uvicorn + frontend as above with `mongodb+srv://…` in `.env`.
-
-### Path B — Docker + Atlas cloud (one command)
-
-Requires a real `mongodb+srv://…` URI in `.env` (not the placeholder).
-
-```bash
-./start-services.sh              # server :8001 + dashboard :5374
-```
-
-### Path C — Docker + zero cloud (recommended offline)
-
-No Atlas account. MongoDB Atlas Local runs in Docker; indexes are auto-created on boot (~30–60 s first time).
-
-```bash
-./start-services.sh --local      # MongoDB + server + dashboard
-```
-
-For host CLI sweeps after Path C, use the local URI (also printed by the script):
-
-```bash
-export MONGODB_URI="mongodb://localhost:27017/rag_params_finder?directConnection=true"
-```
-
-Do **not** run `./start-services.sh` (without `--local`) while `.env` points at `localhost:27017` — the server container cannot reach the host’s `localhost`.
-
-If MongoDB stays unhealthy (`keyfile` / `Unable to acquire security key`), reset stale volumes once after upgrading:
-
-```bash
-./start-services.sh mongodb reset && ./start-services.sh --local
-```
 
 ---
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -138,15 +138,15 @@ Keep credentials in `.env`; never put them in committed YAML configs.
 
 > **Naming note:** `example-mongodb-local.yaml` uses **local embedding models**(sentence-transformers), not local MongoDB. Any example config works with either MongoDB backend — only `MONGODB_URI` (or `./start-services.sh --local`) picks the database.
 
-</details>
 ---
+</details>
 
 ## Local stack at a glance
 
 | Service | URL / port | Required? | Started by |
 |---------|------------|-----------|------------|
-| FastAPI server | `http://localhost:8001` | Yes | `uvicorn` or `./start-services.sh` |
-| Dashboard | `http://localhost:5374` | Recommended | `npm run dev` or `./start-services.sh` |
+| FastAPI server | `http://localhost:8001` | Yes | `./start-services.sh --local` or `./start-services.sh` or `uvicorn` |
+| Dashboard | `http://localhost:5374` | Recommended | `./start-services.sh --local` or `./start-services.sh` or `npm run dev` |
 | MongoDB | `localhost:27017` (local) or Atlas cloud | Yes | `./start-services.sh --local`, `./start-services.sh mongodb start`, or Atlas |
 | SIE gateway | `http://localhost:8720` | SIE sweeps only | Manual — **not** in `start-services.sh`; see [sie-setup.md](docs/user-guide/sie-setup.md) |
 
@@ -234,9 +234,13 @@ Complete the checklist for your config in [mongodb-setup → Before you run a sw
 ```bash
 rag-params-finder run --config configs/example-mongodb-local-bayesian.yaml
 # 100 runs using the Bayesian optimizer
+
 rag-params-finder run --config configs/example-mongodb-sie-parallel.yaml
 # 120 runs of configs/example-mongodb-local.yaml using the Grid Search run in parallelisation
+
 rag-params-finder run --config configs/example-mongodb-local.yaml   # 120 runs, no API key
+
+
 rag-params-finder run --config configs/example-mongodb-voyage.yaml  # 40 runs, Voyage + Tier 1
 # rag-params-finder run --config configs/example-mongodb-sie.yaml   # SIE — see sie-setup.md
 ```

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -4,9 +4,103 @@
 
 ---
 
-## Install
+## Choose your path
 
-**Prerequisites:** Python 3.12+, Node.js 22+, MongoDB ([Atlas cloud or local Docker](docs/user-guide/mongodb-setup.md#choose-your-mongodb-backend)). [Voyage AI](docs/user-guide/mongodb-setup.md#voyage-ai-required-for-voyage-sweep) is optional for local-embedding sweeps.
+### Visitor / judge
+
+Use this path to see the project working with the least setup.
+
+**Prerequisites:**
+
+- Git
+- Docker Desktop installed and running
+
+No Atlas account, Voyage AI key, Node.js installation, or local MongoDB
+installation is required for this path.
+
+```bash
+git clone https://github.com/neomatrix369/rag-params-finder.git
+cd rag-params-finder
+./start-services.sh --local
+```
+
+Then open `http://localhost:5374`. The Docker stack starts MongoDB Atlas
+Local, the API server, and the dashboard.
+
+<details>
+<summary>User running experiments</summary>
+
+**Prerequisites:**
+
+- Git
+- Python 3.12+
+- `uv`
+- MongoDB Atlas Cloud or MongoDB Atlas Local through Docker
+- `MONGODB_URI` when using the host CLI
+- Voyage AI credentials only for Voyage configurations
+- Node.js 22+ and npm only when running the dashboard on the host
+
+See [Getting Started](docs/user-guide/getting-started.md) for the detailed
+experiment setup and [MongoDB Setup](docs/user-guide/mongodb-setup.md) for the
+selected database path.
+
+</details>
+
+<details>
+<summary>Researcher comparing configurations</summary>
+
+**Prerequisites:**
+
+- Everything required to run experiments
+- Example data and question files
+- The dashboard is recommended for comparing results
+- A local or hosted embedding provider, depending on the experiment
+
+See the [Configuration Reference](docs/user-guide/configuration.md) for sweep
+dimensions, parallelism, and Bayesian search.
+
+</details>
+
+<details>
+<summary>Developer extending or debugging the project</summary>
+
+**Prerequisites:**
+
+- Git
+- Python 3.12+
+- `uv`
+- Node.js 22+ and npm
+- Docker Desktop
+
+Install development dependencies with:
+
+```bash
+uv pip install -e ".[dev]"
+cd frontend && npm install
+```
+
+See the [Development Guide](docs/contributor-guide/development.md) for quality
+gates, Docker workflows, and the development loop.
+
+</details>
+
+<details>
+<summary>Operator or troubleshooter</summary>
+
+Requirements depend on the deployed setup:
+
+- Docker for Docker-managed services
+- Atlas credentials and `MONGODB_URI` for MongoDB Atlas Cloud
+- Development dependencies are not required unless changing code
+
+See the [Troubleshooting Guide](docs/user-guide/troubleshooting.md) for health
+checks, logs, indexes, storage, and recovery procedures.
+
+</details>
+
+---
+
+## Install
 
 ```bash
 git clone https://github.com/neomatrix369/rag-params-finder.git

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -113,7 +113,8 @@ See the [Troubleshooting Guide](docs/user-guide/troubleshooting.md) for health c
 
 ---
 
-## Install
+<details>
+<summary>Install</summary>
 
 ```bash
 git clone https://github.com/neomatrix369/rag-params-finder.git
@@ -137,6 +138,7 @@ Keep credentials in `.env`; never put them in committed YAML configs.
 
 > **Naming note:** `example-mongodb-local.yaml` uses **local embedding models**(sentence-transformers), not local MongoDB. Any example config works with either MongoDB backend — only `MONGODB_URI` (or `./start-services.sh --local`) picks the database.
 
+</details>
 ---
 
 ## Local stack at a glance
@@ -233,7 +235,7 @@ Complete the checklist for your config in [mongodb-setup → Before you run a sw
 rag-params-finder run --config configs/example-mongodb-local-bayesian.yaml
 # 100 runs using the Bayesian optimizer
 rag-params-finder run --config configs/example-mongodb-sie-parallel.yaml
-# 120 runs of configs/example-mongodb-local.yaml  using the Grid Search
+# 120 runs of configs/example-mongodb-local.yaml using the Grid Search run in parallelisation
 rag-params-finder run --config configs/example-mongodb-local.yaml   # 120 runs, no API key
 rag-params-finder run --config configs/example-mongodb-voyage.yaml  # 40 runs, Voyage + Tier 1
 # rag-params-finder run --config configs/example-mongodb-sie.yaml   # SIE — see sie-setup.md

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -4,6 +4,24 @@
 
 ---
 
+## Contents
+
+- [Choose your path](#choose-your-path)
+  - [Visitor / judge](#visitor--judge)
+  - [User running experiments](#user-running-experiments)
+  - [Researcher comparing configurations](#researcher-comparing-configurations)
+  - [Developer extending or debugging the project](#developer-extending-or-debugging-the-project)
+  - [Operator or troubleshooter](#operator-or-troubleshooter)
+- [Install](#install)
+- [Local stack at a glance](#local-stack-at-a-glance)
+- [Choose how to start](#choose-how-to-start)
+  - [Path A — Docker + zero cloud](#path-a--docker--zero-cloud-recommended-offline)
+  - [Path B — Docker + Atlas cloud](#path-b--docker--atlas-cloud-one-command)
+  - [Path C — Manual](#path-c--manual-two-terminals-any-mongodb-backend)
+- [Verify the stack](#verify-the-stack)
+- [Run a sweep](#run-a-sweep)
+- [Next steps](#next-steps)
+
 ## Choose your path
 
 ### Visitor / judge
@@ -21,11 +39,11 @@ installation is required for this path.
 ```bash
 git clone https://github.com/neomatrix369/rag-params-finder.git
 cd rag-params-finder
+cp .env.example .env
 ./start-services.sh --local
 ```
 
-Then open `http://localhost:5374`. The Docker stack starts MongoDB Atlas
-Local, the API server, and the dashboard.
+For this path, `.env` only needs to exist; no values need to be edited. Then open `http://localhost:5374`. The Docker stack starts MongoDB Atlas Local, the API server, and the dashboard.
 
 <details>
 <summary>User running experiments</summary>
@@ -40,9 +58,7 @@ Local, the API server, and the dashboard.
 - Voyage AI credentials only for Voyage configurations
 - Node.js 22+ and npm only when running the dashboard on the host
 
-See [Getting Started](docs/user-guide/getting-started.md) for the detailed
-experiment setup and [MongoDB Setup](docs/user-guide/mongodb-setup.md) for the
-selected database path.
+See [Getting Started](docs/user-guide/getting-started.md) for the detailed experiment setup and [MongoDB Setup](docs/user-guide/mongodb-setup.md) for the selected database path.
 
 </details>
 
@@ -56,8 +72,7 @@ selected database path.
 - The dashboard is recommended for comparing results
 - A local or hosted embedding provider, depending on the experiment
 
-See the [Configuration Reference](docs/user-guide/configuration.md) for sweep
-dimensions, parallelism, and Bayesian search.
+See the [Configuration Reference](docs/user-guide/configuration.md) for sweep dimensions, parallelism, and Bayesian search.
 
 </details>
 
@@ -79,8 +94,7 @@ uv pip install -e ".[dev]"
 cd frontend && npm install
 ```
 
-See the [Development Guide](docs/contributor-guide/development.md) for quality
-gates, Docker workflows, and the development loop.
+See the [Development Guide](docs/contributor-guide/development.md) for quality gates, Docker workflows, and the development loop.
 
 </details>
 
@@ -93,8 +107,7 @@ Requirements depend on the deployed setup:
 - Atlas credentials and `MONGODB_URI` for MongoDB Atlas Cloud
 - Development dependencies are not required unless changing code
 
-See the [Troubleshooting Guide](docs/user-guide/troubleshooting.md) for health
-checks, logs, indexes, storage, and recovery procedures.
+See the [Troubleshooting Guide](docs/user-guide/troubleshooting.md) for health checks, logs, indexes, storage, and recovery procedures.
 
 </details>
 
@@ -109,10 +122,20 @@ uv venv && source .venv/bin/activate
 uv pip install -e .
 cd frontend && npm install && cd ..
 
-cp .env.example .env   # then edit — see mongodb-setup.md
+cp .env.example .env
 ```
 
-> **Naming note:** `example-mongodb-local.yaml` uses **local embedding models** (sentence-transformers), not local MongoDB. Any example config works with either MongoDB backend — only `MONGODB_URI` (or `./start-services.sh --local`) picks the database.
+The `.env.example` file contains the available settings and safe placeholders. The `.env` file is the local, uncommitted configuration read by the server and startup scripts. Edit only the values required by the path you selected:
+
+- Atlas Cloud: set `MONGODB_URI` to the Atlas connection string.
+- Atlas Local: leave the placeholders unchanged; `--local` supplies the
+  container connection internally.
+- Voyage: add `VOYAGE_API_KEY` when using a Voyage configuration.
+- SIE: enable it and set `SIE_ENDPOINT` when using an SIE configuration.
+
+Keep credentials in `.env`; never put them in committed YAML configs.
+
+> **Naming note:** `example-mongodb-local.yaml` uses **local embedding models**(sentence-transformers), not local MongoDB. Any example config works with either MongoDB backend — only `MONGODB_URI` (or `./start-services.sh --local`) picks the database.
 
 ---
 
@@ -135,7 +158,15 @@ Pick **one** path. MongoDB must be reachable before the server health check pass
 
 ### Path A — Docker + zero cloud (recommended offline)
 
-No Atlas account. MongoDB Atlas Local runs in Docker; indexes are auto-created on boot (~30–60 s first time).
+No Atlas account. MongoDB Atlas Local runs in Docker; indexes are auto-created on boot (~3 –60 s first time).
+
+Before starting, make sure `.env` exists:
+
+```bash
+cp .env.example .env
+```
+
+No `.env` values need to be edited for this path.
 
 ```bash
 ./start-services.sh --local      # MongoDB + server + dashboard
@@ -147,7 +178,7 @@ For host CLI sweeps after Path A, use the local URI (also printed by the script)
 export MONGODB_URI="mongodb://localhost:27017/rag_params_finder?directConnection=true"
 ```
 
-Do **not** run `./start-services.sh` (without `--local`) while `.env` points at `localhost:27017` — the server container cannot reach the host’s `localhost`.
+Do **not** run `./start-services.sh` (without `--local`) while `.env` points a `localhost:27017` — the server container cannot reach the host’s `localhost`.
 
 If MongoDB stays unhealthy (`keyfile` / `Unable to acquire security key`), reset stale volumes once after upgrading:
 
@@ -157,7 +188,7 @@ If MongoDB stays unhealthy (`keyfile` / `Unable to acquire security key`), reset
 
 ### Path B — Docker + Atlas cloud (one command)
 
-Requires a real `mongodb+srv://…` URI in `.env` (not the placeholder).
+Copy `.env.example` to `.env`, then set a real `mongodb+srv://…` value for `MONGODB_URI` (not the placeholder).
 
 ```bash
 ./start-services.sh              # server :8001 + dashboard :5374
@@ -165,7 +196,7 @@ Requires a real `mongodb+srv://…` URI in `.env` (not the placeholder).
 
 ### Path C — Manual (two terminals, any MongoDB backend)
 
-Set `MONGODB_URI` in `.env` first ([mongodb-setup.md](docs/user-guide/mongodb-setup.md)).
+Copy `.env.example` to `.env` first, then set `MONGODB_URI` for the selected backend ([mongodb-setup.md](docs/user-guide/mongodb-setup.md)).
 
 **Local MongoDB in Docker, server on host:**
 
@@ -199,6 +230,10 @@ Dev hot reload (Docker): `docker compose -f docker-compose.yml -f docker-compose
 Complete the checklist for your config in [mongodb-setup → Before you run a sweep](docs/user-guide/mongodb-setup.md#before-you-run-a-sweep).
 
 ```bash
+rag-params-finder run --config configs/example-mongodb-local-bayesian.yaml
+# 100 runs using the Bayesian optimizer
+rag-params-finder run --config configs/example-mongodb-sie-parallel.yaml
+# 120 runs of configs/example-mongodb-local.yaml  using the Grid Search
 rag-params-finder run --config configs/example-mongodb-local.yaml   # 120 runs, no API key
 rag-params-finder run --config configs/example-mongodb-voyage.yaml  # 40 runs, Voyage + Tier 1
 # rag-params-finder run --config configs/example-mongodb-sie.yaml   # SIE — see sie-setup.md

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -188,6 +188,8 @@ If MongoDB stays unhealthy (`keyfile` / `Unable to acquire security key`), reset
 ./start-services.sh mongodb reset && ./start-services.sh --local
 ```
 
+<details><summary>Other paths</summary>
+
 ### Path B — Docker + Atlas cloud (one command)
 
 Copy `.env.example` to `.env`, then set a real `mongodb+srv://…` value for `MONGODB_URI` (not the placeholder).
@@ -213,6 +215,7 @@ cd frontend && npm run dev                      # Terminal 2 (optional)
 **Atlas cloud:** create search indexes in the Atlas UI first (M0), then start uvicorn + frontend as above with `mongodb+srv://…` in `.env`.
 
 ---
+</details>
 
 ## Verify the stack
 
@@ -236,7 +239,7 @@ rag-params-finder run --config configs/example-mongodb-local-bayesian.yaml
 # 100 runs using the Bayesian optimizer
 
 rag-params-finder run --config configs/example-mongodb-sie-parallel.yaml
-# 120 runs of configs/example-mongodb-local.yaml using the Grid Search run in parallelisation
+# 120 runs of configs/example-mongodb-local.yaml using the Grid Search run using parallelisation
 
 rag-params-finder run --config configs/example-mongodb-local.yaml   # 120 runs, no API key
 
@@ -245,7 +248,7 @@ rag-params-finder run --config configs/example-mongodb-voyage.yaml  # 40 runs, V
 # rag-params-finder run --config configs/example-mongodb-sie.yaml   # SIE — see sie-setup.md
 ```
 
-Open `http://localhost:5374` to watch progress and explore results.
+Open `http://localhost:5374` to watch progress and explore results. See [docs/images](https://github.com/neomatrix369/rag-params-finder#-screenshots).
 
 ---
 

--- a/cli/api_client.py
+++ b/cli/api_client.py
@@ -29,6 +29,21 @@ def _response_detail(response: httpx.Response) -> str:
             detail = body.get("detail")
             if isinstance(detail, str):
                 return detail
+            if isinstance(detail, list):
+                lines = []
+                for item in detail:
+                    if not isinstance(item, dict):
+                        lines.append(str(item))
+                        continue
+                    loc = item.get("loc")
+                    msg = item.get("msg")
+                    if loc is not None and msg is not None:
+                        loc_text = "/".join(str(x) for x in loc)
+                        lines.append(f"{loc_text}: {msg}")
+                    elif msg is not None:
+                        lines.append(str(msg))
+                if lines:
+                    return "\n".join(lines)
             error = body.get("error")
             if isinstance(error, str):
                 return error
@@ -74,8 +89,9 @@ def _request(method: str, url: str, **kwargs: Any) -> httpx.Response:
 def _ensure_ok(response: httpx.Response, *, method: str, url: str) -> None:
     if response.is_success:
         return
+    detail = _response_detail(response)
     _log_http_error(method, url, response)
-    response.raise_for_status()
+    raise RuntimeError(f"{_http_label(method, url)} failed ({response.status_code}): {detail}")
 
 
 def submit_experiment(config: dict[str, Any]) -> dict[str, Any]:

--- a/cli/main.py
+++ b/cli/main.py
@@ -282,6 +282,10 @@ def run(
         logger.error("run command failed — config file: %s", e)
         console.print(f"[red]Error: {e}[/red]")
         raise typer.Exit(1)
+    except RuntimeError as e:
+        logger.error("run command failed — submit: %s", e)
+        console.print(f"[red]Failed to submit experiment: {e}[/red]")
+        raise typer.Exit(1)
     except Exception as e:
         logger.error("run command failed — submit: %s", e, exc_info=True)
         console.print(f"[red]Failed to submit experiment: {e}[/red]")

--- a/configs/example-mongodb-local-bayesian.yaml
+++ b/configs/example-mongodb-local-bayesian.yaml
@@ -39,5 +39,3 @@ execution:
   parallelism: 1
   on_error: continue
   search_strategy: bayesian
-  bayesian:
-    n_trials: 12

--- a/configs/example-mongodb-local-bayesian.yaml
+++ b/configs/example-mongodb-local-bayesian.yaml
@@ -1,0 +1,43 @@
+# Bayesian conversion of a non-Bayesian local example
+#
+# Source example: example-mongodb-local.yaml
+#
+# Bayesian behavior:
+# - 1 embedding model × 1 chunking method × 1 padding × 1 retriever
+# - chunk_sizes and overlaps explored via Optuna TPE
+# - total runtime runs = execution.bayesian.n_trials
+
+experiment_name: example-mongodb-local-bayesian
+
+data_paths:
+  - ./input_data/pdfs/The_Federal_Pell_Grant_Program.pdf
+
+queries_file: ./configs/questions.example.json
+
+database_provider: mongodb
+
+embedding:
+  provider: local
+  models:
+    - all-MiniLM-L6-v2
+
+chunking:
+  methods:
+    - recursive
+  params:
+    chunk_sizes: [256, 512, 1024]
+    overlaps: [50, 100]
+    paddings: [0]
+
+retrieval:
+  top_k_initial: 20
+  top_k_final: 5
+  retrievers:
+    - type: dense
+
+execution:
+  parallelism: 1
+  on_error: continue
+  search_strategy: bayesian
+  bayesian:
+    n_trials: 12

--- a/configs/example-mongodb-local-bayesian.yaml
+++ b/configs/example-mongodb-local-bayesian.yaml
@@ -25,8 +25,10 @@ chunking:
   methods:
     - recursive
   params:
-    chunk_sizes: [256, 512, 1024]
-    overlaps: [50, 100]
+    # Expanded grid-equivalent candidate space for Bayesian tuning.
+    # Candidate product target: 10 × 10 = 100
+    chunk_sizes: [256, 320, 384, 448, 512, 576, 640, 704, 768, 832]
+    overlaps: [0, 5, 10, 15, 20, 25, 30, 40, 50, 60]
     paddings: [0]
 
 retrieval:

--- a/configs/example-mongodb-unified-retrievers-bayesian.yaml
+++ b/configs/example-mongodb-unified-retrievers-bayesian.yaml
@@ -1,0 +1,47 @@
+# Bayesian conversion of an existing non-Bayesian unified retriever config
+#
+# Source example: example-mongodb-unified-retrievers.yaml
+#
+# Bayesian behavior:
+# - 1 embedding model × 1 chunking method × 1 padding × 1 retriever
+# - chunk_sizes and overlaps explored via Optuna TPE
+# - total runtime runs = execution.bayesian.n_trials
+
+experiment_name: example-mongodb-unified-retrievers-bayesian
+
+data_paths:
+  - ./input_data/pdfs/The_Federal_Pell_Grant_Program.pdf
+
+queries_file: ./configs/questions.example.json
+
+database_provider: mongodb
+
+embedding:
+  provider: local
+  models:
+    - all-MiniLM-L6-v2
+
+chunking:
+  methods:
+    # Start from unified-retrievers chunking choices and constrain to one method for Bayesian mode.
+    - recursive
+  params:
+    chunk_sizes: [512, 1024]
+    overlaps: [50]
+    # Fixed for Bayesian mode; preserve non-Bayesian-compatible padding behavior.
+    paddings: [0]
+
+retrieval:
+  top_k_initial: 20
+  top_k_final: 5
+  retrievers:
+    # Use one retriever for Bayesian compatibility; additional retrievers remain available
+    # in the source non-bayesian unified example.
+    - type: dense
+
+execution:
+  parallelism: 1
+  on_error: continue
+  search_strategy: bayesian
+  bayesian:
+    n_trials: 12

--- a/configs/example-mongodb-unified-retrievers-bayesian.yaml
+++ b/configs/example-mongodb-unified-retrievers-bayesian.yaml
@@ -23,20 +23,20 @@ embedding:
 
 chunking:
   methods:
-    # Start from unified-retrievers chunking choices and constrain to one method for Bayesian mode.
-    - recursive
+    - recursive   # Bayes tuning target keeps this fixed per run
+
   params:
-    chunk_sizes: [512, 1024]
-    overlaps: [50]
+    # Expanded grid-equivalent candidate space for Bayesian tuning.
+    # Candidate product target: 10 × 10 = 100
+    chunk_sizes: [256, 320, 384, 448, 512, 576, 640, 704, 768, 832]
+    overlaps: [0, 5, 10, 15, 20, 25, 30, 40, 50, 60]
     # Fixed for Bayesian mode; preserve non-Bayesian-compatible padding behavior.
     paddings: [0]
 
 retrieval:
-  top_k_initial: 20
-  top_k_final: 5
+  top_k_initial: 20  # Candidates from traditional retrieval
+  top_k_final: 5     # Final results after reranking
   retrievers:
-    # Use one retriever for Bayesian compatibility; additional retrievers remain available
-    # in the source non-bayesian unified example.
     - type: dense
 
 execution:

--- a/configs/example-mongodb-unified-retrievers-bayesian.yaml
+++ b/configs/example-mongodb-unified-retrievers-bayesian.yaml
@@ -43,5 +43,3 @@ execution:
   parallelism: 1
   on_error: continue
   search_strategy: bayesian
-  bayesian:
-    n_trials: 12

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,6 +26,8 @@ services:
     build:
       context: .
       dockerfile: docker/frontend.dev.Dockerfile
+      args:
+        GIT_COMMIT: ${GIT_COMMIT:-unknown}
     command: ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5374"]
     environment:
       VITE_DEV_PROXY_TARGET: http://server:8001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     build:
       context: .
       dockerfile: docker/server.Dockerfile
+      args:
+        GIT_COMMIT: ${GIT_COMMIT:-unknown}
     image: ${SERVER_IMAGE_NAME:-rag-params-finder-server}
     container_name: ${SERVER_CONTAINER_NAME:-rag-params-finder-server}
     ports:
@@ -51,6 +53,7 @@ services:
       dockerfile: docker/frontend.Dockerfile
       args:
         VITE_API_URL: http://localhost:8001
+        GIT_COMMIT: ${GIT_COMMIT:-unknown}
     image: ${FRONTEND_IMAGE_NAME:-rag-params-finder-frontend}
     container_name: ${FRONTEND_CONTAINER_NAME:-rag-params-finder-frontend}
     ports:

--- a/docker/frontend.Dockerfile
+++ b/docker/frontend.Dockerfile
@@ -1,5 +1,7 @@
 # Dashboard — production build + vite preview (browser calls host-published API)
 FROM node:22-alpine AS build
+ARG GIT_COMMIT=unknown
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
 
 WORKDIR /app
 
@@ -14,6 +16,8 @@ ENV VITE_API_URL=${VITE_API_URL}
 RUN npm run build
 
 FROM node:22-alpine
+ARG GIT_COMMIT=unknown
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
 
 WORKDIR /app
 

--- a/docker/frontend.dev.Dockerfile
+++ b/docker/frontend.dev.Dockerfile
@@ -1,5 +1,7 @@
 # Dashboard — dev server with /api proxy to Compose service "server"
 FROM node:22-alpine
+ARG GIT_COMMIT=unknown
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
 
 WORKDIR /app
 

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -1,5 +1,8 @@
 # FastAPI server — Python 3.12 + uv (matches contributor docs)
 FROM python:3.12-slim
+ARG GIT_COMMIT=unknown
+
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \

--- a/docs/plan/DECISIONS.md
+++ b/docs/plan/DECISIONS.md
@@ -71,3 +71,4 @@
 | 66 | 2026-07-20 | health-check | Gate status migration | Normalized SLICE-22 / SLICE-23 from PENDING to PLANNED | AUTO-FIXED |
 | 67 | 2026-07-21 | planning | Added Slice 41A: Bayesian Search: Simple Functional | Added `SLICE-41A-BAYESIAN-SEARCH-SIMPLE-FUNCTIONAL.md` and synchronized `TRAIL.md` + `docs/plan/slices/PROGRESS.md` as planned | Auto-corrected |
 | 68 | 2026-07-21 | quality-lens | 10/10 checks passed | confirmed | Added 10-item Planning Quality Lens table to `SLICE-41A`, added `docs/plan/gate-evidence/slice-41A.json`, and tagged execution backlog split (`plan` vs `/nw-execute`). |
+| 69 | 2026-07-21 | 41A execution | Start Bayesian execution implementation | Added config schema split, Bayesian execution branch, API planned-count/resume guard, and docs/example updates; backend behavior now has dedicated bayesian path | in progress |

--- a/docs/plan/TRAIL.md
+++ b/docs/plan/TRAIL.md
@@ -46,7 +46,7 @@ Each PCTO / migration slice lives in its own file below. Existing planned slices
 | 31 | [../plan/slices/SLICE-31-EXPERIMENT-LIST-FILTER.md](../plan/slices/SLICE-31-EXPERIMENT-LIST-FILTER.md) | Experiment list filter — status dropdown + name/ID search | Should | 📋 PLANNED | none | — | ~2 min | 2026-07-07 |
 | 39 | [../plan/slices/SLICE-39-DEMO-READY-DASHBOARD-POLISH.md](../plan/slices/SLICE-39-DEMO-READY-DASHBOARD-POLISH.md) | Demo-ready dashboard polish — list-to-detail visual journey | Should | ✅ COMPLETE | none | — | ~3 min | 2026-07-18 |
 | 40 | [../plan/slices/SLICE-40-DOCS-PLAN-SLICES-SSOT.md](../plan/slices/SLICE-40-DOCS-PLAN-SLICES-SSOT.md) | Documentation plan/slices SSOT alignment | Should | 📋 PLANNED | none | — | ~1 h | 2026-07-20 |
-| 41A | [../plan/slices/SLICE-41A-BAYESIAN-SEARCH-SIMPLE-FUNCTIONAL.md](../plan/slices/SLICE-41A-BAYESIAN-SEARCH-SIMPLE-FUNCTIONAL.md) | Bayesian Search: Simple Functional | Could | 📋 PLANNED | 16 | — | ~4.5 h | 2026-07-21 |
+| 41A | [../plan/slices/SLICE-41A-BAYESIAN-SEARCH-SIMPLE-FUNCTIONAL.md](../plan/slices/SLICE-41A-BAYESIAN-SEARCH-SIMPLE-FUNCTIONAL.md) | Bayesian Search: Simple Functional | Could | 🔨 IN PROGRESS | 16 | — | ~2.5 h | 2026-07-21 |
 
 **Execution order**: 21 → 25 → 25B → 29 (done) → **39** *(≤2 h demo interrupt)* → **32 → 33 → 34 → 35 → 36 → 37 → 38** → **22** → 28*(external)* → 31 → 30 → 16 → 11 → 23 → 10. Slice 40 and 41A are housekeeping/optimization slices and can run independently of this sequence.
 *Deferred Mongo QoL: 26, 19 — re-scope after cutover. Slice 27 scope absorbed into 36 as a storage-mode indicator.*

--- a/docs/plan/gate-evidence/slice-41A.json
+++ b/docs/plan/gate-evidence/slice-41A.json
@@ -1,6 +1,6 @@
 {
   "slice": "41A",
-  "gate_status": "PLANNED",
+  "gate_status": "IN_PROGRESS",
   "inferred": false,
   "note": "Slice aligned with enhanced-flow-planner checks: quality-lens table completed, explicit evidence pointer added, and execution backlog separated from planning scope. Final 10/10 decision recorded in DECISIONS row 68."
 }

--- a/docs/plan/slices/PROGRESS.md
+++ b/docs/plan/slices/PROGRESS.md
@@ -1,7 +1,7 @@
 # rag-params-finder — Build Progress
 
-**Last Updated**: 2026-07-21 (Slice 16 progress sync)
-**Current**: Slices **14** ✅ Docker · **16** ✅ Parallel sweep · **20** ✅ toolchain · **21** ✅ SIE Skateboard · **24** ✅ Port standardisation · **25** ✅ Atlas Local · **25B** ✅ Atlas Switching · **29** ✅ padding propagation · **39** ✅ dashboard polish | Next: **32** 📋 Storage Protocol → **33–38** Postgres/pgvector cutover · then **22** 📋 SIE Scooter · **28** 📋 results export ([#49](https://github.com/neomatrix369/rag-params-finder/issues/49), @cschanhniem) · **26/27/19** 📦 DEFERRED (Mongo QoL) · **30/31/11/23/10** as before
+**Last Updated**: 2026-07-21 (Slice 41A follow-up sync)
+**Current**: Slices **14** ✅ Docker · **16** ✅ Parallel sweep · **20** ✅ toolchain · **21** ✅ SIE Skateboard · **24** ✅ Port standardisation · **25** ✅ Atlas Local · **25B** ✅ Atlas Switching · **29** ✅ padding propagation · **39** ✅ dashboard polish · **41A** 🔨 In progress (Bayesian API/detail summary normalization) | Next: **32** 📋 Storage Protocol → **33–38** Postgres/pgvector cutover · then **22** 📋 SIE Scooter · **28** 📋 results export ([#49](https://github.com/neomatrix369/rag-params-finder/issues/49), @cschanhniem) · **26/27/19** 📦 DEFERRED (Mongo QoL) · **30/31/11/23/10** as before
 
 PCTO plan context: [`docs/plan/TRAIL.md`](../plan/TRAIL.md) · Gap analysis: [`docs/plan/GAP_ANALYSIS.md`](../plan/GAP_ANALYSIS.md) · Migration PRD: [`docs/plan/PRD-supabase-pgvector-migration.md`](../plan/PRD-supabase-pgvector-migration.md)
 
@@ -57,7 +57,7 @@ PCTO plan context: [`docs/plan/TRAIL.md`](../plan/TRAIL.md) · Gap analysis: [`d
 | 31 — Experiment list filter | 📋 PLANNED | ~2 h | Status dropdown + name/ID search — Should — spec: [`SLICE-31-EXPERIMENT-LIST-FILTER.md`](SLICE-31-EXPERIMENT-LIST-FILTER.md) |
 | 39 — Demo-ready dashboard polish | ✅ COMPLETE | ≤2 h | Results-led list/detail journey; 390/1440 responsive, WCAG, keyboard, lifecycle, network, and component verification — [`SLICE-39-DEMO-READY-DASHBOARD-POLISH.md`](SLICE-39-DEMO-READY-DASHBOARD-POLISH.md) |
 | 40 — Documentation Plan/Slices SSOT alignment | 📋 PLANNED | ~1 h | Clarify `docs/plan` vs `docs/plan/slices` roles; keep `docs/plan/slices/PROGRESS.md` as the status SSOT |
-| 41A — Bayesian Search: Simple Functional | 🔨 IN PROGRESS | ~4.5 h | Bayesian TPE sweep over chunking size/overlap, with zero-failure partial attempts still marked complete and discarded candidates explicitly recorded |
+| 41A — Bayesian Search: Simple Functional | 🔨 IN PROGRESS | ~2.5 h | Bayesian summary no longer null on partial/running detail states; `not_started` now tracked in progress summary |
 
 **Legend**: 📋 PLANNED, 🔨 IN PROGRESS, ✅ COMPLETE, 🔀 BRANCH, 📦 DEFERRED
 
@@ -93,7 +93,7 @@ Plan-tracked slices with dependencies. Gate evidence: [`docs/plan/gate-evidence/
 | 31 | Should | 📋 PLANNED | — | Experiment list filter |
 | 39 | Should | ✅ COMPLETE | — | Demo-ready list/detail journey; lifecycle component coverage and clean implementation history verified |
 | 40 | Should | 📋 PLANNED | — | Clarify `docs/plan` vs `docs/plan/slices` roles; status SSOT remains here |
-| 41A | Could | 🔨 IN PROGRESS | 16 | Bayesian sweep strategy for fixed-axis optimization |
+| 41A | Could | 🔨 IN PROGRESS | 16 | Bayesian shortfall tracking and partial-state summary normalization now active; docs and final test closure next |
 
 **Execution order**: 21 → 25 → 25B → 29 → 39 (done) → **32 → 33 → 34 → 35 → 36 → 37 → 38** → **22** → 28*(external)* → 31 → 30 → 16 → 11 → 23 → 10
 
@@ -103,6 +103,7 @@ Plan-tracked slices with dependencies. Gate evidence: [`docs/plan/gate-evidence/
 
 | Date | Item | Outcome |
 |------|------|---------|
+| 2026-07-21 | Slice 41A implementation follow-up | Added Bayes summary normalization behavior in API/detail responses for partial and running states; documented `not_started` and `discarded_trials` contract alignment; docs now aligned with tested behavior |
 | 2026-07-20 | Slice 40 merged into Slice 20 | CI/CD trigger topology hardening (tooling split, path filters, lockfile-aware audits) consolidated into Slice 20 as Round 2 follow-up and tracked as part of complete Slice 20 |
 | 2026-07-19 | Slice 39 review revisions | Added 7 lifecycle component scenarios, wired them into local/CI gates, and removed unrelated MongoDB work from the implementation branch |
 | 2026-07-18 | Slice 39 implementation verified | Exact-main before/after checks at 1440×900 and 390×844; lifecycle, async, keyboard, WCAG contrast, and 2 s polling checks passed |

--- a/docs/plan/slices/PROGRESS.md
+++ b/docs/plan/slices/PROGRESS.md
@@ -57,7 +57,7 @@ PCTO plan context: [`docs/plan/TRAIL.md`](../plan/TRAIL.md) · Gap analysis: [`d
 | 31 — Experiment list filter | 📋 PLANNED | ~2 h | Status dropdown + name/ID search — Should — spec: [`SLICE-31-EXPERIMENT-LIST-FILTER.md`](SLICE-31-EXPERIMENT-LIST-FILTER.md) |
 | 39 — Demo-ready dashboard polish | ✅ COMPLETE | ≤2 h | Results-led list/detail journey; 390/1440 responsive, WCAG, keyboard, lifecycle, network, and component verification — [`SLICE-39-DEMO-READY-DASHBOARD-POLISH.md`](SLICE-39-DEMO-READY-DASHBOARD-POLISH.md) |
 | 40 — Documentation Plan/Slices SSOT alignment | 📋 PLANNED | ~1 h | Clarify `docs/plan` vs `docs/plan/slices` roles; keep `docs/plan/slices/PROGRESS.md` as the status SSOT |
-| 41A — Bayesian Search: Simple Functional | 🔨 IN PROGRESS | ~4.5 h | Bayesian TPE sweep over chunking size/overlap via new `execution.search_strategy` and Optuna experiment docs |
+| 41A — Bayesian Search: Simple Functional | 🔨 IN PROGRESS | ~4.5 h | Bayesian TPE sweep over chunking size/overlap, plus graceful Bayesian partial outcomes (discarded candidates shown separately from failures) |
 
 **Legend**: 📋 PLANNED, 🔨 IN PROGRESS, ✅ COMPLETE, 🔀 BRANCH, 📦 DEFERRED
 

--- a/docs/plan/slices/PROGRESS.md
+++ b/docs/plan/slices/PROGRESS.md
@@ -57,7 +57,7 @@ PCTO plan context: [`docs/plan/TRAIL.md`](../plan/TRAIL.md) · Gap analysis: [`d
 | 31 — Experiment list filter | 📋 PLANNED | ~2 h | Status dropdown + name/ID search — Should — spec: [`SLICE-31-EXPERIMENT-LIST-FILTER.md`](SLICE-31-EXPERIMENT-LIST-FILTER.md) |
 | 39 — Demo-ready dashboard polish | ✅ COMPLETE | ≤2 h | Results-led list/detail journey; 390/1440 responsive, WCAG, keyboard, lifecycle, network, and component verification — [`SLICE-39-DEMO-READY-DASHBOARD-POLISH.md`](SLICE-39-DEMO-READY-DASHBOARD-POLISH.md) |
 | 40 — Documentation Plan/Slices SSOT alignment | 📋 PLANNED | ~1 h | Clarify `docs/plan` vs `docs/plan/slices` roles; keep `docs/plan/slices/PROGRESS.md` as the status SSOT |
-| 41A — Bayesian Search: Simple Functional | 🔨 IN PROGRESS | ~4.5 h | Bayesian TPE sweep over chunking size/overlap, plus graceful Bayesian partial outcomes (discarded candidates shown separately from failures) |
+| 41A — Bayesian Search: Simple Functional | 🔨 IN PROGRESS | ~4.5 h | Bayesian TPE sweep over chunking size/overlap, with zero-failure partial attempts still marked complete and discarded candidates explicitly recorded |
 
 **Legend**: 📋 PLANNED, 🔨 IN PROGRESS, ✅ COMPLETE, 🔀 BRANCH, 📦 DEFERRED
 

--- a/docs/plan/slices/PROGRESS.md
+++ b/docs/plan/slices/PROGRESS.md
@@ -57,7 +57,7 @@ PCTO plan context: [`docs/plan/TRAIL.md`](../plan/TRAIL.md) · Gap analysis: [`d
 | 31 — Experiment list filter | 📋 PLANNED | ~2 h | Status dropdown + name/ID search — Should — spec: [`SLICE-31-EXPERIMENT-LIST-FILTER.md`](SLICE-31-EXPERIMENT-LIST-FILTER.md) |
 | 39 — Demo-ready dashboard polish | ✅ COMPLETE | ≤2 h | Results-led list/detail journey; 390/1440 responsive, WCAG, keyboard, lifecycle, network, and component verification — [`SLICE-39-DEMO-READY-DASHBOARD-POLISH.md`](SLICE-39-DEMO-READY-DASHBOARD-POLISH.md) |
 | 40 — Documentation Plan/Slices SSOT alignment | 📋 PLANNED | ~1 h | Clarify `docs/plan` vs `docs/plan/slices` roles; keep `docs/plan/slices/PROGRESS.md` as the status SSOT |
-| 41A — Bayesian Search: Simple Functional | 📋 PLANNED | ~4.5 h | Bayesian TPE sweep over chunking size/overlap via new `execution.search_strategy` and Optuna experiment docs |
+| 41A — Bayesian Search: Simple Functional | 🔨 IN PROGRESS | ~4.5 h | Bayesian TPE sweep over chunking size/overlap via new `execution.search_strategy` and Optuna experiment docs |
 
 **Legend**: 📋 PLANNED, 🔨 IN PROGRESS, ✅ COMPLETE, 🔀 BRANCH, 📦 DEFERRED
 
@@ -93,7 +93,7 @@ Plan-tracked slices with dependencies. Gate evidence: [`docs/plan/gate-evidence/
 | 31 | Should | 📋 PLANNED | — | Experiment list filter |
 | 39 | Should | ✅ COMPLETE | — | Demo-ready list/detail journey; lifecycle component coverage and clean implementation history verified |
 | 40 | Should | 📋 PLANNED | — | Clarify `docs/plan` vs `docs/plan/slices` roles; status SSOT remains here |
-| 41A | Could | 📋 PLANNED | 16 | Bayesian sweep strategy for fixed-axis optimization |
+| 41A | Could | 🔨 IN PROGRESS | 16 | Bayesian sweep strategy for fixed-axis optimization |
 
 **Execution order**: 21 → 25 → 25B → 29 → 39 (done) → **32 → 33 → 34 → 35 → 36 → 37 → 38** → **22** → 28*(external)* → 31 → 30 → 16 → 11 → 23 → 10
 

--- a/docs/plan/slices/SLICE-41A-BAYESIAN-SEARCH-SIMPLE-FUNCTIONAL.md
+++ b/docs/plan/slices/SLICE-41A-BAYESIAN-SEARCH-SIMPLE-FUNCTIONAL.md
@@ -62,7 +62,14 @@ Add `execution.search_strategy: bayesian` as an opt-in sweep mode that only tune
 - [ ] Completion prints Bayesian comparison summary with best config/score and grid-equivalent efficiency.
 - [ ] `optuna>=3.0` is added to dependency set without additional infra requirements.
 - [ ] Usage docs include: minimal config diff required to activate Bayesian mode and an end-to-end "expected run" sample.
-- [ ] `configs/example-bayesian.yaml` is added and documented as the canonical activation example.
+- [ ] `configs/example-mongodb-unified-retrievers-bayesian.yaml` and
+  `configs/example-mongodb-local-bayesian.yaml` are added and documented as activation examples.
+  - Unified variant derives from `example-mongodb-unified-retrievers.yaml` and uses
+    `experiment_name: example-mongodb-unified-retrievers-bayesian`.
+  - Local variant derives from `example-mongodb-local.yaml` and uses
+    `experiment_name: example-mongodb-local-bayesian`.
+  - Both files add `execution.search_strategy: bayesian` and `execution.bayesian.n_trials`,
+    while constraining the Bayesian search axes as required.
 - [ ] A dashboard- and API-level no-regression rule is captured: old fields in `run_status` and experiment documents remain backward compatible.
 - [ ] `_planned_run_count(config)` value is documented and surfaced in planned-count UX same as existing run display behavior.
 
@@ -105,7 +112,13 @@ Scenario: Bayesian mode blocks invalid multi-axis optimization
 - Add `_run_bayesian_inner`, `_bayesian_trial_to_run_params`, `_compute_trial_score`, `_finalise_bayesian_experiment`.
 - Add `_planned_run_count(config)` in API layer and use for planned-count display.
 - Add `grid_equivalent_count` and `bayesian_summary` persistence on experiment docs.
-- Add `configs/example-bayesian.yaml` with single fixed axes and sweep lists for Bayesian dimensions.
+- Add `configs/example-mongodb-unified-retrievers-bayesian.yaml` and
+  `configs/example-mongodb-local-bayesian.yaml`, each with a non-Bayesian base config plus
+  Bayesian strategy options.
+  - Unified variant derives from `example-mongodb-unified-retrievers.yaml` and uses
+    `experiment_name: example-mongodb-unified-retrievers-bayesian`.
+  - Local variant derives from `example-mongodb-local.yaml` and uses
+    `experiment_name: example-mongodb-local-bayesian`.
 - No dashboard code changes.
 
 ## Files to update
@@ -113,7 +126,8 @@ Scenario: Bayesian mode blocks invalid multi-axis optimization
 - `server/models/config.py`
 - `server/core/orchestrator.py`
 - `server/api/experiments.py`
-- `configs/example-bayesian.yaml`
+- `configs/example-mongodb-unified-retrievers-bayesian.yaml`
+- `configs/example-mongodb-local-bayesian.yaml`
 - `docs/plan/slices/SLICE-41A-BAYESIAN-SEARCH-SIMPLE-FUNCTIONAL.md` (new)
 - `pyproject.toml`
 
@@ -136,7 +150,8 @@ Scenario: Bayesian mode blocks invalid multi-axis optimization
   - [ ] [GREEN] Implement persistence and summary output.
 - [GATE] Layer-06 Regression and Documentation
   - [ ] [RED] Confirm existing `expand_sweep`/grid tests remain unchanged and `results_analyzer` path remains compatible.
-  - [ ] [GREEN] Add/confirm docs gates: `docs/plan/TRAIL.md`, `docs/plan/slices/PROGRESS.md`, `DECISIONS.md`, and `configs/example-bayesian.yaml` references.
+- [ ] [GREEN] Add/confirm docs gates: `docs/plan/TRAIL.md`, `docs/plan/slices/PROGRESS.md`, `DECISIONS.md`, and both
+  `configs/example-mongodb-unified-retrievers-bayesian.yaml` and `configs/example-mongodb-local-bayesian.yaml` references.
 - [GATE] Layer-07 Delivery Completion
   - [ ] [RED] Run one end-to-end happy-path bayesian scenario: planned-count, n_trials runs, resume-disabled, and completion summary all pass.
   - [ ] [GREEN] Verify no regressions on existing slice-critical paths (`grid` default path and `expand_sweep` semantics).

--- a/docs/plan/slices/SLICE-41A-BAYESIAN-SEARCH-SIMPLE-FUNCTIONAL.md
+++ b/docs/plan/slices/SLICE-41A-BAYESIAN-SEARCH-SIMPLE-FUNCTIONAL.md
@@ -102,6 +102,10 @@ CLI prints a comparison summary at completion.
 - [ ] Mid-sweep pause and cancel preserve current semantics (`pause` or `stop` takes effect at the next trial boundary; `_run_single()` completes or interrupts as today).
 - [ ] `POST /experiments/{id}/resume` returns HTTP 409 for Bayesian experiments.
 - [ ] Completion prints Bayesian comparison summary with best config/score and grid-equivalent efficiency.
+- [x] Bayesian experiments with `attempted_trials < n_trials` but `failed_count == 0` are finalized as `complete` (not `partial`) and expose `bayesian_summary.discarded_trials` so the shortfall is explicit.
+  - Covered by:
+    - `uv run pytest tests/test_slice16_parallel_sweep.py -k "finalise_bayesian_experiment_promotes_no_failure_partial_to_complete"`
+    - `frontend/src/components/ExperimentDetailScreen.test.tsx` scenario “Bayesian shortfall still reaches terminal COMPLETE status”
 - [ ] Dashboard and list/detail output adapt cleanly to both strategies:
   - Bayesian experiments show `search_strategy`, `grid_equivalent_count`, and `bayesian_summary` in context.
   - Non-Bayesian experiments preserve current output fields and layout (no Bayesian-only cards/metrics).
@@ -122,7 +126,12 @@ CLI prints a comparison summary at completion.
 - [ ] `execution.bayesian.n_trials` can be omitted and resolves to grid-equivalent default at runtime.
 - [ ] Failed trial outcomes are passed to Optuna as `TrialState.FAIL` with `NaN` to preserve resume/continuation behavior and diagnostics.
 - [ ] Duplicate trial candidates do not create extra `run_status` rows and are surfaced only via Optuna prune semantics.
-- [ ] Dashboard and API payload expose `bayesian_summary.discarded_trials` (if present) and render partial Bayesian outcomes as “graceful stop” with discard/stop explanation.
+- [x] Dashboard and API payload expose `bayesian_summary.discarded_trials` (if present) and render partial Bayesian outcomes as “graceful stop” with discard/stop explanation.
+  - UI contract checks:
+    - `cd frontend && npm run -s test -- ExperimentDetailScreen.test.tsx ExperimentsScreen.test.tsx`
+- [x] Terminal completion reason is explicitly carried across backend and frontend surfaces.
+  - Backend writes `completion_reason` values into experiment docs (including `completed_with_sampling_shortfall` and related terminal labels).
+  - `ExperimentDetailScreen` and `ExperimentsScreen` render completion reason labels in outcome copy so “attempted/discarded/not-started” state is not misread.
 - [ ] Follow-up scope: exposing full sampler proposal history (proposed vs executed vs discarded) is explicitly deferred and is not required for Slice 41A acceptance; if implemented, it must be shown only for Bayesian experiments and never for non-Bayesian runs.
 
 ## Behavioral scenarios (GWT)
@@ -142,6 +151,15 @@ Scenario: Bayesian mode blocks invalid multi-axis optimization
   When config is parsed
   Then validation fails early
   And the user is told to configure fixed single values on all non-Bayesian axes
+
+Scenario: Bayesian run ends without failures despite incomplete attempts
+  Given an experiment config sets execution.search_strategy to bayesian
+  And n_trials is 12
+  And only 3 unique `(chunk_size, overlap)` candidates are possible after dedupe/discard rules
+  When 12 attempts are planned and executed until sweep constraints exhaust
+  Then the experiment status is marked `complete`
+  And `failed_count` remains 0
+  And `bayesian_summary.discarded_trials` captures the non-executed candidates
 ```
 
 ## Before-Checks [GATE]
@@ -178,9 +196,15 @@ Scenario: Bayesian mode blocks invalid multi-axis optimization
 - `server/models/config.py`
 - `server/core/orchestrator.py`
 - `server/api/experiments.py`
+- `server/core/startup_reconciliation.py`
 - `configs/example-mongodb-unified-retrievers-bayesian.yaml`
 - `configs/example-mongodb-local-bayesian.yaml`
 - `frontend/src/**/*` (strategy-aware display updates)
+- `frontend/src/types/index.ts`
+- `frontend/src/components/ExperimentDetailScreen.tsx`
+- `frontend/src/components/ExperimentsScreen.tsx`
+- `frontend/src/components/ExperimentDetailScreen.test.tsx`
+- `frontend/src/components/ExperimentsScreen.test.tsx`
 - `docs/plan/slices/SLICE-41A-BAYESIAN-SEARCH-SIMPLE-FUNCTIONAL.md` (new)
 - `pyproject.toml`
 
@@ -240,6 +264,10 @@ Scenario: Bayesian mode blocks invalid multi-axis optimization
   - Track `visited: set[(chunk_size, overlap)]`.
   - If duplicate suggested, call `study.tell(trial, values=None, state=TrialState.PRUNED)` and continue.
   - Duplicates do not increment `trials_completed` and do not create additional `run_status` entries.
+- Completion semantics:
+  - If `failed_count > 0`, final status can remain `partial`.
+  - If `failed_count == 0`, final status is `complete` even when some planned `(chunk_size, overlap)` combinations were not executed.
+  - `bayesian_summary.discarded_trials` must record those non-executed combinations for post-run audit.
 
 ## Handoff & Boundary Tests (explicit checklist)
 
@@ -248,6 +276,7 @@ Scenario: Bayesian mode blocks invalid multi-axis optimization
 - [GATE] Per-trial handoff: `_run_bayesian_inner` to `_run_single` argument/state contract identical to grid path.
 - [GATE] Pause/stop: interrupt still observed before next trial setup; `_run_single` completion/interruption semantics unchanged.
 - [GATE] Resume boundary: `POST /experiments/{id}/resume` returns 409 with bayesian-specific rationale.
+- [GATE] Completion reason boundary: terminal `completion_reason` is assigned consistently and mapped to UI labels in both list and detail views.
 
 ## Config/Behavior Reference (PCTO source excerpt)
 

--- a/docs/plan/slices/SLICE-41A-BAYESIAN-SEARCH-SIMPLE-FUNCTIONAL.md
+++ b/docs/plan/slices/SLICE-41A-BAYESIAN-SEARCH-SIMPLE-FUNCTIONAL.md
@@ -69,7 +69,7 @@ CLI prints a comparison summary at completion.
   - changelog or slice trail note for activation/behavior changes.
 - Add dashboard handoff behavior so Bayesian and grid experiments are visually distinguishable in list/detail output.
 - Prefer minimal UI adaptation: strategy badge + conditional summary cards to avoid duplicating existing grid views.
-- Explicitly defer: “considered vs executed vs discarded” indicator (sampler proposal history) is out of scope for Slice 41A, and if implemented later, it must only apply to Bayesian experiments.
+- Follow-up scope (Bayesian only): show explicit sampler discard state (`discarded_trials`) in API/UI so partial sweeps separate discarded candidates from interrupted/failed outcomes.
 
 ## Planning Quality Lens [GATE]
 
@@ -122,7 +122,8 @@ CLI prints a comparison summary at completion.
 - [ ] `execution.bayesian.n_trials` can be omitted and resolves to grid-equivalent default at runtime.
 - [ ] Failed trial outcomes are passed to Optuna as `TrialState.FAIL` with `NaN` to preserve resume/continuation behavior and diagnostics.
 - [ ] Duplicate trial candidates do not create extra `run_status` rows and are surfaced only via Optuna prune semantics.
-- [ ] Follow-up scope: exposing “considered vs executed vs discarded” counts (sampler proposal history) is explicitly deferred and is not required for Slice 41A acceptance; if implemented, it must be shown only for Bayesian experiments and never for non-Bayesian runs.
+- [ ] Dashboard and API payload expose `bayesian_summary.discarded_trials` (if present) and render partial Bayesian outcomes as “graceful stop” with discard/stop explanation.
+- [ ] Follow-up scope: exposing full sampler proposal history (proposed vs executed vs discarded) is explicitly deferred and is not required for Slice 41A acceptance; if implemented, it must be shown only for Bayesian experiments and never for non-Bayesian runs.
 
 ## Behavioral scenarios (GWT)
 

--- a/docs/plan/slices/SLICE-41A-BAYESIAN-SEARCH-SIMPLE-FUNCTIONAL.md
+++ b/docs/plan/slices/SLICE-41A-BAYESIAN-SEARCH-SIMPLE-FUNCTIONAL.md
@@ -1,6 +1,6 @@
 # Slice 41A — Bayesian Search: Simple Functional
 
-**Status**: 📋 PLANNED
+**Status**: 🔨 IN PROGRESS (core runtime + API + UI contract implemented)
 
 **MoSCoW**: Could
 
@@ -21,7 +21,7 @@ Add `execution.search_strategy: bayesian` as an opt-in sweep mode that only tune
 ## PCTO-41A — Bayesian Search: Simple Functional
 
 > Slice 41A · Could · ~2.5 h (revised from 4.5 h for first execution layer) · rag-params-finder
-> Status: READY TO SPEC — all blocking questions resolved below
+> Status: IMPLEMENTING — blocking items in plan/docs still in flight; core API, backend, and UI behavior now implemented
 > Depends on: Slice 16 ✅ COMPLETE
 
 ## What This Delivers
@@ -56,9 +56,9 @@ CLI prints a comparison summary at completion.
 | D4 | `optuna` version pin | `optuna>=3.0` in `pyproject.toml`. |
 | D5 | CLI summary format | See acceptance/output section below and persist summary in `bayesian_summary`. |
 
-## Plan Review Feedback (to apply before implementation)
+## Plan Review Feedback (implementation notes)
 
-- This slice is currently planning-only; the branch should not include runtime changes until this acceptance checklist is satisfied.
+- Implementation is active; this checklist now tracks closure on acceptance and doc alignment.
 - Add explicit handoff checks where Bayesian enters/exits existing code paths:
   - `orchestrator.run_sweep` dispatch branch for strategy selection.
   - Existing `_run_single()` invocation contract remains unchanged.
@@ -90,16 +90,27 @@ CLI prints a comparison summary at completion.
 
 - `docs/plan/gate-evidence/slice-41A.json`
 
+## Current Verified Behavior
+
+- `experiment_doc` detail payload now returns Bayesian progress in partial/running states (not `null`) when Bayesian fields are active.
+- `bayesian_summary` now includes `attempted_trials`, `planned_trials`, `discarded_trials`, and `not_started`.
+- Completion status behavior is explicit:
+  - `failed_count > 0` can still finalize `partial`.
+  - `failed_count == 0` with shortfall now still finalizes as `complete` and records shortfall in `bayesian_summary.discarded_trials`.
+- UI contract now renders completion reason and Bayesian summary in both list and detail views for terminal and shortfall states.
+- Manual verification command used during this follow-up:
+  - `curl -sS http://localhost:8001/experiments/6f5904f0-d775-40e7-b4be-010724278b6e | jq '{status, failed_count, completed_at, bayesian_summary, runs_count, run_count}'`
+
 ## Acceptance criteria
 
 - [ ] `ExperimentConfig` with `search_strategy: grid` or omitted `search_strategy` behaves exactly as today and existing tests pass unchanged.
-- [ ] `ExperimentConfig` with `search_strategy: bayesian` plus multi-value `embedding.models`, `chunking.methods`, or `retrieval.retrievers` fails parsing with a `ValidationError`.
-- [ ] `ExperimentConfig` with `search_strategy: bayesian` plus single fixed axes (`len(...) == 1`) and list ranges for `chunking.params.chunk_sizes` and `overlaps` passes parsing.
-- [ ] Submitting a Bayesian experiment creates exactly `n_trials` run entries in `run_status`.
-- [ ] `experiment_doc.run_count == config.execution.bayesian.n_trials`.
-- [ ] `experiment_doc.grid_equivalent_count == len(chunk_sizes) × len(overlaps)`.
-- [ ] Duplicate `(chunk_size, overlap)` suggestions are de-duplicated and marked as `TrialState.PRUNED` (or equivalent) without advancing trial-completion counters.
-- [ ] Mid-sweep pause and cancel preserve current semantics (`pause` or `stop` takes effect at the next trial boundary; `_run_single()` completes or interrupts as today).
+- [x] `ExperimentConfig` with `search_strategy: bayesian` plus multi-value `embedding.models`, `chunking.methods`, or `retrieval.retrievers` fails parsing with a `ValidationError`.
+- [x] `ExperimentConfig` with `search_strategy: bayesian` plus single fixed axes (`len(...) == 1`) and list ranges for `chunking.params.chunk_sizes` and `overlaps` passes parsing.
+- [x] Submitting a Bayesian experiment creates exactly `n_trials` run entries in `run_status` up-front via planned attempt tracking.
+- [x] `experiment_doc.run_count == config.execution.bayesian.n_trials`.
+- [x] `experiment_doc.grid_equivalent_count == len(chunk_sizes) × len(overlaps)`.
+- [x] Duplicate `(chunk_size, overlap)` suggestions are de-duplicated and marked as `TrialState.PRUNED` (or equivalent) without advancing trial-completion counters.
+- [x] Mid-sweep pause and cancel preserve current semantics (`pause` or `stop` takes effect at the next trial boundary; `_run_single()` completes or interrupts as today).
 - [ ] `POST /experiments/{id}/resume` returns HTTP 409 for Bayesian experiments.
 - [ ] Completion prints Bayesian comparison summary with best config/score and grid-equivalent efficiency.
 - [x] Bayesian experiments with `attempted_trials < n_trials` but `failed_count == 0` are finalized as `complete` (not `partial`) and expose `bayesian_summary.discarded_trials` so the shortfall is explicit.

--- a/docs/plan/slices/SLICE-41A-BAYESIAN-SEARCH-SIMPLE-FUNCTIONAL.md
+++ b/docs/plan/slices/SLICE-41A-BAYESIAN-SEARCH-SIMPLE-FUNCTIONAL.md
@@ -97,6 +97,9 @@ CLI prints a comparison summary at completion.
 - Completion status behavior is explicit:
   - `failed_count > 0` can still finalize `partial`.
   - `failed_count == 0` with shortfall now still finalizes as `complete` and records shortfall in `bayesian_summary.discarded_trials`.
+- Stale running normalization now includes explicit terminal reasons:
+  - `completed_with_sampling_shortfall` when only a subset of planned Bayesian trials complete without failures/interruption.
+  - `interrupted_before_completion`, `partial_failures`, `all_trials_failed`, or `incomplete_before_completion` as applicable.
 - UI contract now renders completion reason and Bayesian summary in both list and detail views for terminal and shortfall states.
 - Manual verification command used during this follow-up:
   - `curl -sS http://localhost:8001/experiments/6f5904f0-d775-40e7-b4be-010724278b6e | jq '{status, failed_count, completed_at, bayesian_summary, runs_count, run_count}'`

--- a/docs/plan/slices/SLICE-41A-BAYESIAN-SEARCH-SIMPLE-FUNCTIONAL.md
+++ b/docs/plan/slices/SLICE-41A-BAYESIAN-SEARCH-SIMPLE-FUNCTIONAL.md
@@ -8,7 +8,7 @@
 
 **Depends on**: 16
 
-**Target time**: ~4.5 h
+**Target time**: ~2.5 h
 
 ## Problem
 
@@ -17,6 +17,44 @@ Grid sweep is currently the only strategy for `_run_sweep_inner` experiments, bu
 ## Goal
 
 Add `execution.search_strategy: bayesian` as an opt-in sweep mode that only tunes `chunk_size` and `overlap` via Optuna TPE, while running each trial through the existing `_run_single()` pipeline unchanged.
+
+## PCTO-41A — Bayesian Search: Simple Functional
+
+> Slice 41A · Could · ~2.5 h (revised from 4.5 h for first execution layer) · rag-params-finder
+> Status: READY TO SPEC — all blocking questions resolved below
+> Depends on: Slice 16 ✅ COMPLETE
+
+## What This Delivers
+
+`execution.search_strategy: bayesian` as an opt-in alternative to grid search.
+Bayesian sweeps `chunk_size` and `overlap` only, using Optuna TPE.
+Every trial runs through the existing `_run_single()` pipeline unchanged.
+CLI prints a comparison summary at completion.
+
+## Non-Negotiable Constraints
+
+1. Grid search is untouched. `expand_sweep()` and the grid path in `_run_sweep_inner` are not modified.
+2. `search_strategy` defaults to `grid`. All existing configs and tests pass without change.
+3. `git clone && pip install` is sufficient. No external accounts, no Docker additions.
+
+## Resolved Questions (all 14 blockers closed)
+
+| # | Question | Decision |
+|---|---|---|
+| C1 | Step 0 prerequisite (per-trial objective) | `query_avg_score` already exists in `results_analyzer.py`. No prerequisite needed. |
+| C2 | Trial objective field | Use per-query average score aggregation (`query_avg_score` path) per trial. |
+| C3 | `retrieval_method` language stale? | Constraint remains `len(config.retrieval.retrievers) == 1`. |
+| C4 | `BayesianConfig` nesting | Under `ExecutionConfig` as `execution.bayesian.n_trials`. |
+| B1 | `padding` in v1 search space | Fixed to `0` in Bayesian runs. |
+| B2 | `run_count` meaning | `run_count = n_trials`. Add `grid_equivalent_count` on experiment doc. |
+| B3 | `BayesianConfig` location | `ExecutionConfig` under `execution.bayesian`. |
+| B4 | `resume_experiment` behavior | HTTP 409 with reason: `"Bayesian experiments cannot be resumed (study state is in-memory only)"`. |
+| B5 | `parallelism > 1` | Warn only; recommend `1` in example configs. |
+| B6 | Failed trial score to Optuna | Use `study.tell(trial, float("nan"), state=TrialState.FAIL)` for failed trials. |
+| D1 | Acceptance criteria and tests | Defined in this slice. |
+| D2 | `n_trials` default value | Omit `execution.bayesian` or set `n_trials` to null: default at runtime to grid-equivalent count. If set, use explicit budget; if above grid-equivalent, cap at grid-equivalent with a warning. |
+| D4 | `optuna` version pin | `optuna>=3.0` in `pyproject.toml`. |
+| D5 | CLI summary format | See acceptance/output section below and persist summary in `bayesian_summary`. |
 
 ## Plan Review Feedback (to apply before implementation)
 
@@ -29,6 +67,8 @@ Add `execution.search_strategy: bayesian` as an opt-in sweep mode that only tune
   - usage and examples for enabling bayesian mode in user-facing docs.
   - config schema/docs reference update showing `search_strategy` + `bayesian.n_trials`.
   - changelog or slice trail note for activation/behavior changes.
+- Add dashboard handoff behavior so Bayesian and grid experiments are visually distinguishable in list/detail output.
+- Prefer minimal UI adaptation: strategy badge + conditional summary cards to avoid duplicating existing grid views.
 
 ## Planning Quality Lens [GATE]
 
@@ -57,9 +97,16 @@ Add `execution.search_strategy: bayesian` as an opt-in sweep mode that only tune
 - [ ] Submitting a Bayesian experiment creates exactly `n_trials` run entries in `run_status`.
 - [ ] `experiment_doc.run_count == config.execution.bayesian.n_trials`.
 - [ ] `experiment_doc.grid_equivalent_count == len(chunk_sizes) × len(overlaps)`.
+- [ ] Duplicate `(chunk_size, overlap)` suggestions are de-duplicated and marked as `TrialState.PRUNED` (or equivalent) without advancing trial-completion counters.
 - [ ] Mid-sweep pause and cancel preserve current semantics (`pause` or `stop` takes effect at the next trial boundary; `_run_single()` completes or interrupts as today).
 - [ ] `POST /experiments/{id}/resume` returns HTTP 409 for Bayesian experiments.
 - [ ] Completion prints Bayesian comparison summary with best config/score and grid-equivalent efficiency.
+- [ ] Dashboard and list/detail output adapt cleanly to both strategies:
+  - Bayesian experiments show `search_strategy`, `grid_equivalent_count`, and `bayesian_summary` in context.
+  - Non-Bayesian experiments preserve current output fields and layout (no Bayesian-only cards/metrics).
+- [ ] Dashboard and API output shape remain backward compatible:
+  - New fields are additive (`bayesian_summary`, `grid_equivalent_count`) when strategy is bayesian.
+  - Non-bayesian outputs remain unchanged and do not require dashboard special-casing beyond hiding bayesian blocks.
 - [ ] `optuna>=3.0` is added to dependency set without additional infra requirements.
 - [ ] Usage docs include: minimal config diff required to activate Bayesian mode and an end-to-end "expected run" sample.
 - [ ] `configs/example-mongodb-unified-retrievers-bayesian.yaml` and
@@ -70,8 +117,10 @@ Add `execution.search_strategy: bayesian` as an opt-in sweep mode that only tune
     `experiment_name: example-mongodb-local-bayesian`.
   - Both files add `execution.search_strategy: bayesian` and `execution.bayesian.n_trials`,
     while constraining the Bayesian search axes as required.
-- [ ] A dashboard- and API-level no-regression rule is captured: old fields in `run_status` and experiment documents remain backward compatible.
 - [ ] `_planned_run_count(config)` value is documented and surfaced in planned-count UX same as existing run display behavior.
+- [ ] `execution.bayesian.n_trials` can be omitted and resolves to grid-equivalent default at runtime.
+- [ ] Failed trial outcomes are passed to Optuna as `TrialState.FAIL` with `NaN` to preserve resume/continuation behavior and diagnostics.
+- [ ] Duplicate trial candidates do not create extra `run_status` rows and are surfaced only via Optuna prune semantics.
 
 ## Behavioral scenarios (GWT)
 
@@ -106,7 +155,7 @@ Scenario: Bayesian mode blocks invalid multi-axis optimization
 
 ## Implementation backlog (for /nw-execute)
 
-- Add `BayesianConfig` under `ExecutionConfig` with `n_trials: int = 12`.
+- Add `BayesianConfig` under `ExecutionConfig` with `n_trials: int | None = None`.
 - Add `search_strategy` and `bayesian` to `ExperimentConfig.execution`.
 - Add cross-field validation enforcing single fixed axes for Bayesian runs.
 - Add `_run_bayesian_inner`, `_bayesian_trial_to_run_params`, `_compute_trial_score`, `_finalise_bayesian_experiment`.
@@ -119,7 +168,7 @@ Scenario: Bayesian mode blocks invalid multi-axis optimization
     `experiment_name: example-mongodb-unified-retrievers-bayesian`.
   - Local variant derives from `example-mongodb-local.yaml` and uses
     `experiment_name: example-mongodb-local-bayesian`.
-- No dashboard code changes.
+- Add dashboard UI updates for strategy-aware rendering in experiment summary views and run detail tables.
 
 ## Files to update
 
@@ -128,6 +177,7 @@ Scenario: Bayesian mode blocks invalid multi-axis optimization
 - `server/api/experiments.py`
 - `configs/example-mongodb-unified-retrievers-bayesian.yaml`
 - `configs/example-mongodb-local-bayesian.yaml`
+- `frontend/src/**/*` (strategy-aware display updates)
 - `docs/plan/slices/SLICE-41A-BAYESIAN-SEARCH-SIMPLE-FUNCTIONAL.md` (new)
 - `pyproject.toml`
 
@@ -155,6 +205,38 @@ Scenario: Bayesian mode blocks invalid multi-axis optimization
 - [GATE] Layer-07 Delivery Completion
   - [ ] [RED] Run one end-to-end happy-path bayesian scenario: planned-count, n_trials runs, resume-disabled, and completion summary all pass.
   - [ ] [GREEN] Verify no regressions on existing slice-critical paths (`grid` default path and `expand_sweep` semantics).
+  - [ ] [RED] Add dashboard contract tests showing both bayesian and non-Bayesian output rendering behavior.
+  - [ ] [GATE] Specification coverage: every GWT clause has at least one test; all essential success and failure clauses covered.
+  - [ ] [GATE] Branch coverage: 100% branch target on touched functions; accepted exclusions are documented.
+  - [ ] [GATE] Mutation testing: apply mutation checks when feature-complete; no high-severity survivals.
+
+## Dashboard Adaptation Contract (authoritative)
+
+- `frontend` list/detail output must include strategy label:
+  - `search_strategy: bayesian` for Bayesian runs.
+  - `search_strategy: grid` (or omitted) for existing behavior.
+- Bayesian run rows show a dedicated summary region with:
+  - best candidate
+  - trials run / `grid_equivalent_count`
+  - best-first coverage mode and source trial summary
+- Non-Bayesian runs keep existing summary ordering and fields.
+- API fields consumed by dashboard must keep existing JSON keys stable when non-bayesian.
+
+## Runtime Loop Design (authoritative)
+
+- `_resolve_n_trials(config: ExperimentConfig) -> int`:
+  - `grid_equivalent = _compute_grid_equivalent(config)`
+  - If `config.execution.bayesian.n_trials is None`: return `grid_equivalent`.
+  - If `n_trials > grid_equivalent`: log warning and cap to `grid_equivalent`.
+  - Else return provided `n_trials`.
+- Bayesian loop stopping conditions are conjunctive:
+  - `trials_completed < n_trials`
+  - `len(visited) < grid_equivalent`
+  - `optuna_calls < max_optuna_calls` where `max_optuna_calls = n_trials * 3`.
+- Duplicate suggestions handling:
+  - Track `visited: set[(chunk_size, overlap)]`.
+  - If duplicate suggested, call `study.tell(trial, values=None, state=TrialState.PRUNED)` and continue.
+  - Duplicates do not increment `trials_completed` and do not create additional `run_status` entries.
 
 ## Handoff & Boundary Tests (explicit checklist)
 
@@ -163,3 +245,18 @@ Scenario: Bayesian mode blocks invalid multi-axis optimization
 - [GATE] Per-trial handoff: `_run_bayesian_inner` to `_run_single` argument/state contract identical to grid path.
 - [GATE] Pause/stop: interrupt still observed before next trial setup; `_run_single` completion/interruption semantics unchanged.
 - [GATE] Resume boundary: `POST /experiments/{id}/resume` returns 409 with bayesian-specific rationale.
+
+## Config/Behavior Reference (PCTO source excerpt)
+
+- `ExecutionConfig` additions:
+  - `search_strategy: Literal["grid", "bayesian"] = "grid"`
+  - `bayesian: BayesianConfig` with `n_trials: int | None = None` (runtime default to grid-equivalent)
+- Bayesian path contract:
+  - `_execute_sweep()` dispatches by `search_strategy`.
+  - Bayesian mode uses deduplicated trial suggestion on (`chunk_size`, `overlap`) only.
+  - Duplicate suggestions must transition to `TrialState.PRUNED` and should not count toward `n_trials`.
+  - `_run_single()` is called using the existing arguments/state contract from grid path.
+- CLI completion output includes:
+  - Best config and score
+  - Trials run vs. unique combinations
+  - Grid-equivalent count and coverage mode (full or capped)

--- a/docs/plan/slices/SLICE-41A-BAYESIAN-SEARCH-SIMPLE-FUNCTIONAL.md
+++ b/docs/plan/slices/SLICE-41A-BAYESIAN-SEARCH-SIMPLE-FUNCTIONAL.md
@@ -69,6 +69,7 @@ CLI prints a comparison summary at completion.
   - changelog or slice trail note for activation/behavior changes.
 - Add dashboard handoff behavior so Bayesian and grid experiments are visually distinguishable in list/detail output.
 - Prefer minimal UI adaptation: strategy badge + conditional summary cards to avoid duplicating existing grid views.
+- Explicitly defer: “considered vs executed vs discarded” indicator (sampler proposal history) is out of scope for Slice 41A, and if implemented later, it must only apply to Bayesian experiments.
 
 ## Planning Quality Lens [GATE]
 
@@ -121,6 +122,7 @@ CLI prints a comparison summary at completion.
 - [ ] `execution.bayesian.n_trials` can be omitted and resolves to grid-equivalent default at runtime.
 - [ ] Failed trial outcomes are passed to Optuna as `TrialState.FAIL` with `NaN` to preserve resume/continuation behavior and diagnostics.
 - [ ] Duplicate trial candidates do not create extra `run_status` rows and are surfaced only via Optuna prune semantics.
+- [ ] Follow-up scope: exposing “considered vs executed vs discarded” counts (sampler proposal history) is explicitly deferred and is not required for Slice 41A acceptance; if implemented, it must be shown only for Bayesian experiments and never for non-Bayesian runs.
 
 ## Behavioral scenarios (GWT)
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -68,6 +68,9 @@ retrieval:
 execution:
   parallelism: 1                     # 1 runs sequentially (safe default); increase for local-provider throughput demos
   on_error: continue                 # "continue" (partial results) or "stop" (halt experiment)
+  search_strategy: grid              # "grid" (default cartesian) or "bayesian"
+  bayesian:
+    n_trials: 12                     # ignored unless search_strategy: bayesian
 ```
 
 ### Parallelism (`execution.parallelism`)
@@ -79,6 +82,31 @@ execution:
 - **Voyage / remote providers**: larger parallelism can hit external RPM/TPM quotas; for that path, use cautious values and dedicated throttling (not part of this slice).
 - **SIE**: transient retry protection is in-process in this demo path (e.g., `503`, `429`, and `rate-limit` style failures), with `Retry-After` honored where available. SIE requests remain capped in-process to avoid runaway fan-out.
 - **Slice 16 implemented**: **[Slice 16 — Parallel Sweep Runs](../plan/slices/SLICE-16-PARALLEL-SWEEP-RUNS.md)** adds bounded concurrent `_run_single` scheduling with current `on_error` and cancellation semantics; optional queue-based rollout remains out of scope.
+
+### Bayesian sweep strategy (`execution.search_strategy`)
+
+Set `search_strategy: bayesian` to use Optuna TPE for chunk tuning:
+
+```yaml
+execution:
+  search_strategy: bayesian
+  bayesian:
+    n_trials: 12
+```
+
+Bayesian mode tunes **only** chunk-size and overlap while keeping all other axes fixed and still runs the same `_run_single()` pipeline for each trial:
+
+- `embedding.models` must contain exactly one model
+- `chunking.methods` must contain exactly one method
+- `chunking.params.paddings` must contain one value
+- `retrieval.retrievers` must contain one retriever entry
+
+Expected run count is `execution.bayesian.n_trials`. UI and API planned counts also show the **equivalent grid size** via experiment field `grid_equivalent_count` = `len(chunk_sizes) × len(overlaps)`.
+
+Example canonical configs:
+
+- [example-mongodb-unified-retrievers-bayesian.yaml](../../configs/example-mongodb-unified-retrievers-bayesian.yaml) (opt-in, Bayesian search over chunking only)
+- [example-mongodb-local-bayesian.yaml](../../configs/example-mongodb-local-bayesian.yaml) (opt-in, Bayesian search over chunking only)
 
 ### Example config files
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -101,7 +101,12 @@ Bayesian mode tunes **only** chunk-size and overlap while keeping all other axes
 - `chunking.params.paddings` must contain one value
 - `retrieval.retrievers` must contain one retriever entry
 
-Expected run count is `execution.bayesian.n_trials`. UI and API planned counts also show the **equivalent grid size** via experiment field `grid_equivalent_count` = `len(chunk_sizes) × len(overlaps)`.
+Expected run count is:
+- `execution.bayesian.n_trials` when it is set
+- otherwise, the grid-equivalent default `len(chunk_sizes) × len(overlaps)` when omitted
+
+If `n_trials` is higher than the grid-equivalent count, runtime caps it to the grid size.
+UI and API planned counts also expose `grid_equivalent_count` for Bayesian runs.
 
 Example canonical configs:
 

--- a/docs/user-guide/dashboard-guide.md
+++ b/docs/user-guide/dashboard-guide.md
@@ -52,6 +52,7 @@ The landing screen presents all submitted experiments as result-led cards, newes
 | `running` | Blue | One or more runs still active |
 | `paused` | Violet | Sweep paused — completed runs kept; resume to continue remaining combos |
 | `partial` | Yellow | Sweep stopped early — some runs complete, some failed/interrupted, and/or some parameter combos never started |
+| `partial` *(Bayesian)* | Yellow | Sweep stopped early after sampler pruning or interruption — some candidates were **discarded** before execution |
 | `failed` | Red | All runs failed, **or** experiment rejected at search-index preflight (no runs started) |
 | `cancelled` | Gray | Experiment was cancelled |
 
@@ -92,7 +93,7 @@ Pause, resume, and cancel controls appear **only in the overview header** — no
 | Status | Banner |
 |---|---|
 | `complete` | Green — all planned runs succeeded |
-| `partial` | Amber — “Sweep Incomplete” with breakdown (e.g. 41/90 complete, 48 never started) |
+| `partial` | Amber — “Sweep Incomplete” with breakdown (e.g. 41/90 complete, 48 never started; 12 discarded if Bayesian) |
 | `paused` | Violet — “Experiment Paused” banner with run count; resume via header controls |
 | `cancelled` | Gray — runs completed before cancellation |
 | Failed runs | Red panel listing `error_message` per run |

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -248,6 +248,7 @@ and does not fit into the model's context window of 32000 tokens.
 1. Restart the server once — reconciliation runs at startup (check logs for `Reconciled N orphaned experiment(s)`)
 2. On the detail screen, verify outcome metrics: **Successful + Failed + Interrupted + Not Started = Total**
 3. To finish remaining parameter combos: **`rag-params-finder resume <experiment-id>`** if status is `paused`, or pause a running sweep first then resume later. Alternatively submit a trimmed YAML for missing combos, or wait for Slice 10 `recover` (retry failed/interrupted runs in-place)
+4. For Bayesian experiments, if the experiment is `partial`, this can be a graceful sampler stop when duplicate or low-value candidates are pruned before execution. The detail page may show `discarded_trials`; compare with `attempted_trials` and `planned_trials` in `bayesian_summary` to confirm intent.
 
 **Prevention during long sweeps**:
 

--- a/frontend/src/components/ExperimentDetailScreen.test.tsx
+++ b/frontend/src/components/ExperimentDetailScreen.test.tsx
@@ -68,9 +68,13 @@ function run(experimentId: string, index: number, phase: Phase): RunStatus {
   };
 }
 
-function detailFixture(status: ExperimentStatus, phases: Phase[]): DetailFixture {
+function detailFixture(
+  status: ExperimentStatus,
+  phases: Phase[],
+  overrides: Partial<DetailFixture> = {},
+): DetailFixture {
   const experimentId = `detail-${status}`;
-  return {
+  const base: DetailFixture = {
     experiment_id: experimentId,
     experiment_name: `${status} detail sweep`,
     config: {},
@@ -79,6 +83,7 @@ function detailFixture(status: ExperimentStatus, phases: Phase[]): DetailFixture
     run_count: 3,
     runs: phases.map((phase, index) => run(experimentId, index, phase)),
   };
+  return { ...base, ...overrides };
 }
 
 function dbStats(fixture: DetailFixture): ExperimentDbStatsSummary {
@@ -262,6 +267,55 @@ describe('ExperimentDetailScreen lifecycle presentation', () => {
         actions: renderedActionVisibility(),
       };
       expect(actualLifecyclePresentation).toEqual({ summary, nextStep, actions });
+    },
+  );
+
+  it(
+    'reports attempted and discarded counts correctly when Bayesian sweep is complete but short of planned trials without failures',
+    async () => {
+      /**
+       * Scenario: Bayesian shortfall still reaches terminal COMPLETE status
+       * Slice: 41A — Bayesian Search: Simple Functional.
+       * Given a completed Bayesian experiment with no failed runs and planned/attempted/discarded mismatch.
+       * When the detail summary renders.
+       * Then lifecycle copy uses attempted/discarded/not-started labels aligned with those event counts.
+       */
+      const fixture = detailFixture('complete', Array.from({ length: 79 }, () => Phase.COMPLETE), {
+        experiment_id: 'bayesian-shortfall-detail',
+        experiment_name: 'bayesian shortfall detail sweep',
+        config: { execution: { search_strategy: 'bayesian' } },
+        run_count: 100,
+        completion_reason: 'completed_with_sampling_shortfall',
+        bayesian_summary: {
+          planned_trials: 100,
+          attempted_trials: 79,
+          discarded_trials: 21,
+        },
+      });
+      apiMocks.getExperiment.mockImplementation(async (experimentId: string) => {
+        if (experimentId !== 'bayesian-shortfall-detail') throw new Error(`Unknown fixture: ${experimentId}`);
+        return fixture;
+      });
+
+      render(
+        <ExperimentDetailScreen
+          experimentId={fixture.experiment_id}
+          initialExperiment={fixture}
+          initialDbStats={dbStats(fixture)}
+          onBack={vi.fn()}
+          onExplore={vi.fn()}
+        />,
+      );
+      await waitFor(() => expect(apiMocks.getExperiment).toHaveBeenCalledOnce());
+
+      expect(screen.getByText(
+        'Planned 100 Bayesian combinations. 79 attempted: 79 complete, 0 interrupted, 21 discarded by sampler, 0 not started (completed with sampling shortfall).',
+      )).toBeTruthy();
+      expect(screen.getByText(/21 discarded by sampler/)).toBeTruthy();
+      expect(
+        screen.getByText(/Attempted 79 of 100 combinations; 79 completed successfully with no failures \(completed with sampling shortfall\)\./),
+      ).toBeTruthy();
+      expect(screen.getByText(/(?:0 interrupted|0 failed)/)).toBeTruthy();
     },
   );
 });

--- a/frontend/src/components/ExperimentDetailScreen.tsx
+++ b/frontend/src/components/ExperimentDetailScreen.tsx
@@ -125,6 +125,7 @@ interface ExperimentDetail {
   experiment_name: string;
   status: ExperimentStatus;
   created_at?: string;
+  completed_at?: string | null;
   run_count?: number;
   grid_equivalent_count?: number;
   failed_count?: number;
@@ -140,7 +141,6 @@ interface ExperimentDetail {
   };
   runs?: RunStatus[];
   started_at?: string;
-  completed_at?: string | null;
   git_commit?: string;
   git_branch?: string;
   git_dirty?: boolean;
@@ -574,9 +574,9 @@ export default function ExperimentDetailScreen({
   }, []);
 
   const startDetailPollIfRunning = useCallback(
-    (status: ExperimentStatus | undefined) => {
+    (status: ExperimentStatus | undefined, completedAt?: string | null) => {
       stopDetailPoll();
-      if (!isRunningExperimentStatus(status)) return;
+      if (!isRunningExperimentStatus(status, completedAt)) return;
 
       devInfo('ExperimentDetailScreen', `detail poll started — ${experimentId.slice(0, 8)}… every ${DETAIL_POLL_MS}ms`);
 
@@ -594,7 +594,9 @@ export default function ExperimentDetailScreen({
             `detail poll OK — ${experimentId.slice(0, 8)}… status=${next.status}`,
             pollDevLogAtRef.current,
           );
-          if (isTerminalExperimentStatus(next.status)) {
+          if (
+            isTerminalExperimentStatus(next.status, next.completed_at)
+          ) {
             stopDetailPoll();
           }
         } catch (pollErr) {
@@ -663,6 +665,7 @@ export default function ExperimentDetailScreen({
       stopDetailPoll();
 
       let loadedStatus: ExperimentStatus | undefined;
+      let loadedCompletedAt: string | null | undefined;
 
       try {
         const loaded = hasSeed
@@ -671,6 +674,7 @@ export default function ExperimentDetailScreen({
         stall.stop();
         if (!aliveRef.current) return;
         loadedStatus = loaded.status;
+        loadedCompletedAt = loaded.completed_at;
         setDetail(loaded as unknown as ExperimentDetail);
         const runs = (loaded as { runs?: unknown[] }).runs;
         const runRows = Array.isArray(runs) ? runs.length : 0;
@@ -681,7 +685,7 @@ export default function ExperimentDetailScreen({
         setLoadFeed((f) =>
           appendDetailFeed(
             f,
-            isRunningExperimentStatus(loaded.status)
+            isRunningExperimentStatus(loaded.status, loadedCompletedAt)
               ? 'Run rows loaded — live polling while experiment is running.'
               : 'Run rows loaded.',
             'default',
@@ -700,7 +704,7 @@ export default function ExperimentDetailScreen({
         stall.stop();
         if (aliveRef.current) {
           setHydrating(false);
-          startDetailPollIfRunning(loadedStatus);
+          startDetailPollIfRunning(loadedStatus, loadedCompletedAt);
         }
       }
     }
@@ -718,8 +722,9 @@ export default function ExperimentDetailScreen({
   const refreshDetailAfterControl = useCallback(async () => {
     const refreshed = await getExperiment(experimentId);
     setDetail(refreshed as unknown as ExperimentDetail);
-    if (isRunningExperimentStatus(refreshed.status)) {
-      startDetailPollIfRunning(refreshed.status);
+    const refreshedCompletedAt = refreshed.completed_at;
+    if (isRunningExperimentStatus(refreshed.status, refreshedCompletedAt)) {
+      startDetailPollIfRunning(refreshed.status, refreshedCompletedAt);
     } else {
       stopDetailPoll();
     }
@@ -743,10 +748,9 @@ export default function ExperimentDetailScreen({
     }
   }
 
-  const TERMINAL_STATUSES: ExperimentStatus[] = ['complete', 'failed', 'partial', 'cancelled'];
-  const isTerminal = detail && TERMINAL_STATUSES.includes(detail.status);
-  const isRunning = isRunningExperimentStatus(detail?.status);
-  const isPaused = isPausedExperimentStatus(detail?.status);
+  const isTerminal = detail && isTerminalExperimentStatus(detail.status, detail.completed_at);
+  const isRunning = isRunningExperimentStatus(detail?.status, detail?.completed_at);
+  const isPaused = isPausedExperimentStatus(detail?.status, detail?.completed_at);
   const canExplore = Boolean(onExplore && (isTerminal || isRunning || isPaused));
   const canDelete = isTerminal || isPaused;
 

--- a/frontend/src/components/ExperimentDetailScreen.tsx
+++ b/frontend/src/components/ExperimentDetailScreen.tsx
@@ -965,23 +965,26 @@ export default function ExperimentDetailScreen({
       return `Paused after ${runSummary.complete} of ${runSummary.expected} runs completed; resume to run the remaining parameter combinations.`;
     }
     if (detail.status === 'complete') {
+      const reasonSuffix = detail.completion_reason && detail.completion_reason !== 'all_planned_trials_completed'
+        ? ` (${completionReasonLabel(detail.completion_reason)})`
+        : '';
       if (isBayesianIncomplete) {
-        const reasonSuffix = detail.completion_reason && detail.completion_reason !== 'all_planned_trials_completed'
-          ? ` (${completionReasonLabel(detail.completion_reason)})`
-          : '';
         return `Planned ${bayesianPlannedTrials} Bayesian combinations. `
           + `${bayesianAttemptedTrials} attempted: ${bayesianCompletedCount} complete, ${runSummary.interrupted} interrupted, `
           + `${bayesianDiscardedCount} discarded by sampler, ${bayesianNotStartedCount} not started${reasonSuffix}.`;
       }
-      return `All ${runSummary.expected} configured runs completed${detail.completion_reason && detail.completion_reason !== 'all_planned_trials_completed' ? ` (${completionReasonLabel(detail.completion_reason)})` : ''}; stored results are ready to inspect.`;
+      return `All ${runSummary.expected} configured runs completed${reasonSuffix}; stored results are ready to inspect.`;
     }
+    const partialReasonSuffix = detail.completion_reason
+      ? ` (${completionReasonLabel(detail.completion_reason)})`
+      : '';
     if (detail.status === 'partial') {
       if (isBayesianStrategy) {
         return `Planned ${bayesianPlannedTrials} Bayesian combinations. `
           + `${bayesianAttemptedTrials} attempted: ${runSummary.complete} complete, ${runSummary.failed} failed, `
-          + `${runSummary.interrupted} interrupted, ${bayesianDiscardedCount} discarded by sampler, ${bayesianNotStartedCount} not started.`;
+          + `${runSummary.interrupted} interrupted, ${bayesianDiscardedCount} discarded by sampler, ${bayesianNotStartedCount} not started${partialReasonSuffix}.`;
       }
-      return `${runSummary.complete} of ${runSummary.expected} runs completed${detail.completion_reason ? ` (${completionReasonLabel(detail.completion_reason)})` : ''}; treat rankings from completed runs as preliminary results.`;
+      return `${runSummary.complete} of ${runSummary.expected} runs completed${partialReasonSuffix}; treat rankings from completed runs as preliminary results.`;
     }
     if (detail.status === 'cancelled') {
       return `Collection stopped after ${runSummary.complete} of ${runSummary.expected} runs completed.`;

--- a/frontend/src/components/ExperimentDetailScreen.tsx
+++ b/frontend/src/components/ExperimentDetailScreen.tsx
@@ -126,7 +126,18 @@ interface ExperimentDetail {
   status: ExperimentStatus;
   created_at?: string;
   run_count?: number;
+  grid_equivalent_count?: number;
   failed_count?: number;
+  bayesian_summary?: {
+    best_query_avg_score?: number;
+    best_chunk_size?: number;
+    best_overlap?: number;
+    best_embedding_model?: string;
+    best_retrieval_method?: string;
+    best_retriever_type?: string;
+    grid_equivalent_count?: number;
+    planned_trials?: number;
+  };
   runs?: RunStatus[];
   started_at?: string;
   completed_at?: string | null;
@@ -150,6 +161,9 @@ interface ExperimentDetail {
     };
     retrieval?: {
       retrieval_provider?: string;
+    };
+    execution?: {
+      search_strategy?: 'grid' | 'bayesian';
     };
   };
 }
@@ -1070,10 +1084,26 @@ export default function ExperimentDetailScreen({
                 }
               >
                 <div className="space-y-3">
+                  <MetadataItem
+                    label="Search Strategy"
+                    value={detail.config?.execution?.search_strategy ?? 'grid'}
+                  />
                   <MetadataItem label="Rerank Model" value={detail.retrieval_model ?? 'none'} />
                   <MetadataItem label="Top-K Initial" value={detail.top_k_initial} />
                   <MetadataItem label="Top-K Final" value={detail.top_k_final} />
                   <MetadataItem label="Parallelism" value={detail.parallelism} />
+                  {detail.config?.execution?.search_strategy === 'bayesian' ? (
+                    <>
+                      <MetadataItem
+                        label="Planned Bayesian Trials"
+                        value={detail.run_count}
+                      />
+                      <MetadataItem
+                        label="Grid-Equivalent Count"
+                        value={detail.grid_equivalent_count}
+                      />
+                    </>
+                  ) : null}
                   <MetadataItem label="On Error" value={detail.on_error} />
                   <MetadataItem label="Queries" value={detail.queries_file} />
                 </div>
@@ -1126,6 +1156,12 @@ export default function ExperimentDetailScreen({
                 <DimensionBadge label="Chunking" values={detail.sweep_summary.chunking_methods} />
                 <DimensionBadge label="Chunk Sizes" values={detail.sweep_summary.chunk_sizes} />
                 <DimensionBadge label="Overlaps" values={detail.sweep_summary.overlaps} />
+                {detail.config?.execution?.search_strategy === 'bayesian' && (
+                  <DimensionBadge
+                    label="Bayesian Strategy"
+                    values={['chunk_size × overlap']}
+                  />
+                )}
                 {detail.sweep_summary.paddings && detail.sweep_summary.paddings.length > 0 && (
                   <DimensionBadge label="Paddings" values={detail.sweep_summary.paddings} />
                 )}
@@ -1143,6 +1179,30 @@ export default function ExperimentDetailScreen({
                 )}
               </div>
             </CollapsibleCard>
+
+            {detail.config?.execution?.search_strategy === 'bayesian' && detail.bayesian_summary && (
+              <CollapsibleCard
+                title="Bayesian Summary"
+                icon={icons.grid}
+                storageKey={`detail-bayesian-summary-${experimentId}`}
+                headerExtra={
+                  <span className="text-sm font-semibold text-accent-strong">
+                    {detail.run_count}/{detail.grid_equivalent_count ?? '—'} trials
+                  </span>
+                }
+                className="mt-3"
+              >
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <MetadataItem label="Best Query Avg Score" value={detail.bayesian_summary.best_query_avg_score} />
+                  <MetadataItem label="Best Chunk Size" value={detail.bayesian_summary.best_chunk_size} />
+                  <MetadataItem label="Best Overlap" value={detail.bayesian_summary.best_overlap} />
+                  <MetadataItem
+                    label="Best Embedding"
+                    value={detail.bayesian_summary.best_embedding_model}
+                  />
+                </div>
+              </CollapsibleCard>
+            )}
           </div>
         )}
 

--- a/frontend/src/components/ExperimentDetailScreen.tsx
+++ b/frontend/src/components/ExperimentDetailScreen.tsx
@@ -170,6 +170,7 @@ interface ExperimentDetail {
     planned_trials?: number;
     attempted_trials?: number;
     discarded_trials?: number;
+    not_started?: number;
     termination_reason?: string;
   };
   runs?: RunStatus[];

--- a/frontend/src/components/ExperimentDetailScreen.tsx
+++ b/frontend/src/components/ExperimentDetailScreen.tsx
@@ -138,6 +138,9 @@ interface ExperimentDetail {
     best_retriever_type?: string;
     grid_equivalent_count?: number;
     planned_trials?: number;
+    attempted_trials?: number;
+    discarded_trials?: number;
+    termination_reason?: string;
   };
   runs?: RunStatus[];
   started_at?: string;
@@ -893,6 +896,24 @@ export default function ExperimentDetailScreen({
   }
 
   const runSummary = summarizeExperimentRuns(detail.runs, detail.run_count);
+  const isBayesianStrategy = detail.config?.execution?.search_strategy === 'bayesian';
+  const bayesianSummary = detail.bayesian_summary;
+  const bayesianPlannedTrials = isBayesianStrategy && typeof bayesianSummary?.planned_trials === 'number'
+    ? bayesianSummary.planned_trials
+    : runSummary.expected;
+  const bayesianAttemptedTrials = isBayesianStrategy
+    ? Math.max(
+        0,
+        bayesianSummary?.attempted_trials
+          ?? (runSummary.complete + runSummary.failed + runSummary.interrupted + runSummary.inProgress),
+      )
+    : 0;
+  const bayesianDiscardedCount = isBayesianStrategy
+    ? Math.max(0, bayesianSummary?.discarded_trials ?? 0)
+    : 0;
+  const bayesianNotStartedCount = isBayesianStrategy
+    ? Math.max(0, bayesianPlannedTrials - bayesianAttemptedTrials - bayesianDiscardedCount)
+    : runSummary.neverStarted;
   const sweepSummary = (() => {
     if (detail.status === 'running') {
       return `${runSummary.complete} of ${runSummary.expected} runs are complete; stored results can grow as the sweep continues.`;
@@ -904,6 +925,11 @@ export default function ExperimentDetailScreen({
       return `All ${runSummary.expected} configured runs completed; stored results are ready to inspect.`;
     }
     if (detail.status === 'partial') {
+      if (isBayesianStrategy) {
+        return `Planned ${bayesianPlannedTrials} Bayesian combinations. `
+          + `${bayesianAttemptedTrials} attempted: ${runSummary.complete} complete, ${runSummary.failed} failed, `
+          + `${runSummary.interrupted} interrupted, ${bayesianDiscardedCount} discarded by sampler, ${bayesianNotStartedCount} not started.`;
+      }
       return `${runSummary.complete} of ${runSummary.expected} runs completed; treat rankings from completed runs as preliminary results.`;
     }
     if (detail.status === 'cancelled') {
@@ -1011,7 +1037,11 @@ export default function ExperimentDetailScreen({
             </div>
             <div className="rounded-xl border border-line bg-paper p-3">
               <p className="text-xs font-bold uppercase tracking-wider text-muted">Run set</p>
-              <p className="mt-1 text-sm font-semibold text-ink">{runSummary.complete} complete · {runSummary.expected} configured</p>
+              <p className="mt-1 text-sm font-semibold text-ink">
+                {isBayesianStrategy
+                  ? `${bayesianAttemptedTrials} attempted · ${bayesianPlannedTrials} planned`
+                  : `${runSummary.complete} complete · ${runSummary.expected} configured`}
+              </p>
             </div>
             <div className="rounded-xl border border-line bg-paper p-3">
               <p className="text-xs font-bold uppercase tracking-wider text-muted">Next step</p>
@@ -1024,7 +1054,22 @@ export default function ExperimentDetailScreen({
             <StatCard compact label="Successful" value={runSummary.complete} icon={icons.check} color="green" />
             <StatCard compact label="Failed" value={runSummary.failed} icon={icons.x} color="red" />
             <StatCard compact label="Interrupted" value={runSummary.interrupted} icon={icons.x} color="amber" />
-            <StatCard compact label="Not Started" value={runSummary.neverStarted} icon={icons.grid} color="slate" />
+            <StatCard
+              compact
+              label={isBayesianStrategy ? 'Not Started' : 'Not Started'}
+              value={isBayesianStrategy ? bayesianNotStartedCount : runSummary.neverStarted}
+              icon={icons.grid}
+              color="slate"
+            />
+            {isBayesianStrategy && (
+              <StatCard
+                compact
+                label="Discarded by Sampler"
+                value={bayesianDiscardedCount}
+                icon={icons.x}
+                color="slate"
+              />
+            )}
             {runSummary.inProgress > 0 && (
               <StatCard compact label="In Progress" value={runSummary.inProgress} icon={icons.play} color="purple" />
             )}
@@ -1232,6 +1277,12 @@ export default function ExperimentDetailScreen({
                   <MetadataItem
                     label="Best Embedding"
                     value={detail.bayesian_summary.best_embedding_model}
+                  />
+                  <MetadataItem label="Attempts" value={detail.bayesian_summary.attempted_trials} />
+                  <MetadataItem label="Discarded by Sampler" value={detail.bayesian_summary.discarded_trials} />
+                  <MetadataItem
+                    label="Sampler Notes"
+                    value={detail.bayesian_summary.termination_reason || 'none'}
                   />
                 </div>
               </CollapsibleCard>
@@ -1492,13 +1543,26 @@ export default function ExperimentDetailScreen({
                 <div>
                   <h3 className="text-lg font-bold text-amber-900">Sweep Incomplete</h3>
                   <p className="text-sm text-amber-800 mt-1">
-                    {runSummary.complete} of {runSummary.expected} run(s) completed successfully.
+                    {isBayesianStrategy
+                      ? `Bayesian partial: ${bayesianAttemptedTrials} of ${bayesianPlannedTrials} attempted and started, `
+                        + `${runSummary.complete} completed successfully, ${bayesianDiscardedCount} discarded by sampler, ${bayesianNotStartedCount} not started.`
+                      : `${runSummary.complete} of ${runSummary.expected} run(s) completed successfully.`}
                     {runSummary.interrupted > 0 && ` ${runSummary.interrupted} interrupted.`}
                     {runSummary.failed > 0 && ` ${runSummary.failed} failed.`}
-                    {runSummary.neverStarted > 0 && ` ${runSummary.neverStarted} never started.`}
+                    {runSummary.neverStarted > 0 && ` ${runSummary.neverStarted} not started.`}
+                    {isBayesianStrategy && bayesianDiscardedCount > 0 && (
+                      <span>
+                        {' '}
+                        {detail.bayesian_summary?.termination_reason === 'sampler_candidate_exhaustion'
+                          ? `${bayesianDiscardedCount} were discarded by Bayesian sampler pruning.`
+                          : `${bayesianDiscardedCount} discarded while exploring candidate trials.`}
+                      </span>
+                    )}
                   </p>
                   <p className="text-xs text-amber-700 mt-2">
-                    The experiment stopped before every parameter combination ran — often after a server restart or cancellation mid-sweep.
+                    {isBayesianStrategy
+                      ? `Bayesian sweep configured ${bayesianPlannedTrials} candidate combinations: ${bayesianAttemptedTrials} attempted, ${bayesianDiscardedCount} discarded by sampler, ${bayesianNotStartedCount} not started.`
+                      : 'The experiment stopped before every parameter combination ran — often after a server restart or cancellation mid-sweep.'}
                   </p>
                 </div>
               </div>

--- a/frontend/src/components/ExperimentDetailScreen.tsx
+++ b/frontend/src/components/ExperimentDetailScreen.tsx
@@ -304,6 +304,31 @@ function formatDuration(startedAt?: string, completedAt?: string | null): string
   return formatTimeWithUnits(totalSeconds);
 }
 
+function parseSafeTimestamp(value: string | undefined): number | null {
+  if (!value) return null;
+  const parsed = new Date(value).getTime();
+  if (Number.isNaN(parsed)) return null;
+  return parsed;
+}
+
+function formatDurationFromRuns(runs: RunStatus[] = [], startedAt?: string, completedAt?: string | null): string {
+  const runStartedAt = Math.min(
+    ...runs.map((run) => parseSafeTimestamp(run.created_at)).filter((value): value is number => value !== null),
+  );
+  const runCompletedAt = Math.max(
+    ...runs.map((run) => parseSafeTimestamp(run.updated_at)).filter((value): value is number => value !== null),
+  );
+
+  const allRunsHaveTimestamps =
+    Number.isFinite(runStartedAt) && Number.isFinite(runCompletedAt) && runCompletedAt >= runStartedAt;
+
+  if (allRunsHaveTimestamps) {
+    return formatDuration(new Date(runStartedAt).toISOString(), new Date(runCompletedAt).toISOString());
+  }
+
+  return formatDuration(startedAt, completedAt);
+}
+
 function ProgressSubtitle({
   completed,
   total,
@@ -1006,7 +1031,11 @@ export default function ExperimentDetailScreen({
             <StatCard
               compact
               label="Duration"
-              value={isRunning || isPaused ? '—' : formatDuration(detail.started_at, detail.completed_at)}
+              value={
+                isRunning || isPaused
+                  ? '—'
+                  : formatDurationFromRuns(detail.runs ?? [], detail.started_at, detail.completed_at)
+              }
               icon={icons.clock}
               color="purple"
             />

--- a/frontend/src/components/ExperimentDetailScreen.tsx
+++ b/frontend/src/components/ExperimentDetailScreen.tsx
@@ -54,6 +54,35 @@ function appendDetailFeed(prev: FeedEntry[], text: string, variant: FeedEntry['v
   return [...prev, { id: `${Date.now()}-${detailFeedSeq}`, text, variant }];
 }
 
+const COMPLETION_REASONS = {
+  all_planned_trials_completed: 'all planned trials completed',
+  completed_with_sampling_shortfall: 'completed with sampling shortfall',
+  interrupted_before_completion: 'interrupted before completion',
+  cancelled_by_user: 'cancelled by user',
+  paused_by_user: 'paused by user',
+  all_trials_failed: 'all trials failed',
+  partial_failures: 'partial with failures',
+  partial_with_failures: 'partial with failures',
+  partial_outcomes: 'partial outcomes',
+  mixed_outcomes: 'mixed outcomes',
+  mixed_failures: 'mixed failures',
+  infrastructure_error: 'infrastructure error',
+  paused_or_interrupted_before_completion: 'interrupted before completion',
+  incomplete_before_completion: 'incomplete before completion',
+  incomplete_with_zero_runs: 'incomplete before completion',
+  incomplete_without_runs: 'incomplete before completion',
+  reconciled_from_orphaned_run: 'reconciled from orphaned run',
+  resolved_stale_running: 'reconciled from stale running state',
+  cancelled_before_attempt: 'cancelled before attempts',
+  completed_with_shortfall: 'completed with sampling shortfall',
+  incomplete_by_partial_outcomes: 'incomplete outcome',
+} as const;
+
+function completionReasonLabel(reason?: string | null): string {
+  if (!reason) return 'completion state recorded';
+  return COMPLETION_REASONS[reason as keyof typeof COMPLETION_REASONS] ?? reason.replace(/_/g, ' ');
+}
+
 // Icon components (minimal SVG)
 const icons = {
   clock: (
@@ -129,6 +158,7 @@ interface ExperimentDetail {
   run_count?: number;
   grid_equivalent_count?: number;
   failed_count?: number;
+  completion_reason?: string;
   bayesian_summary?: {
     best_query_avg_score?: number;
     best_chunk_size?: number;
@@ -247,6 +277,7 @@ function Pagination({
 function PhaseIndicator({ current }: { current: Phase }) {
   const currentIdx = PHASE_ORDER.indexOf(current);
   const isFailed = current === Phase.FAILED || current === Phase.INTERRUPTED;
+  const safeCurrent = typeof current === 'string' ? current : 'unknown';
 
   return (
     <div className="relative group flex gap-1 items-center">
@@ -266,7 +297,7 @@ function PhaseIndicator({ current }: { current: Phase }) {
           />
         );
       })}
-      <span className="ml-2 text-xs text-slate-500">{current}</span>
+      <span className="ml-2 text-xs text-slate-500">{safeCurrent}</span>
 
       {/* Tooltip on hover */}
       <div className="absolute left-0 bottom-full mb-2 hidden group-hover:block z-50 pointer-events-none">
@@ -914,6 +945,17 @@ export default function ExperimentDetailScreen({
   const bayesianNotStartedCount = isBayesianStrategy
     ? Math.max(0, bayesianPlannedTrials - bayesianAttemptedTrials - bayesianDiscardedCount)
     : runSummary.neverStarted;
+  const isBayesianIncomplete = isBayesianStrategy
+    && bayesianAttemptedTrials < bayesianPlannedTrials;
+  const hasShortfallCompletionReason = detail.completion_reason
+    ? ['completed_with_sampling_shortfall', 'completed_with_shortfall'].includes(detail.completion_reason)
+    : false;
+  const bayesianCompletedCount = isBayesianStrategy
+    ? hasShortfallCompletionReason
+      ? bayesianAttemptedTrials
+      : Math.max(0, bayesianAttemptedTrials - runSummary.failed - runSummary.interrupted - runSummary.inProgress)
+    : runSummary.complete;
+  const isCompleteWithBayesianShortfall = detail.status === 'complete' && isBayesianIncomplete;
   const sweepSummary = (() => {
     if (detail.status === 'running') {
       return `${runSummary.complete} of ${runSummary.expected} runs are complete; stored results can grow as the sweep continues.`;
@@ -922,7 +964,15 @@ export default function ExperimentDetailScreen({
       return `Paused after ${runSummary.complete} of ${runSummary.expected} runs completed; resume to run the remaining parameter combinations.`;
     }
     if (detail.status === 'complete') {
-      return `All ${runSummary.expected} configured runs completed; stored results are ready to inspect.`;
+      if (isBayesianIncomplete) {
+        const reasonSuffix = detail.completion_reason && detail.completion_reason !== 'all_planned_trials_completed'
+          ? ` (${completionReasonLabel(detail.completion_reason)})`
+          : '';
+        return `Planned ${bayesianPlannedTrials} Bayesian combinations. `
+          + `${bayesianAttemptedTrials} attempted: ${bayesianCompletedCount} complete, ${runSummary.interrupted} interrupted, `
+          + `${bayesianDiscardedCount} discarded by sampler, ${bayesianNotStartedCount} not started${reasonSuffix}.`;
+      }
+      return `All ${runSummary.expected} configured runs completed${detail.completion_reason && detail.completion_reason !== 'all_planned_trials_completed' ? ` (${completionReasonLabel(detail.completion_reason)})` : ''}; stored results are ready to inspect.`;
     }
     if (detail.status === 'partial') {
       if (isBayesianStrategy) {
@@ -930,7 +980,7 @@ export default function ExperimentDetailScreen({
           + `${bayesianAttemptedTrials} attempted: ${runSummary.complete} complete, ${runSummary.failed} failed, `
           + `${runSummary.interrupted} interrupted, ${bayesianDiscardedCount} discarded by sampler, ${bayesianNotStartedCount} not started.`;
       }
-      return `${runSummary.complete} of ${runSummary.expected} runs completed; treat rankings from completed runs as preliminary results.`;
+      return `${runSummary.complete} of ${runSummary.expected} runs completed${detail.completion_reason ? ` (${completionReasonLabel(detail.completion_reason)})` : ''}; treat rankings from completed runs as preliminary results.`;
     }
     if (detail.status === 'cancelled') {
       return `Collection stopped after ${runSummary.complete} of ${runSummary.expected} runs completed.`;
@@ -1138,6 +1188,10 @@ export default function ExperimentDetailScreen({
                   <MetadataItem
                     label="Completed"
                     value={detail.completed_at ? new Date(detail.completed_at).toLocaleString() : undefined}
+                  />
+                  <MetadataItem
+                    label="Completion Reason"
+                    value={detail.completion_reason ? completionReasonLabel(detail.completion_reason) : undefined}
                   />
                   <MetadataItem label="App Version" value={detail.app_version} />
                   <MetadataItem label="Python" value={detail.python_version} />
@@ -1505,18 +1559,26 @@ export default function ExperimentDetailScreen({
 
         {/* Terminal outcome summary */}
         {isTerminal && detail.status === 'complete' && (
-          <div className="mt-6 rounded-panel border border-emerald-300 bg-emerald-50 p-5 shadow-panel sm:p-6">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-              <div className="flex items-center gap-4">
-                <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-white">
-                  {icons.check}
-                </div>
+        <div
+          className={isCompleteWithBayesianShortfall
+            ? 'mt-6 rounded-panel border border-amber-300 bg-amber-50 p-5 shadow-panel sm:p-6'
+            : 'mt-6 rounded-panel border border-emerald-300 bg-emerald-50 p-5 shadow-panel sm:p-6'}
+        >
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-4">
+              <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-white">
+                {icons.check}
+              </div>
                 <div>
                   <h3 className="text-lg font-bold text-green-900">
-                    All Runs Completed Successfully!
+                    {isCompleteWithBayesianShortfall
+                      ? 'Bayesian Sampling Completed with Partial Coverage'
+                      : 'All Runs Completed Successfully!'}
                   </h3>
-                  <p className="text-sm text-green-700 mt-1">
-                    {runSummary.complete} of {runSummary.expected} run(s) finished without errors
+                <p className="text-sm text-green-700 mt-1">
+                    {isCompleteWithBayesianShortfall
+                      ? `Attempted ${bayesianAttemptedTrials} of ${bayesianPlannedTrials} combinations; ${bayesianCompletedCount} completed successfully with no failures${detail.completion_reason && detail.completion_reason !== 'all_planned_trials_completed' ? ` (${completionReasonLabel(detail.completion_reason)})` : ''}.`
+                      : `${runSummary.complete} of ${runSummary.expected} run(s) finished without errors`}
                   </p>
                 </div>
               </div>

--- a/frontend/src/components/ExperimentsScreen.test.tsx
+++ b/frontend/src/components/ExperimentsScreen.test.tsx
@@ -21,7 +21,11 @@ vi.mock('../services/apiClient', async () => {
   return { ...actual, ...apiMocks };
 });
 
-function experiment(status: Experiment['status'], failedCount = 0): Experiment {
+function experiment(
+  status: Experiment['status'],
+  failedCount = 0,
+  overrides: Partial<Experiment> = {},
+): Experiment {
   return {
     experiment_id: `experiment-${status}`,
     experiment_name: `${status} sweep`,
@@ -30,6 +34,7 @@ function experiment(status: Experiment['status'], failedCount = 0): Experiment {
     status,
     run_count: 3,
     failed_count: failedCount,
+    ...overrides,
   };
 }
 
@@ -40,6 +45,18 @@ const lifecycleExperiments = [
   experiment('partial'),
   experiment('failed', 2),
   experiment('cancelled'),
+  experiment('complete', 0, {
+    experiment_id: 'experiment-bayesian-shortfall',
+    experiment_name: 'bayesian shortfall',
+    config: { execution: { search_strategy: 'bayesian' } },
+    run_count: 100,
+    completion_reason: 'completed_with_sampling_shortfall',
+    bayesian_summary: {
+      planned_trials: 100,
+      attempted_trials: 79,
+      discarded_trials: 21,
+    },
+  }),
 ];
 
 function renderedRowPresentation(experimentName: string) {
@@ -98,6 +115,13 @@ describe('ExperimentsScreen lifecycle presentation', () => {
         resume: false,
         view: true,
       },
+      bayesian_shortfall: {
+        outcome: '100 runs configured · Bayesian: 79 attempted · 21 discarded · completed with sampling shortfall',
+        pause: false,
+        cancel: false,
+        resume: false,
+        view: true,
+      },
       partial: {
         outcome: '3 runs configured · incomplete outcome',
         pause: false,
@@ -136,6 +160,7 @@ describe('ExperimentsScreen lifecycle presentation', () => {
       running: renderedRowPresentation('running sweep'),
       paused: renderedRowPresentation('paused sweep'),
       complete: renderedRowPresentation('complete sweep'),
+      bayesian_shortfall: renderedRowPresentation('bayesian shortfall'),
       partial: renderedRowPresentation('partial sweep'),
       failed: renderedRowPresentation('failed sweep'),
       cancelled: renderedRowPresentation('cancelled sweep'),

--- a/frontend/src/components/ExperimentsScreen.tsx
+++ b/frontend/src/components/ExperimentsScreen.tsx
@@ -617,8 +617,8 @@ export default function ExperimentsScreen({
               <div className="space-y-3">
                 {paginatedExperiments.map((exp) => {
                   const isSelected = selectedExperiments.has(exp.experiment_id);
-                  const isRunning = isRunningExperimentStatus(exp.status);
-                  const isPaused = isPausedExperimentStatus(exp.status);
+                  const isRunning = isRunningExperimentStatus(exp.status, exp.completed_at);
+                  const isPaused = isPausedExperimentStatus(exp.status, exp.completed_at);
                   const isCollapsed = collapsedExperiments.has(exp.experiment_id);
                   const dbStats = statsByExperimentId.get(exp.experiment_id);
                   const showRowControls = isRunning || isPaused;

--- a/frontend/src/components/ExperimentsScreen.tsx
+++ b/frontend/src/components/ExperimentsScreen.tsx
@@ -149,13 +149,34 @@ function statusEdgeClass(status: Experiment['status']): string {
   return 'border-l-slate-400';
 }
 
+function resolveSearchStrategy(experiment: Experiment): 'grid' | 'bayesian' {
+  const configExecution = (experiment.config as { execution?: Record<string, unknown> } | undefined)?.execution;
+  if (!configExecution || typeof configExecution !== 'object') {
+    return 'grid';
+  }
+  const searchStrategy = configExecution['search_strategy'];
+  if (searchStrategy === 'bayesian' || searchStrategy === 'grid') {
+    return searchStrategy;
+  }
+  return 'grid';
+}
+
 function experimentOutcomeLabel(experiment: Experiment): string {
+  const bayesianSummary = experiment.bayesian_summary;
   const configuredRuns = experiment.run_count == null
     ? 'Run count pending'
     : `${experiment.run_count} run${experiment.run_count === 1 ? '' : 's'} configured`;
   if (experiment.status === 'running') return `${configuredRuns} · sweep in progress`;
   if (experiment.status === 'paused') return `${configuredRuns} · waiting to resume`;
   if (experiment.status === 'complete') return `${configuredRuns} · sweep complete`;
+  if (experiment.status === 'partial' && resolveSearchStrategy(experiment) === 'bayesian') {
+    const discarded = bayesianSummary?.discarded_trials ?? 0;
+    const attempted = bayesianSummary?.attempted_trials;
+    if (attempted == null) {
+      return `${configuredRuns} · Bayesian sampling incomplete`;
+    }
+    return `${configuredRuns} · Bayesian: ${attempted} attempted · ${discarded} discarded`;
+  }
   if (experiment.status === 'partial') return `${configuredRuns} · incomplete outcome`;
   if (experiment.status === 'cancelled') return `${configuredRuns} · collection stopped`;
   if (experiment.failed_count) return `${configuredRuns} · ${experiment.failed_count} failed`;

--- a/frontend/src/components/ExperimentsScreen.tsx
+++ b/frontend/src/components/ExperimentsScreen.tsx
@@ -202,17 +202,21 @@ function experimentOutcomeLabel(experiment: Experiment): string {
   const plannedTrials = bayesianSummary?.planned_trials;
   const attemptedTrials = bayesianSummary?.attempted_trials;
   const discardedTrials = bayesianSummary?.discarded_trials;
+  const notStartedTrials = bayesianSummary?.not_started;
+  const reasonSuffix = experiment.completion_reason
+    ? ` · ${completionReasonLabel(experiment.completion_reason)}`
+    : '';
   const hasBayesianIncomplete =
     isBayesianStrategy && plannedTrials != null && attemptedTrials != null && attemptedTrials < plannedTrials;
   if (experiment.status === 'running') return `${configuredRuns} · sweep in progress`;
   if (experiment.status === 'paused') return `${configuredRuns} · waiting to resume`;
   if (experiment.status === 'complete') {
     if (hasBayesianIncomplete) {
-      const notStarted = Math.max(0, plannedTrials - attemptedTrials - (discardedTrials ?? 0));
+      const notStarted = Math.max(
+        0,
+        (notStartedTrials ?? plannedTrials ?? 0) - (attemptedTrials ?? 0) - (discardedTrials ?? 0),
+      );
       const notStartedSuffix = notStarted > 0 ? ` · ${notStarted} not started` : '';
-      const reasonSuffix = experiment.completion_reason
-        ? ` · ${completionReasonLabel(experiment.completion_reason)}`
-        : '';
       return `${configuredRuns} · Bayesian: ${attemptedTrials} attempted · ${discardedTrials ?? 0} discarded`
         + notStartedSuffix
         + reasonSuffix;
@@ -226,11 +230,13 @@ function experimentOutcomeLabel(experiment: Experiment): string {
     const discarded = bayesianSummary?.discarded_trials ?? 0;
     const attempted = bayesianSummary?.attempted_trials;
     if (attempted == null) {
-      return `${configuredRuns} · Bayesian sampling incomplete`;
+      return `${configuredRuns} · Bayesian sampling incomplete${reasonSuffix}`;
     }
-    return `${configuredRuns} · Bayesian: ${attempted} attempted · ${discarded} discarded`;
+    const notStarted = Math.max(0, (notStartedTrials ?? plannedTrials ?? 0) - attempted - discarded);
+    const notStartedSuffix = notStarted > 0 ? ` · ${notStarted} not started` : '';
+    return `${configuredRuns} · Bayesian: ${attempted} attempted · ${discarded} discarded${notStartedSuffix}${reasonSuffix}`;
   }
-  if (experiment.status === 'partial') return `${configuredRuns} · incomplete outcome`;
+  if (experiment.status === 'partial') return `${configuredRuns} · incomplete outcome${reasonSuffix}`;
   if (experiment.status === 'cancelled') return `${configuredRuns} · collection stopped`;
   if (experiment.failed_count) return `${configuredRuns} · ${experiment.failed_count} failed`;
   return `${configuredRuns} · sweep failed`;

--- a/frontend/src/components/ExperimentsScreen.tsx
+++ b/frontend/src/components/ExperimentsScreen.tsx
@@ -161,14 +161,67 @@ function resolveSearchStrategy(experiment: Experiment): 'grid' | 'bayesian' {
   return 'grid';
 }
 
+const COMPLETION_REASONS: Record<string, string> = {
+  all_planned_trials_completed: 'all planned trials completed',
+  completed_with_sampling_shortfall: 'completed with sampling shortfall',
+  all_trials_failed: 'all trials failed',
+  partial_failures: 'partial with failures',
+  interrupted_before_completion: 'interrupted before completion',
+  cancelled_by_user: 'cancelled by user',
+  paused_by_user: 'paused by user',
+  incomplete_before_completion: 'incomplete before completion',
+  incomplete_with_zero_runs: 'incomplete before completion',
+  incomplete_without_runs: 'incomplete before completion',
+  reconciled_from_orphaned_run: 'reconciled from orphaned run',
+  partial_with_failures: 'partial with failures',
+  partial_outcomes: 'partial outcomes',
+  mixed_outcomes: 'mixed outcomes',
+  mixed_failures: 'mixed failures',
+  infrastructure_error: 'infrastructure error',
+  paused_or_interrupted_before_completion: 'interrupted before completion',
+  completed_with_shortfall: 'completed with sampling shortfall',
+  resolved_stale_running: 'reconciled from stale running state',
+  incomplete_by_partial_outcomes: 'incomplete outcome',
+  cancelled_before_attempt: 'cancelled before attempts',
+};
+
+function completionReasonLabel(reason?: string | null): string {
+  if (!reason) return 'completion state recorded';
+  if (Object.prototype.hasOwnProperty.call(COMPLETION_REASONS, reason)) {
+    return COMPLETION_REASONS[reason as keyof typeof COMPLETION_REASONS];
+  }
+  return reason.replace(/_/g, ' ');
+}
+
 function experimentOutcomeLabel(experiment: Experiment): string {
   const bayesianSummary = experiment.bayesian_summary;
   const configuredRuns = experiment.run_count == null
     ? 'Run count pending'
     : `${experiment.run_count} run${experiment.run_count === 1 ? '' : 's'} configured`;
+  const isBayesianStrategy = resolveSearchStrategy(experiment) === 'bayesian';
+  const plannedTrials = bayesianSummary?.planned_trials;
+  const attemptedTrials = bayesianSummary?.attempted_trials;
+  const discardedTrials = bayesianSummary?.discarded_trials;
+  const hasBayesianIncomplete =
+    isBayesianStrategy && plannedTrials != null && attemptedTrials != null && attemptedTrials < plannedTrials;
   if (experiment.status === 'running') return `${configuredRuns} · sweep in progress`;
   if (experiment.status === 'paused') return `${configuredRuns} · waiting to resume`;
-  if (experiment.status === 'complete') return `${configuredRuns} · sweep complete`;
+  if (experiment.status === 'complete') {
+    if (hasBayesianIncomplete) {
+      const notStarted = Math.max(0, plannedTrials - attemptedTrials - (discardedTrials ?? 0));
+      const notStartedSuffix = notStarted > 0 ? ` · ${notStarted} not started` : '';
+      const reasonSuffix = experiment.completion_reason
+        ? ` · ${completionReasonLabel(experiment.completion_reason)}`
+        : '';
+      return `${configuredRuns} · Bayesian: ${attemptedTrials} attempted · ${discardedTrials ?? 0} discarded`
+        + notStartedSuffix
+        + reasonSuffix;
+    }
+    if (experiment.completion_reason && experiment.completion_reason !== 'all_planned_trials_completed') {
+      return `${configuredRuns} · sweep complete · ${completionReasonLabel(experiment.completion_reason)}`;
+    }
+    return `${configuredRuns} · sweep complete`;
+  }
   if (experiment.status === 'partial' && resolveSearchStrategy(experiment) === 'bayesian') {
     const discarded = bayesianSummary?.discarded_trials ?? 0;
     const attempted = bayesianSummary?.attempted_trials;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -85,7 +85,21 @@ export interface Experiment {
   completed_at?: string | null;
   status: ExperimentStatus;
   run_count?: number;
+  grid_equivalent_count?: number;
   failed_count?: number;
+  bayesian_summary?: {
+    best_query_avg_score?: number;
+    best_chunk_size?: number;
+    best_overlap?: number;
+    best_embedding_model?: string;
+    best_retrieval_method?: string;
+    best_retriever_type?: string;
+    grid_equivalent_count?: number;
+    planned_trials?: number;
+  };
+  execution?: {
+    search_strategy?: 'grid' | 'bayesian';
+  };
   error?: string;
   git_commit?: string;
   git_branch?: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -96,6 +96,9 @@ export interface Experiment {
     best_retriever_type?: string;
     grid_equivalent_count?: number;
     planned_trials?: number;
+    attempted_trials?: number;
+    discarded_trials?: number;
+    termination_reason?: string;
   };
   execution?: {
     search_strategy?: 'grid' | 'bayesian';

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -99,6 +99,7 @@ export interface Experiment {
     planned_trials?: number;
     attempted_trials?: number;
     discarded_trials?: number;
+    not_started?: number;
     termination_reason?: string;
   };
   execution?: {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -87,6 +87,7 @@ export interface Experiment {
   run_count?: number;
   grid_equivalent_count?: number;
   failed_count?: number;
+  completion_reason?: string;
   bayesian_summary?: {
     best_query_avg_score?: number;
     best_chunk_size?: number;

--- a/frontend/src/utils/experimentStatus.ts
+++ b/frontend/src/utils/experimentStatus.ts
@@ -28,16 +28,34 @@ export function summarizeExperimentRuns(
   return { expected, started, complete, failed, interrupted, neverStarted, inProgress };
 }
 
-export function isTerminalExperimentStatus(status: ExperimentStatus | undefined): boolean {
+function isCompletedByTimestamp(
+  completedAt: string | null | undefined,
+): boolean {
+  return Boolean(completedAt);
+}
+
+export function isTerminalExperimentStatus(
+  status: ExperimentStatus | undefined,
+  completedAt?: string | null,
+): boolean {
+  if (isCompletedByTimestamp(completedAt)) return true;
   if (!status) return false;
   return TERMINAL_STATUSES.includes(status);
 }
 
-export function isRunningExperimentStatus(status: ExperimentStatus | undefined): boolean {
+export function isRunningExperimentStatus(
+  status: ExperimentStatus | undefined,
+  completedAt?: string | null,
+): boolean {
+  if (isCompletedByTimestamp(completedAt)) return false;
   return status === 'running';
 }
 
-export function isPausedExperimentStatus(status: ExperimentStatus | undefined): boolean {
+export function isPausedExperimentStatus(
+  status: ExperimentStatus | undefined,
+  completedAt?: string | null,
+): boolean {
+  if (isCompletedByTimestamp(completedAt)) return false;
   return status === 'paused';
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "numpy>=1.26,<3",
     "sie-sdk>=0.6.0",
     "aim>=3.0",
+    "optuna>=3.0",
 ]
 
 [project.optional-dependencies]

--- a/server/api/experiments.py
+++ b/server/api/experiments.py
@@ -38,8 +38,27 @@ router = APIRouter()
 
 def _planned_run_count(config: ExperimentConfig) -> int:
     if config.execution.search_strategy == "bayesian":
-        return config.execution.bayesian.n_trials
+        return _resolve_bayesian_n_trials(config)
     return len(expand_sweep(config))
+
+
+def _resolve_bayesian_n_trials(config: ExperimentConfig) -> int:
+    grid_equivalent = len(config.chunking.params.chunk_sizes) * len(config.chunking.params.overlaps)
+    configured = config.execution.bayesian.n_trials
+    if configured is None:
+        logger.info(
+            "bayesian n_trials not set; defaulting to grid-equivalent %s",
+            grid_equivalent,
+        )
+        return grid_equivalent
+    if configured > grid_equivalent:
+        logger.warning(
+            "requested bayesian n_trials=%s exceeds grid-equivalent=%s, capping at grid-equivalent",
+            configured,
+            grid_equivalent,
+        )
+        return grid_equivalent
+    return configured
 
 
 async def _run_heavy_read[R](fn: Callable[[], R]) -> R:
@@ -326,7 +345,7 @@ async def resume_experiment(experiment_id: str):
     if config.execution.search_strategy == "bayesian":
         raise HTTPException(
             status_code=409,
-            detail="Resume is not supported for bayesian search strategy",
+            detail=("Bayesian experiments cannot be resumed (study state is in-memory only)"),
         )
     await asyncio.to_thread(mongo_mark_experiment_running, experiment_id)
     schedule_sweep(resume_sweep, experiment_id, config)

--- a/server/api/experiments.py
+++ b/server/api/experiments.py
@@ -170,18 +170,32 @@ def _normalize_stale_running_status(experiment: dict) -> dict:
     expected = int(experiment.get("run_count") or 0)
     complete = sum(1 for run in runs if run.get("phase") == Phase.COMPLETE.value)
     failed = sum(1 for run in runs if run.get("phase") == Phase.FAILED.value)
+    interrupted = sum(1 for run in runs if run.get("phase") == Phase.INTERRUPTED.value)
 
     if complete == expected and failed == 0:
         resolved_status = ExperimentStatus.COMPLETE
+        completion_reason = "all_planned_trials_completed"
+    elif failed == 0 and interrupted == 0 and complete < expected and complete > 0:
+        resolved_status = ExperimentStatus.COMPLETE
+        completion_reason = "completed_with_sampling_shortfall"
     elif failed == expected or (failed > 0 and complete == 0 and failed == len(runs)):
         resolved_status = ExperimentStatus.FAILED
+        completion_reason = "all_trials_failed"
+    elif failed == 0 and interrupted > 0 and complete > 0:
+        resolved_status = ExperimentStatus.PARTIAL
+        completion_reason = "interrupted_before_completion"
+    elif failed > 0:
+        resolved_status = ExperimentStatus.PARTIAL
+        completion_reason = "partial_failures"
     else:
         resolved_status = ExperimentStatus.PARTIAL
+        completion_reason = "incomplete_before_completion"
 
     now = datetime.now(UTC)
     resolved = {
         "status": resolved_status,
         "failed_count": failed,
+        "completion_reason": completion_reason,
         "completed_at": now,
     }
     get_collection(EXPERIMENTS_COLLECTION).update_one({"_id": experiment_id}, {"$set": resolved})

--- a/server/api/experiments.py
+++ b/server/api/experiments.py
@@ -25,8 +25,9 @@ from server.core.orchestrator import resume_sweep, run_sweep
 from server.core.search_index_guard import validate_experiment_search_indexes
 from server.core.search_index_plan import SearchIndexMismatchError
 from server.core.sie_guard import SIEUnavailableError, validate_sie_readiness
+from server.db.atlas import EXPERIMENTS_COLLECTION, RUN_STATUS_COLLECTION, get_collection
 from server.models.config import ExperimentConfig, expand_sweep
-from server.models.enums import ExperimentStatus, RetrieverType
+from server.models.enums import ExperimentStatus, Phase, RetrieverType
 from server.utils.log_throttle import info_throttled
 from server.utils.logger import get_logger
 from server.utils.metadata import collect_experiment_metadata
@@ -34,6 +35,13 @@ from server.utils.metadata import collect_experiment_metadata
 logger = get_logger(__name__)
 
 router = APIRouter()
+_TERMINAL_PHASES = frozenset(
+    {
+        Phase.COMPLETE.value,
+        Phase.FAILED.value,
+        Phase.INTERRUPTED.value,
+    }
+)
 
 
 def _planned_run_count(config: ExperimentConfig) -> int:
@@ -59,6 +67,49 @@ def _resolve_bayesian_n_trials(config: ExperimentConfig) -> int:
         )
         return grid_equivalent
     return configured
+
+
+def _normalize_stale_running_status(experiment: dict) -> dict:
+    """If status is still RUNNING but no active sweep exists, reconcile from run status."""
+    if experiment.get("status") != ExperimentStatus.RUNNING:
+        return experiment
+
+    experiment_id = experiment.get("experiment_id") or experiment.get("_id")
+    if not experiment_id or is_sweep_in_flight(experiment_id):
+        return experiment
+
+    runs = list(
+        get_collection(RUN_STATUS_COLLECTION).find(
+            {"experiment_id": experiment_id},
+            {"_id": 0},
+        )
+    )
+    if not runs:
+        return experiment
+
+    if any(run.get("phase") not in _TERMINAL_PHASES for run in runs):
+        return experiment
+
+    expected = int(experiment.get("run_count") or 0)
+    complete = sum(1 for run in runs if run.get("phase") == Phase.COMPLETE.value)
+    failed = sum(1 for run in runs if run.get("phase") == Phase.FAILED.value)
+
+    if complete == expected and failed == 0:
+        resolved_status = ExperimentStatus.COMPLETE
+    elif failed == expected or (failed > 0 and complete == 0 and failed == len(runs)):
+        resolved_status = ExperimentStatus.FAILED
+    else:
+        resolved_status = ExperimentStatus.PARTIAL
+
+    now = datetime.now(UTC)
+    resolved = {
+        "status": resolved_status,
+        "failed_count": failed,
+        "completed_at": now,
+    }
+    get_collection(EXPERIMENTS_COLLECTION).update_one({"_id": experiment_id}, {"$set": resolved})
+    experiment.update(resolved)
+    return experiment
 
 
 async def _run_heavy_read[R](fn: Callable[[], R]) -> R:
@@ -153,6 +204,8 @@ async def list_experiments():
     """List all experiments."""
     logger.debug("list OK — GET /experiments")
     experiments = await asyncio.to_thread(mongo_list_all_experiment_docs)
+    for experiment in experiments:
+        await asyncio.to_thread(_normalize_stale_running_status, experiment)
     logger.debug("list OK — %s experiment(s)", len(experiments))
     return {"experiments": experiments}
 
@@ -181,6 +234,7 @@ async def get_experiment(experiment_id: str):
         raise HTTPException(status_code=404, detail="Experiment not found")
 
     runs = experiment["runs"]
+    _normalize_stale_running_status(experiment)
     logger.debug(
         "detail OK — %s status=%s, %s run row(s)",
         experiment_id,

--- a/server/api/experiments.py
+++ b/server/api/experiments.py
@@ -36,6 +36,12 @@ logger = get_logger(__name__)
 router = APIRouter()
 
 
+def _planned_run_count(config: ExperimentConfig) -> int:
+    if config.execution.search_strategy == "bayesian":
+        return config.execution.bayesian.n_trials
+    return len(expand_sweep(config))
+
+
 async def _run_heavy_read[R](fn: Callable[[], R]) -> R:
     """Run expensive read-only Mongo aggregations off the default API thread pool."""
     loop = asyncio.get_running_loop()
@@ -56,7 +62,7 @@ async def create_experiment(config: ExperimentConfig):
     experiment_id = str(uuid.uuid4())
     timestamp_suffix = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
     stamped_name = f"{config.experiment_name}_{timestamp_suffix}"
-    runs = expand_sweep(config)
+    runs = _planned_run_count(config)
 
     metadata = collect_experiment_metadata()
     now = datetime.now(UTC)
@@ -81,7 +87,8 @@ async def create_experiment(config: ExperimentConfig):
         "started_at": None,  # Set when first run actually begins
         "completed_at": None,
         "status": ExperimentStatus.RUNNING,
-        "run_count": len(runs),
+        "run_count": runs,
+        "grid_equivalent_count": len(expand_sweep(config)),
         **metadata,
         "data_paths": config.data_paths,
         "queries_file": config.queries_file,
@@ -104,15 +111,21 @@ async def create_experiment(config: ExperimentConfig):
     }
     await asyncio.to_thread(mongo_insert_experiment_doc, experiment_doc)
 
-    logger.info("experiment created — %s (%s), %s run(s)", stamped_name, experiment_id, len(runs))
+    logger.info(
+        "experiment created — %s (%s), %s planned run(s), %s run(s) per trial strategy",
+        stamped_name,
+        experiment_id,
+        runs,
+        len(expand_sweep(config)),
+    )
     schedule_sweep(run_sweep, experiment_id, config)
 
     return {
         "status": "submitted",
         "experiment_id": experiment_id,
         "experiment_name": stamped_name,
-        "run_count": len(runs),
-        "message": f"Experiment queued — {len(runs)} run(s) will execute",
+        "run_count": runs,
+        "message": f"Experiment queued — {runs} run(s) will execute",
     }
 
 
@@ -310,15 +323,20 @@ async def resume_experiment(experiment_id: str):
         raise HTTPException(status_code=400, detail="Experiment config is missing")
 
     config = ExperimentConfig.model_validate(config_payload)
+    if config.execution.search_strategy == "bayesian":
+        raise HTTPException(
+            status_code=409,
+            detail="Resume is not supported for bayesian search strategy",
+        )
     await asyncio.to_thread(mongo_mark_experiment_running, experiment_id)
     schedule_sweep(resume_sweep, experiment_id, config)
 
-    runs = expand_sweep(config)
-    logger.info("resume OK — %s scheduled, %s run(s) in sweep", experiment_id, len(runs))
+    runs = _planned_run_count(config)
+    logger.info("resume OK — %s scheduled, %s run(s) in sweep", experiment_id, runs)
     return {
         "status": "resume_requested",
         "experiment_id": experiment_id,
-        "run_count": len(runs),
+        "run_count": runs,
         "message": "Experiment resumed — remaining parameter combinations will execute",
     }
 

--- a/server/api/experiments.py
+++ b/server/api/experiments.py
@@ -2,6 +2,7 @@ import asyncio
 import uuid
 from collections.abc import Callable
 from datetime import UTC, datetime
+from typing import SupportsInt, cast
 
 from fastapi import APIRouter, HTTPException
 
@@ -69,21 +70,97 @@ def _resolve_bayesian_n_trials(config: ExperimentConfig) -> int:
     return configured
 
 
+def _to_non_negative_int(value: object) -> int | None:
+    try:
+        as_int = int(cast(SupportsInt, value))
+    except (TypeError, ValueError):
+        return None
+    return max(0, int(as_int))
+
+
+def _is_bayesian_experiment(experiment: dict) -> bool:
+    config = experiment.get("config")
+    if not isinstance(config, dict):
+        return False
+    execution = config.get("execution")
+    if not isinstance(execution, dict):
+        return False
+    return execution.get("search_strategy") == "bayesian"
+
+
+def _ensure_bayesian_summary(
+    experiment: dict,
+    runs: list[dict] | None = None,
+) -> None:
+    if not _is_bayesian_experiment(experiment):
+        return
+
+    planned_trials = _to_non_negative_int(experiment.get("run_count"))
+    if planned_trials is None:
+        return
+
+    existing_summary = experiment.get("bayesian_summary")
+    if not isinstance(existing_summary, dict):
+        existing_summary = {}
+
+    planned_trials = int(planned_trials)
+    attempted_trials = existing_summary.get("attempted_trials")
+    if isinstance(attempted_trials, int):
+        attempted_trials = _to_non_negative_int(attempted_trials) or 0
+    elif isinstance(runs, list):
+        attempted_trials = len(runs)
+    else:
+        attempted_trials = 0
+
+    if "discarded_trials" in existing_summary:
+        discarded_trials = _to_non_negative_int(existing_summary["discarded_trials"]) or 0
+    else:
+        discarded_trials = existing_summary.get("discarded_trials", 0)
+        discarded_trials = _to_non_negative_int(discarded_trials) or 0
+
+    not_started = max(
+        0,
+        planned_trials - attempted_trials - discarded_trials,
+    )
+
+    existing_summary.update(
+        {
+            "planned_trials": planned_trials,
+            "attempted_trials": attempted_trials,
+            "discarded_trials": discarded_trials,
+            "grid_equivalent_count": _to_non_negative_int(
+                existing_summary.get("grid_equivalent_count")
+            )
+            or _to_non_negative_int(experiment.get("grid_equivalent_count"))
+            or planned_trials,
+            "not_started": not_started,
+        }
+    )
+    experiment["bayesian_summary"] = existing_summary
+
+
 def _normalize_stale_running_status(experiment: dict) -> dict:
     """If status is still RUNNING but no active sweep exists, reconcile from run status."""
+    runs = experiment.get("runs")
+    if not isinstance(runs, list):
+        runs = []
     if experiment.get("status") != ExperimentStatus.RUNNING:
+        _ensure_bayesian_summary(experiment, runs=runs)
         return experiment
 
     experiment_id = experiment.get("experiment_id") or experiment.get("_id")
     if not experiment_id or is_sweep_in_flight(experiment_id):
         return experiment
 
-    runs = list(
-        get_collection(RUN_STATUS_COLLECTION).find(
-            {"experiment_id": experiment_id},
-            {"_id": 0},
+    runs = list(runs)
+    if not runs:
+        runs = list(
+            get_collection(RUN_STATUS_COLLECTION).find(
+                {"experiment_id": experiment_id},
+                {"_id": 0},
+            )
         )
-    )
+    _ensure_bayesian_summary(experiment, runs=runs)
     if not runs:
         return experiment
 
@@ -109,6 +186,7 @@ def _normalize_stale_running_status(experiment: dict) -> dict:
     }
     get_collection(EXPERIMENTS_COLLECTION).update_one({"_id": experiment_id}, {"$set": resolved})
     experiment.update(resolved)
+    _ensure_bayesian_summary(experiment, runs=runs)
     return experiment
 
 

--- a/server/core/orchestrator.py
+++ b/server/core/orchestrator.py
@@ -2,6 +2,7 @@ import time
 import uuid
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from datetime import UTC, datetime
+from typing import Any, cast
 
 from server.core.aim_logger import AimLogger
 from server.core.chunkers import chunk_text
@@ -217,6 +218,8 @@ def _execute_sweep(
     """Declared sync; scheduled on the dedicated sweep executor (see executors.py)."""
     register_sweep_control(experiment_id)
     try:
+        if config.execution.search_strategy == "bayesian":
+            return _run_bayesian_inner(experiment_id, config, skip_signatures)
         return _run_sweep_inner(experiment_id, config, skip_signatures)
     except SearchIndexMismatchError as exc:
         return _fail_experiment_preflight(experiment_id, config, str(exc))
@@ -226,20 +229,243 @@ def _execute_sweep(
         unregister_sweep_control(experiment_id)
 
 
+def _run_bayesian_inner(
+    experiment_id: str,
+    config: ExperimentConfig,
+    skip_signatures: set[ParamSignature],
+) -> dict:
+    del skip_signatures
+
+    try:
+        check_control(experiment_id)
+    except ExperimentCancelledError:
+        logger.info("sweep skipped — experiment %s cancel signalled before start", experiment_id)
+        return {
+            "experiment_id": experiment_id,
+            "run_ids": [],
+            "status": ExperimentStatus.CANCELLED,
+        }
+
+    validate_experiment_search_indexes(config)
+    validate_sie_readiness(config)
+
+    expanded = list(expand_sweep(config))
+    template = expanded[0]
+    planned_runs = config.execution.bayesian.n_trials
+    if config.execution.parallelism > 1:
+        logger.warning(
+            "Bayesian mode ignores parallelism > 1 in trial objective loop; "
+            "using sequential execution"
+        )
+
+    run_ids: list[str] = []
+    cancelled = False
+    paused = False
+    stop_after_failure = False
+    infrastructure_error: str | None = None
+
+    import optuna
+
+    study = optuna.create_study(direction="maximize", sampler=optuna.samplers.TPESampler())
+    best_trial: dict | None = None
+
+    def _try_run_trial(trial: "optuna.trial.Trial") -> float:
+        nonlocal cancelled
+        nonlocal paused
+        nonlocal stop_after_failure
+        nonlocal infrastructure_error
+
+        if stop_after_failure:
+            return 0.0
+
+        try:
+            check_control(experiment_id)
+        except ExperimentCancelledError:
+            cancelled = True
+            stop_after_failure = True
+            return 0.0
+        except ExperimentPausedError:
+            paused = True
+            stop_after_failure = True
+            return 0.0
+
+        params = _bayesian_trial_to_run_params(
+            config,
+            template,
+            trial,
+        )
+
+        if not run_ids:
+            get_collection(EXPERIMENTS_COLLECTION).update_one(
+                {"_id": experiment_id},
+                {"$set": {"started_at": datetime.now(UTC)}},
+            )
+
+        run_id = str(uuid.uuid4())
+        run_ids.append(run_id)
+        try:
+            _run_single(
+                experiment_id,
+                run_id,
+                params,
+                config.execution.parallelism,
+            )
+            return _compute_trial_score(experiment_id, run_id)
+        except ExperimentCancelledError:
+            cancelled = True
+            stop_after_failure = True
+            raise
+        except ExperimentPausedError:
+            paused = True
+            stop_after_failure = True
+            raise
+        except SIEUnavailableError as exc:
+            infrastructure_error = str(exc)
+            stop_after_failure = True
+            raise
+        except Exception:
+            if config.execution.on_error == "stop":
+                stop_after_failure = True
+            raise
+
+    try:
+        for _ in range(planned_runs):
+            trial = study.ask()
+            try:
+                score = _try_run_trial(trial)
+            except Exception:
+                if cancelled or paused:
+                    logger.info(
+                        "bayesian stopped before completing planned trials — %s",
+                        experiment_id,
+                    )
+                    break
+                if stop_after_failure:
+                    score = 0.0
+                    study.tell(trial, score)
+                    break
+                score = 0.0
+            study.tell(trial, score)
+            if len(study.trials) >= planned_runs:
+                break
+            if stop_after_failure:
+                break
+
+            try:
+                check_control(experiment_id)
+            except ExperimentCancelledError:
+                cancelled = True
+                break
+            except ExperimentPausedError:
+                paused = True
+                break
+
+    finally:
+        if run_ids:
+            best_trial = _run_best_trial_payload(experiment_id)
+
+        final_status, failed_count = _finalise_bayesian_experiment(
+            experiment_id,
+            config,
+            planned_runs,
+            cancelled,
+            paused,
+            run_ids,
+            best_trial,
+            infrastructure_error,
+        )
+
+    return {
+        "experiment_id": experiment_id,
+        "run_ids": run_ids,
+        "status": final_status,
+    }
+
+
+def _finalise_bayesian_experiment(
+    experiment_id: str,
+    config: ExperimentConfig,
+    planned_trials: int,
+    cancelled: bool,
+    paused: bool,
+    run_ids: list[str],
+    best_trial: dict | None,
+    infrastructure_error: str | None,
+) -> tuple[ExperimentStatus, int]:
+    if cancelled:
+        final_status = ExperimentStatus.CANCELLED
+        failed_count = _count_failed_runs(experiment_id)
+    elif paused:
+        final_status = ExperimentStatus.PAUSED
+        failed_count = _count_failed_runs(experiment_id)
+    elif run_ids:
+        final_status, failed_count = _compute_final_status(experiment_id, planned_trials)
+        if failed_count == planned_trials and final_status != ExperimentStatus.FAILED:
+            final_status = ExperimentStatus.FAILED
+    else:
+        final_status = ExperimentStatus.CANCELLED
+        failed_count = 0
+
+    experiment_update: dict = {
+        "status": final_status,
+        "run_count": planned_trials,
+        "failed_count": failed_count,
+        "completed_at": datetime.now(UTC),
+        "grid_equivalent_count": _grid_equivalent_count(config),
+    }
+
+    if best_trial is not None:
+        experiment_update["bayesian_summary"] = {
+            "best_query_avg_score": best_trial.get("query_avg_score"),
+            "best_chunk_size": best_trial.get("chunk_size"),
+            "best_overlap": best_trial.get("overlap"),
+            "best_embedding_model": best_trial.get("embedding_model"),
+            "best_retrieval_method": best_trial.get("retrieval_method"),
+            "best_retriever_type": best_trial.get("retrieval_method"),
+            "grid_equivalent_count": _grid_equivalent_count(config),
+            "planned_trials": planned_trials,
+        }
+
+    if infrastructure_error:
+        experiment_update["error_message"] = infrastructure_error
+        if final_status not in {ExperimentStatus.CANCELLED, ExperimentStatus.PAUSED}:
+            final_status = ExperimentStatus.FAILED
+            experiment_update["status"] = final_status
+
+    get_collection(EXPERIMENTS_COLLECTION).update_one(
+        {"_id": experiment_id},
+        {"$set": experiment_update},
+    )
+    _log_failed_run_summary(experiment_id, failed_count)
+    if best_trial is not None:
+        _log_bayesian_summary(
+            experiment_id,
+            best_trial,
+            planned_trials,
+            _grid_equivalent_count(config),
+        )
+
+    return final_status, failed_count
+
+
 def _fail_experiment_preflight(
     experiment_id: str,
     config: ExperimentConfig,
     error_message: str,
 ) -> dict:
     """Mark experiment failed before any run starts due to search-index preflight."""
-    runs = expand_sweep(config)
+    runs = (
+        config.execution.bayesian.n_trials
+        if config.execution.search_strategy == "bayesian"
+        else len(expand_sweep(config))
+    )
     completed_at = datetime.now(UTC)
     get_collection(EXPERIMENTS_COLLECTION).update_one(
         {"_id": experiment_id},
         {
             "$set": {
                 "status": ExperimentStatus.FAILED,
-                "run_count": len(runs),
+                "run_count": runs,
                 "failed_count": 0,
                 "completed_at": completed_at,
                 "error_message": error_message,
@@ -257,6 +483,117 @@ def _fail_experiment_preflight(
         "status": ExperimentStatus.FAILED,
         "error_message": error_message,
     }
+
+
+def _grid_equivalent_count(config: ExperimentConfig) -> int:
+    return len(config.chunking.params.chunk_sizes) * len(config.chunking.params.overlaps)
+
+
+def _bayesian_trial_to_run_params(
+    config: ExperimentConfig,
+    template_run: RunParams,
+    trial,
+) -> RunParams:
+    chunk_sizes = config.chunking.params.chunk_sizes
+    overlaps = config.chunking.params.overlaps
+    chunk_size = trial.suggest_categorical("chunk_size", chunk_sizes)
+    overlap = trial.suggest_categorical("overlap", overlaps)
+    return RunParams(
+        **template_run.model_dump(exclude={"chunk_size", "overlap"}),
+        chunk_size=int(chunk_size),
+        overlap=int(overlap),
+    )
+
+
+def _compute_trial_score(experiment_id: str, run_id: str) -> float:
+    results = list(
+        get_collection(RESULTS_COLLECTION).find(
+            {"run_id": run_id, "experiment_id": experiment_id},
+            {"query_text": 1, "results": 1},
+        )
+    )
+    if not results:
+        return 0.0
+
+    query_scores: dict[str, list[float]] = {}
+    for result in results:
+        query_text = str(result.get("query_text", ""))
+        for scored in result.get("results", []):
+            score = scored.get("rerank_score")
+            if score is None:
+                score = scored.get("dense_score", 0.0)
+            query_scores.setdefault(query_text, []).append(float(score))
+
+    if not query_scores:
+        return 0.0
+
+    query_avgs = [sum(values) / len(values) for values in query_scores.values() if values]
+    if not query_avgs:
+        return 0.0
+    return sum(query_avgs) / len(query_avgs)
+
+
+def _run_best_trial_payload(experiment_id: str) -> dict | None:
+    from server.core.results_analyzer import analyze_results
+
+    query_results = list(
+        get_collection(RESULTS_COLLECTION).find(
+            {"experiment_id": experiment_id},
+            {"run_id": 1, "query_text": 1, "results": 1},
+        )
+    )
+    if not query_results:
+        return None
+
+    run_statuses = list(
+        get_collection(RUN_STATUS_COLLECTION).find(
+            {"experiment_id": experiment_id},
+            {
+                "database_provider": 1,
+                "embedding_provider": 1,
+                "embedding_model": 1,
+                "chunking_method": 1,
+                "chunk_size": 1,
+                "overlap": 1,
+                "padding": 1,
+                "retrieval_method": 1,
+                "retrieval_provider": 1,
+                "retrieval_model": 1,
+                "retrievers": 1,
+            },
+        )
+    )
+
+    best_result = analyze_results(query_results, run_statuses).get("best_params")
+    if not isinstance(best_result, dict):
+        return None
+    best: dict[Any, Any] = cast(dict[Any, Any], best_result)
+    if not best:
+        return None
+    return best
+
+
+def _log_bayesian_summary(
+    experiment_id: str,
+    best_trial: dict,
+    planned_trials: int,
+    grid_equivalent_count: int,
+) -> None:
+    best_score = best_trial.get("query_avg_score")
+    best_signature = (
+        best_trial.get("chunk_size"),
+        best_trial.get("overlap"),
+        best_trial.get("embedding_model"),
+        best_trial.get("retrieval_method"),
+    )
+    logger.info(
+        "bayesian complete — experiment=%s best=%s score=%s grid_equivalent_efficiency=%s/%s",
+        experiment_id,
+        best_signature,
+        best_score,
+        planned_trials,
+        grid_equivalent_count,
+    )
 
 
 def _run_sweep_inner(

--- a/server/core/orchestrator.py
+++ b/server/core/orchestrator.py
@@ -426,16 +426,30 @@ def _finalise_bayesian_experiment(
     if cancelled:
         final_status = ExperimentStatus.CANCELLED
         failed_count = _count_failed_runs(experiment_id)
+        completion_reason = "cancelled_by_user"
     elif paused:
         final_status = ExperimentStatus.PAUSED
         failed_count = _count_failed_runs(experiment_id)
+        completion_reason = "paused_by_user"
     elif run_ids:
         final_status, failed_count = _compute_final_status(experiment_id, planned_trials)
+        if final_status == ExperimentStatus.PARTIAL and failed_count == 0:
+            final_status = ExperimentStatus.COMPLETE
+        if final_status == ExperimentStatus.COMPLETE and attempted_trials < planned_trials:
+            completion_reason = "completed_with_sampling_shortfall"
+        elif final_status == ExperimentStatus.COMPLETE:
+            completion_reason = "all_planned_trials_completed"
+        elif final_status == ExperimentStatus.FAILED and failed_count == planned_trials:
+            completion_reason = "all_trials_failed"
+        elif final_status == ExperimentStatus.FAILED:
+            completion_reason = "partial_failures"
         if failed_count == planned_trials and final_status != ExperimentStatus.FAILED:
             final_status = ExperimentStatus.FAILED
+            completion_reason = "all_trials_failed"
     else:
         final_status = ExperimentStatus.CANCELLED
         failed_count = 0
+        completion_reason = "cancelled_before_attempt"
 
     experiment_update: dict = {
         "status": final_status,
@@ -443,6 +457,7 @@ def _finalise_bayesian_experiment(
         "failed_count": failed_count,
         "completed_at": datetime.now(UTC),
         "grid_equivalent_count": _grid_equivalent_count(config),
+        "completion_reason": completion_reason,
     }
 
     bayesian_summary: dict[str, object] = {
@@ -473,6 +488,7 @@ def _finalise_bayesian_experiment(
         if final_status not in {ExperimentStatus.CANCELLED, ExperimentStatus.PAUSED}:
             final_status = ExperimentStatus.FAILED
             experiment_update["status"] = final_status
+            experiment_update["completion_reason"] = "infrastructure_error"
 
     get_collection(EXPERIMENTS_COLLECTION).update_one(
         {"_id": experiment_id},
@@ -509,6 +525,7 @@ def _fail_experiment_preflight(
                 "status": ExperimentStatus.FAILED,
                 "run_count": runs,
                 "failed_count": 0,
+                "completion_reason": "infrastructure_error",
                 "completed_at": completed_at,
                 "error_message": error_message,
             }
@@ -809,17 +826,41 @@ def _run_sweep_inner(
     if cancelled:
         final_status = ExperimentStatus.CANCELLED
         failed_count = _count_failed_runs(experiment_id)
+        completion_reason = "cancelled_by_user"
     elif paused:
         final_status = ExperimentStatus.PAUSED
         failed_count = _count_failed_runs(experiment_id)
+        completion_reason = "paused_by_user"
     else:
         final_status, failed_count = _compute_final_status(experiment_id, len(all_runs))
+        run_summaries = list(
+            get_collection(RUN_STATUS_COLLECTION).find(
+                {"experiment_id": experiment_id},
+                {"_id": 0, "phase": 1},
+            )
+        )
+        complete = sum(1 for run in run_summaries if run.get("phase") == Phase.COMPLETE.value)
+        interrupted = sum(1 for run in run_summaries if run.get("phase") == Phase.INTERRUPTED.value)
+
+        if final_status == ExperimentStatus.COMPLETE:
+            completion_reason = "all_planned_trials_completed"
+        elif final_status == ExperimentStatus.FAILED and failed_count == 0 and complete == 0:
+            completion_reason = "interrupted_before_completion"
+        elif final_status == ExperimentStatus.PARTIAL and failed_count == 0 and interrupted > 0:
+            completion_reason = "paused_or_interrupted_before_completion"
+        elif final_status == ExperimentStatus.PARTIAL and failed_count > 0:
+            completion_reason = "mixed_outcomes"
+        elif final_status == ExperimentStatus.FAILED and failed_count == len(all_runs):
+            completion_reason = "all_trials_failed"
+        else:
+            completion_reason = "partial_outcomes"
 
     completed_at = datetime.now(UTC)
     experiment_update: dict = {
         "status": final_status,
         "run_count": len(all_runs),
         "failed_count": failed_count,
+        "completion_reason": completion_reason,
         "completed_at": completed_at,
     }
     if infrastructure_error:
@@ -827,6 +868,7 @@ def _run_sweep_inner(
         if final_status not in {ExperimentStatus.CANCELLED, ExperimentStatus.PAUSED}:
             final_status = ExperimentStatus.FAILED
             experiment_update["status"] = final_status
+            experiment_update["completion_reason"] = "infrastructure_error"
 
     get_collection(EXPERIMENTS_COLLECTION).update_one(
         {"_id": experiment_id},

--- a/server/core/orchestrator.py
+++ b/server/core/orchestrator.py
@@ -465,6 +465,10 @@ def _finalise_bayesian_experiment(
         "planned_trials": planned_trials,
         "attempted_trials": attempted_trials,
         "discarded_trials": discarded_trials,
+        "not_started": max(
+            0,
+            planned_trials - attempted_trials - discarded_trials,
+        ),
     }
     if discarded_trials > 0 and final_status == ExperimentStatus.PARTIAL:
         bayesian_summary["termination_reason"] = "sampler_candidate_exhaustion"

--- a/server/core/orchestrator.py
+++ b/server/core/orchestrator.py
@@ -388,6 +388,8 @@ def _run_bayesian_inner(
     finally:
         if run_ids:
             best_trial = _run_best_trial_payload(experiment_id)
+        attempted_trials = len(run_ids)
+        discarded_trials = max(0, planned_runs - attempted_trials)
 
         final_status, failed_count = _finalise_bayesian_experiment(
             experiment_id,
@@ -396,6 +398,8 @@ def _run_bayesian_inner(
             cancelled,
             paused,
             run_ids,
+            attempted_trials,
+            discarded_trials,
             best_trial,
             infrastructure_error,
         )
@@ -414,6 +418,8 @@ def _finalise_bayesian_experiment(
     cancelled: bool,
     paused: bool,
     run_ids: list[str],
+    attempted_trials: int,
+    discarded_trials: int,
     best_trial: dict | None,
     infrastructure_error: str | None,
 ) -> tuple[ExperimentStatus, int]:
@@ -439,17 +445,28 @@ def _finalise_bayesian_experiment(
         "grid_equivalent_count": _grid_equivalent_count(config),
     }
 
+    bayesian_summary: dict[str, object] = {
+        "grid_equivalent_count": _grid_equivalent_count(config),
+        "planned_trials": planned_trials,
+        "attempted_trials": attempted_trials,
+        "discarded_trials": discarded_trials,
+    }
+    if discarded_trials > 0 and final_status == ExperimentStatus.PARTIAL:
+        bayesian_summary["termination_reason"] = "sampler_candidate_exhaustion"
+
     if best_trial is not None:
-        experiment_update["bayesian_summary"] = {
-            "best_query_avg_score": best_trial.get("query_avg_score"),
-            "best_chunk_size": best_trial.get("chunk_size"),
-            "best_overlap": best_trial.get("overlap"),
-            "best_embedding_model": best_trial.get("embedding_model"),
-            "best_retrieval_method": best_trial.get("retrieval_method"),
-            "best_retriever_type": best_trial.get("retrieval_method"),
-            "grid_equivalent_count": _grid_equivalent_count(config),
-            "planned_trials": planned_trials,
-        }
+        bayesian_summary.update(
+            {
+                "best_query_avg_score": best_trial.get("query_avg_score"),
+                "best_chunk_size": best_trial.get("chunk_size"),
+                "best_overlap": best_trial.get("overlap"),
+                "best_embedding_model": best_trial.get("embedding_model"),
+                "best_retrieval_method": best_trial.get("retrieval_method"),
+                "best_retriever_type": best_trial.get("retrieval_method"),
+            }
+        )
+
+    experiment_update["bayesian_summary"] = bayesian_summary
 
     if infrastructure_error:
         experiment_update["error_message"] = infrastructure_error

--- a/server/core/orchestrator.py
+++ b/server/core/orchestrator.py
@@ -251,7 +251,9 @@ def _run_bayesian_inner(
 
     expanded = list(expand_sweep(config))
     template = expanded[0]
-    planned_runs = config.execution.bayesian.n_trials
+    planned_runs = _resolve_bayesian_n_trials(config)
+    max_optuna_calls = planned_runs * 3
+    visited: set[tuple[int, int]] = set()
     if config.execution.parallelism > 1:
         logger.warning(
             "Bayesian mode ignores parallelism > 1 in trial objective loop; "
@@ -269,31 +271,28 @@ def _run_bayesian_inner(
     study = optuna.create_study(direction="maximize", sampler=optuna.samplers.TPESampler())
     best_trial: dict | None = None
 
-    def _try_run_trial(trial: "optuna.trial.Trial") -> float:
+    def _try_run_trial(
+        trial: "optuna.trial.Trial",
+        params: RunParams,
+    ) -> float | None:
         nonlocal cancelled
         nonlocal paused
         nonlocal stop_after_failure
         nonlocal infrastructure_error
 
         if stop_after_failure:
-            return 0.0
+            return None
 
         try:
             check_control(experiment_id)
         except ExperimentCancelledError:
             cancelled = True
             stop_after_failure = True
-            return 0.0
+            return None
         except ExperimentPausedError:
             paused = True
             stop_after_failure = True
-            return 0.0
-
-        params = _bayesian_trial_to_run_params(
-            config,
-            template,
-            trial,
-        )
+            return None
 
         if not run_ids:
             get_collection(EXPERIMENTS_COLLECTION).update_one(
@@ -314,25 +313,45 @@ def _run_bayesian_inner(
         except ExperimentCancelledError:
             cancelled = True
             stop_after_failure = True
-            raise
+            return None
         except ExperimentPausedError:
             paused = True
             stop_after_failure = True
-            raise
+            return None
         except SIEUnavailableError as exc:
             infrastructure_error = str(exc)
             stop_after_failure = True
-            raise
+            return None
         except Exception:
             if config.execution.on_error == "stop":
                 stop_after_failure = True
-            raise
+            return None
 
     try:
-        for _ in range(planned_runs):
+        for _ in range(max_optuna_calls):
+            if len(visited) >= _grid_equivalent_count(config):
+                break
+            if len(run_ids) >= planned_runs:
+                break
+
             trial = study.ask()
             try:
-                score = _try_run_trial(trial)
+                params = _bayesian_trial_to_run_params(
+                    config,
+                    template,
+                    trial,
+                )
+                candidate = (params.chunk_size, params.overlap)
+                if candidate in visited:
+                    study.tell(
+                        trial,
+                        values=None,
+                        state=optuna.trial.TrialState.PRUNED,
+                    )
+                    continue
+
+                visited.add(candidate)
+                score = _try_run_trial(trial, params)
             except Exception:
                 if cancelled or paused:
                     logger.info(
@@ -341,13 +360,19 @@ def _run_bayesian_inner(
                     )
                     break
                 if stop_after_failure:
-                    score = 0.0
-                    study.tell(trial, score)
+                    study.tell(trial, float("nan"), state=optuna.trial.TrialState.FAIL)
                     break
-                score = 0.0
-            study.tell(trial, score)
-            if len(study.trials) >= planned_runs:
-                break
+
+                study.tell(trial, float("nan"), state=optuna.trial.TrialState.FAIL)
+                if config.execution.on_error == "stop":
+                    stop_after_failure = True
+                continue
+
+            if score is None:
+                study.tell(trial, float("nan"), state=optuna.trial.TrialState.FAIL)
+            else:
+                study.tell(trial, score)
+
             if stop_after_failure:
                 break
 
@@ -455,7 +480,7 @@ def _fail_experiment_preflight(
 ) -> dict:
     """Mark experiment failed before any run starts due to search-index preflight."""
     runs = (
-        config.execution.bayesian.n_trials
+        _resolve_bayesian_n_trials(config)
         if config.execution.search_strategy == "bayesian"
         else len(expand_sweep(config))
     )
@@ -571,6 +596,25 @@ def _run_best_trial_payload(experiment_id: str) -> dict | None:
     if not best:
         return None
     return best
+
+
+def _resolve_bayesian_n_trials(config: ExperimentConfig) -> int:
+    grid_equivalent = _grid_equivalent_count(config)
+    configured = config.execution.bayesian.n_trials
+    if configured is None:
+        logger.info(
+            "bayesian n_trials not set; defaulting to grid-equivalent %s",
+            grid_equivalent,
+        )
+        return grid_equivalent
+    if configured > grid_equivalent:
+        logger.warning(
+            "requested bayesian n_trials=%s exceeds grid-equivalent=%s, capping",
+            configured,
+            grid_equivalent,
+        )
+        return grid_equivalent
+    return configured
 
 
 def _log_bayesian_summary(

--- a/server/core/startup_reconciliation.py
+++ b/server/core/startup_reconciliation.py
@@ -74,7 +74,34 @@ def _reconcile_one(
     runs = list(run_coll.find({"experiment_id": experiment_id}))
     status, failed_count = _derive_experiment_status(experiment, runs)
     complete_count = sum(1 for run in runs if run.get("phase") == Phase.COMPLETE.value)
+    interrupted_count = sum(1 for run in runs if run.get("phase") == Phase.INTERRUPTED.value)
     expected = int(experiment.get("run_count") or 0)
+    attempted = len(runs)
+
+    if status == ExperimentStatus.COMPLETE:
+        if complete_count < expected:
+            completion_reason = "completed_with_sampling_shortfall"
+        else:
+            completion_reason = "all_planned_trials_completed"
+    elif status == ExperimentStatus.FAILED:
+        completion_reason = "all_trials_failed" if failed_count == expected else "mixed_failures"
+    elif status == ExperimentStatus.PARTIAL:
+        if failed_count == 0 and interrupted_count > 0:
+            completion_reason = "interrupted_before_completion"
+        elif failed_count > 0:
+            completion_reason = "mixed_failures"
+        else:
+            completion_reason = "incomplete_before_completion"
+    elif status == ExperimentStatus.CANCELLED:
+        completion_reason = "cancelled_by_user"
+    elif status == ExperimentStatus.PAUSED:
+        completion_reason = "paused_by_user"
+    else:
+        completion_reason = (
+            "reconciled_from_orphaned_run"
+            if attempted > 0 or expected > 0
+            else "incomplete_before_completion"
+        )
 
     exp_coll.update_one(
         {"_id": experiment_id},
@@ -82,6 +109,7 @@ def _reconcile_one(
             "$set": {
                 "status": status,
                 "failed_count": failed_count,
+                "completion_reason": completion_reason,
                 "completed_at": now,
             }
         },

--- a/server/models/config.py
+++ b/server/models/config.py
@@ -167,8 +167,13 @@ class RetrievalConfig(BaseModel):
 
 
 class ExecutionConfig(BaseModel):
+    class BayesianConfig(BaseModel):
+        n_trials: int = Field(default=12, ge=1)
+
     parallelism: int = Field(default=1, ge=1, le=16)
     on_error: Literal["continue", "stop"] = Field(default="continue")
+    search_strategy: Literal["grid", "bayesian"] = Field(default="grid")
+    bayesian: BayesianConfig = Field(default_factory=BayesianConfig)
 
 
 class ExperimentConfig(BaseModel):
@@ -180,6 +185,36 @@ class ExperimentConfig(BaseModel):
     chunking: ChunkingConfig
     retrieval: RetrievalConfig
     execution: ExecutionConfig = Field(default_factory=ExecutionConfig)
+
+    @model_validator(mode="after")
+    def validate_bayesian_only_tunes_chunking(self) -> "ExperimentConfig":
+        if self.execution.search_strategy != "bayesian":
+            return self
+
+        if len(self.embedding.models) != 1:
+            raise ValueError(
+                "Bayesian search requires one embedding model; "
+                "set search_strategy=grid for multi-value embedding.models"
+            )
+        if len(self.chunking.methods) != 1:
+            raise ValueError(
+                "Bayesian search requires one chunking method; "
+                "set search_strategy=grid for multi-value chunking.methods"
+            )
+        if len(self.chunking.params.paddings) != 1:
+            raise ValueError(
+                "Bayesian search requires one chunking.params.paddings value; "
+                "tune only chunk_size and overlap"
+            )
+
+        retrievers = self.retrieval.retrievers
+        if len(retrievers) != 1:
+            raise ValueError(
+                "Bayesian search requires one retrieval.retrievers value; "
+                "set search_strategy=grid for multi-value retrievers"
+            )
+
+        return self
 
 
 class RunParams(BaseModel):

--- a/server/models/config.py
+++ b/server/models/config.py
@@ -168,7 +168,7 @@ class RetrievalConfig(BaseModel):
 
 class ExecutionConfig(BaseModel):
     class BayesianConfig(BaseModel):
-        n_trials: int = Field(default=12, ge=1)
+        n_trials: int | None = Field(default=None, ge=1)
 
     parallelism: int = Field(default=1, ge=1, le=16)
     on_error: Literal["continue", "stop"] = Field(default="continue")

--- a/stop-services.sh
+++ b/stop-services.sh
@@ -45,7 +45,7 @@ case "$choice" in
     ;;
   3)
     if [[ "${NONINTERACTIVE:-}" != "1" ]]; then
-      echo "Type DELETE HF CACHE to remove HuggingFace model cache volume (Atlas data unaffected):"
+      echo "Type DELETE HF CACHE to remove HuggingFace model cache volume (cloud Atlas data unaffected)."
       read -r confirm
       if [[ "$confirm" == "DELETE HF CACHE" ]]; then
         "${DOCKER_COMPOSE[@]}" "${COMPOSE_FILES[@]}" "${COMPOSE_DOWN_PROFILES[@]}" down -v

--- a/tests/test_config_examples.py
+++ b/tests/test_config_examples.py
@@ -63,6 +63,8 @@ class TestExampleMongoDbSieConfig:
         "configs/example-mongodb-voyage.yaml",
         "configs/example-mongodb-unified-retrievers.yaml",
         "configs/example-mongodb-sie.yaml",
+        "configs/example-mongodb-unified-retrievers-bayesian.yaml",
+        "configs/example-mongodb-local-bayesian.yaml",
     ],
 )
 def test_given_example_yaml_when_load_and_validate_then_no_errors(config_rel_path: str) -> None:

--- a/tests/test_expand_sweep.py
+++ b/tests/test_expand_sweep.py
@@ -1,5 +1,8 @@
 """Tests for sweep expansion — one retriever per run."""
 
+import pytest
+from pydantic import ValidationError
+
 from server.models.config import (
     ChunkingConfig,
     ChunkParams,
@@ -100,3 +103,77 @@ def test_old_config_format_migrates_to_separate_sweep_entries() -> None:
         RetrieverType.RERANKER,
     ]
     assert all(len(run.retrievers) == 1 for run in runs)
+
+
+def test_bayesian_requires_fixed_embedding_model() -> None:
+    with pytest.raises(ValidationError):
+        ExperimentConfig(
+            experiment_name="invalid-bayes-embedding",
+            data_paths=["./input_data/pdfs/sample.pdf"],
+            queries_file="./configs/questions.example.json",
+            embedding=EmbeddingConfig(
+                provider="local", models=["all-MiniLM-L6-v2", "all-MiniLM-L6-v2"]
+            ),
+            chunking=ChunkingConfig(
+                methods=[ChunkingMethod.RECURSIVE],
+                params=ChunkParams(chunk_sizes=[128, 256], overlaps=[50]),
+            ),
+            retrieval=RetrievalConfig(retrievers=[RetrieverConfig(type=RetrieverType.DENSE)]),
+            execution=ExecutionConfig(search_strategy="bayesian"),
+        )
+
+
+@pytest.mark.parametrize(
+    "invalid_field",
+    ["chunking_methods", "retrievers"],
+)
+def test_bayesian_requires_single_fixed_nonchunk_axes(invalid_field: str) -> None:
+    kwargs = {
+        "experiment_name": "invalid-bayes-" + invalid_field,
+        "data_paths": ["./input_data/pdfs/sample.pdf"],
+        "queries_file": "./configs/questions.example.json",
+        "embedding": EmbeddingConfig(provider="local", models=["all-MiniLM-L6-v2"]),
+        "chunking": ChunkingConfig(
+            methods=[ChunkingMethod.RECURSIVE],
+            params=ChunkParams(chunk_sizes=[128, 256], overlaps=[50]),
+        ),
+        "retrieval": RetrievalConfig(retrievers=[RetrieverConfig(type=RetrieverType.DENSE)]),
+        "execution": ExecutionConfig(search_strategy="bayesian"),
+    }
+
+    if invalid_field == "chunking_methods":
+        kwargs["chunking"] = ChunkingConfig(
+            methods=[ChunkingMethod.RECURSIVE, ChunkingMethod.FIXED],
+            params=ChunkParams(chunk_sizes=[128, 256], overlaps=[50]),
+        )
+    if invalid_field == "retrievers":
+        kwargs["retrieval"] = RetrievalConfig(
+            retrievers=[
+                RetrieverConfig(type=RetrieverType.DENSE),
+                RetrieverConfig(type=RetrieverType.SPARSE),
+            ]
+        )
+
+    with pytest.raises(ValidationError):
+        ExperimentConfig(**kwargs)
+
+
+def test_bayesian_accepts_fixed_axes_with_chunking_ranges() -> None:
+    config = ExperimentConfig(
+        experiment_name="valid-bayes",
+        data_paths=["./input_data/pdfs/sample.pdf"],
+        queries_file="./configs/questions.example.json",
+        embedding=EmbeddingConfig(provider="local", models=["all-MiniLM-L6-v2"]),
+        chunking=ChunkingConfig(
+            methods=[ChunkingMethod.RECURSIVE],
+            params=ChunkParams(chunk_sizes=[128, 256], overlaps=[0, 50]),
+        ),
+        retrieval=RetrievalConfig(retrievers=[RetrieverConfig(type=RetrieverType.DENSE)]),
+        execution=ExecutionConfig(
+            search_strategy="bayesian",
+            bayesian=ExecutionConfig.BayesianConfig(n_trials=12),
+        ),
+    )
+
+    assert len(config.chunking.params.chunk_sizes) == 2
+    assert len(config.chunking.params.overlaps) == 2

--- a/tests/test_experiments_api_bayesian.py
+++ b/tests/test_experiments_api_bayesian.py
@@ -91,3 +91,86 @@ def test_resume_bayesian_experiment_returns_409() -> None:
 
     assert response.status_code == 409
     assert response.json()["detail"]
+
+
+def test_detail_bayesian_experiment_populates_progress_summary_when_missing() -> None:
+    """
+    Scenario: GET /experiments/{id} exposes Bayesian summary even before finalization.
+
+    Given a running Bayesian experiment without persisted summary metadata
+    And run rows exist for partial progress
+    When detail is requested
+    Then response includes a normalized `bayesian_summary` with attempts and not-started.
+    """
+    experiment_doc = {
+        "_id": "exp-bayesian-summary",
+        "experiment_id": "exp-bayesian-summary",
+        "status": "running",
+        "run_count": 100,
+        "grid_equivalent_count": 100,
+        "config": {
+            "execution": {"search_strategy": "bayesian"},
+        },
+        "runs": [
+            {"phase": "complete", "run_id": "run-1"},
+            {"phase": "complete", "run_id": "run-2"},
+            {"phase": "querying", "run_id": "run-3"},
+        ],
+        "completed_at": None,
+    }
+
+    with (
+        patch(
+            "server.api.experiments.mongo_find_experiment_with_runs",
+            return_value=experiment_doc,
+        ),
+    ):
+        client = _make_experiments_client()
+        response = client.get("/experiments/exp-bayesian-summary")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "running"
+    bayesian_summary = body["bayesian_summary"]
+    assert bayesian_summary["planned_trials"] == 100
+    assert bayesian_summary["attempted_trials"] == 3
+    assert bayesian_summary["discarded_trials"] == 0
+    assert bayesian_summary["not_started"] == 97
+
+
+def test_detail_partial_bayesian_experiment_populates_summary_from_runs() -> None:
+    """
+    Scenario: GET /experiments/{id} includes Bayesian summary for partial runs.
+
+    Given a partially completed Bayesian experiment
+    And the document has no stored bayesian_summary
+    When the detail endpoint is queried
+    Then summary is derived from the observed run rows.
+    """
+    experiment_doc = {
+        "_id": "exp-bayesian-partial",
+        "experiment_id": "exp-bayesian-partial",
+        "status": "partial",
+        "run_count": 100,
+        "config": {"execution": {"search_strategy": "bayesian"}},
+        "runs": [{"phase": "complete", "run_id": "run-1"}] * 79,
+        "completed_at": "2026-07-21T15:34:04.225000+00:00",
+    }
+
+    with (
+        patch(
+            "server.api.experiments.mongo_find_experiment_with_runs",
+            return_value=experiment_doc,
+        ),
+    ):
+        client = _make_experiments_client()
+        response = client.get("/experiments/exp-bayesian-partial")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "partial"
+    bayesian_summary = body["bayesian_summary"]
+    assert bayesian_summary["planned_trials"] == 100
+    assert bayesian_summary["attempted_trials"] == 79
+    assert bayesian_summary["discarded_trials"] == 0
+    assert bayesian_summary["not_started"] == 21

--- a/tests/test_experiments_api_bayesian.py
+++ b/tests/test_experiments_api_bayesian.py
@@ -1,0 +1,93 @@
+"""API tests for Bayesian execution strategy on /experiments."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _make_experiments_client() -> TestClient:
+    app = FastAPI()
+    from server.api.experiments import router
+
+    app.include_router(router, prefix="/experiments")
+    return TestClient(app)
+
+
+_BAYESIAN_CONFIG = {
+    "experiment_name": "example-bayesian-api",
+    "data_paths": ["./input_data/pdfs/The_Federal_Pell_Grant_Program.pdf"],
+    "queries_file": "./configs/questions.example.json",
+    "database_provider": "mongodb",
+    "embedding": {
+        "provider": "local",
+        "models": ["all-MiniLM-L6-v2"],
+    },
+    "chunking": {
+        "methods": ["recursive"],
+        "params": {
+            "chunk_sizes": [256, 512, 768],
+            "overlaps": [0, 50],
+            "paddings": [0],
+        },
+    },
+    "retrieval": {
+        "top_k_initial": 20,
+        "top_k_final": 5,
+        "retrievers": [{"type": "dense"}],
+    },
+    "execution": {
+        "search_strategy": "bayesian",
+        "bayesian": {"n_trials": 12},
+    },
+}
+
+
+def test_create_experiment_reports_bayesian_n_trials_as_run_count() -> None:
+    """
+    Scenario: POST /experiments for bayesian config reports planned Bayesian count.
+
+    Given a valid bayesian configuration with chunk_size × overlap search space
+    When create request is submitted
+    Then run_count reflects execution.bayesian.n_trials.
+    """
+    with (
+        patch("server.api.experiments.validate_experiment_search_indexes"),
+        patch("server.api.experiments.validate_sie_readiness"),
+        patch("server.api.experiments.mongo_insert_experiment_doc"),
+        patch("server.api.experiments.schedule_sweep"),
+    ):
+        client = _make_experiments_client()
+        response = client.post("/experiments", json=_BAYESIAN_CONFIG)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["run_count"] == 12
+
+
+def test_resume_bayesian_experiment_returns_409() -> None:
+    """
+    Scenario: POST /experiments/{id}/resume rejects bayesian experiments.
+
+    Given a persisted bayesian experiment marked PAUSED
+    When resume endpoint is called
+    Then HTTP 409 is returned with a non-empty message.
+    """
+    experiment_doc = {
+        "_id": "exp-bayesian",
+        "status": "paused",
+        "config": _BAYESIAN_CONFIG,
+    }
+
+    with (
+        patch("server.api.experiments.mongo_find_experiment_by_id", return_value=experiment_doc),
+        patch("server.api.experiments.mongo_mark_experiment_running"),
+        patch("server.api.experiments.schedule_sweep"),
+    ):
+        client = _make_experiments_client()
+        response = client.post("/experiments/exp-bayesian/resume")
+
+    assert response.status_code == 409
+    assert response.json()["detail"]

--- a/tests/test_experiments_api_bayesian.py
+++ b/tests/test_experiments_api_bayesian.py
@@ -51,7 +51,7 @@ def test_create_experiment_reports_bayesian_n_trials_as_run_count() -> None:
 
     Given a valid bayesian configuration with chunk_size × overlap search space
     When create request is submitted
-    Then run_count reflects execution.bayesian.n_trials.
+    Then run_count reflects the capped bayesian run count.
     """
     with (
         patch("server.api.experiments.validate_experiment_search_indexes"),
@@ -64,7 +64,7 @@ def test_create_experiment_reports_bayesian_n_trials_as_run_count() -> None:
 
     assert response.status_code == 200
     body = response.json()
-    assert body["run_count"] == 12
+    assert body["run_count"] == 6
 
 
 def test_resume_bayesian_experiment_returns_409() -> None:

--- a/tests/test_slice16_parallel_sweep.py
+++ b/tests/test_slice16_parallel_sweep.py
@@ -21,6 +21,7 @@ from server.core.experiment_control import ExperimentCancelledError, ExperimentP
 from server.core.orchestrator import (
     _completed_param_signatures,
     _compute_final_status,
+    _finalise_bayesian_experiment,
     _log_failed_run_summary,
     _primary_retriever,
     _run_doc_signature,
@@ -55,6 +56,12 @@ from server.models.enums import (
     RetrieverType,
 )
 from server.models.results import Chunk, SearchResult
+
+
+def _mock_collection() -> MagicMock:
+    return MagicMock(
+        update_one=MagicMock(),
+    )
 
 
 def _run_param() -> RunParams:
@@ -450,6 +457,106 @@ class TestSlice16ParallelSweep:
 
         # Then
         mock_run_sweep_inner.assert_called_once_with("exp-resume", config, completed_signatures)
+
+    @patch("server.core.orchestrator._run_bayesian_inner")
+    @patch("server.core.orchestrator._run_sweep_inner")
+    def test_run_sweep_dispatches_bayesian_and_grid_paths(
+        self,
+        mock_run_sweep_inner: MagicMock,
+        mock_run_bayesian_inner: MagicMock,
+    ) -> None:
+        """
+        Scenario: run_sweep dispatches by execution.search_strategy.
+
+        Given one grid and one bayesian configuration
+        When run_sweep executes
+        Then each execution path calls its own inner function.
+        """
+        config_bayesian = _slice_config(parallelism=1)
+        config_bayesian.execution.search_strategy = "bayesian"
+        config_grid = _slice_config(parallelism=1)
+
+        mock_run_bayesian_inner.return_value = {
+            "experiment_id": "exp-bayes",
+            "run_ids": ["r-1"],
+            "status": ExperimentStatus.COMPLETE,
+        }
+        mock_run_sweep_inner.return_value = {
+            "experiment_id": "exp-grid",
+            "run_ids": ["r-2"],
+            "status": ExperimentStatus.COMPLETE,
+        }
+
+        run_sweep("exp-bayes", config_bayesian)
+        run_sweep("exp-grid", config_grid)
+
+        mock_run_bayesian_inner.assert_called_once_with("exp-bayes", config_bayesian, set())
+        mock_run_sweep_inner.assert_called_once_with("exp-grid", config_grid, set())
+
+
+@patch("server.core.orchestrator._count_failed_runs", return_value=0)
+@patch("server.core.orchestrator._log_bayesian_summary")
+@patch("server.core.orchestrator.get_collection")
+def test_finalise_bayesian_experiment_persists_summary(
+    mock_get_collection: MagicMock,
+    mock_log_summary: MagicMock,
+    mock_count_failed_runs: MagicMock,
+) -> None:
+    """
+    Scenario: _finalise_bayesian_experiment stores Bayesian metadata in experiment docs
+
+    Given bayesian completion with successful and failed runs
+    When finalization runs
+    Then run_count, grid_equivalent_count, and bayesian_summary are persisted.
+    """
+    config = _slice_config(parallelism=1)
+    config.execution.search_strategy = "bayesian"
+    config.execution.bayesian.n_trials = 4
+    config.chunking.params.chunk_sizes = [128, 256, 512]
+    config.chunking.params.overlaps = [0, 50]
+
+    collection = _mock_collection()
+    mock_get_collection.return_value = collection
+
+    best_trial = {
+        "query_avg_score": 0.82,
+        "chunk_size": 256,
+        "overlap": 50,
+        "embedding_model": "all-MiniLM-L6-v2",
+        "retrieval_method": "dense",
+        "retrieval_type": "dense",
+    }
+
+    final_status, failed_count = _finalise_bayesian_experiment(
+        experiment_id="exp-bayesian",
+        config=config,
+        planned_trials=4,
+        cancelled=False,
+        paused=False,
+        run_ids=["run-1", "run-2", "run-3", "run-4"],
+        best_trial=best_trial,
+        infrastructure_error=None,
+    )
+
+    assert final_status == ExperimentStatus.PARTIAL
+    assert failed_count == 0
+    # _count_failed_runs is only used for cancelled/paused paths, not this branch.
+    mock_count_failed_runs.assert_not_called()
+
+    # Validate experiment document persisted fields
+    update_call = collection.update_one.call_args.args[1]["$set"]
+    assert update_call["status"] == ExperimentStatus.PARTIAL
+    assert update_call["run_count"] == 4
+    assert update_call["failed_count"] == 0
+    assert update_call["grid_equivalent_count"] == 6
+
+    bayesian_summary = update_call["bayesian_summary"]
+    assert bayesian_summary["best_query_avg_score"] == 0.82
+    assert bayesian_summary["best_chunk_size"] == 256
+    assert bayesian_summary["best_overlap"] == 50
+    assert bayesian_summary["grid_equivalent_count"] == 6
+    assert bayesian_summary["planned_trials"] == 4
+    mock_log_summary.assert_called_once()
 
 
 @patch("server.core.orchestrator.get_collection")

--- a/tests/test_slice16_parallel_sweep.py
+++ b/tests/test_slice16_parallel_sweep.py
@@ -505,7 +505,7 @@ def test_finalise_bayesian_experiment_persists_summary(
     """
     Scenario: _finalise_bayesian_experiment stores Bayesian metadata in experiment docs
 
-    Given bayesian completion with successful and failed runs
+    Given bayesian completion with successful runs only
     When finalization runs
     Then run_count, grid_equivalent_count, and bayesian_summary are persisted.
     """
@@ -540,14 +540,14 @@ def test_finalise_bayesian_experiment_persists_summary(
         infrastructure_error=None,
     )
 
-    assert final_status == ExperimentStatus.PARTIAL
+    assert final_status == ExperimentStatus.COMPLETE
     assert failed_count == 0
     # _count_failed_runs is only used for cancelled/paused paths, not this branch.
     mock_count_failed_runs.assert_not_called()
 
     # Validate experiment document persisted fields
     update_call = collection.update_one.call_args.args[1]["$set"]
-    assert update_call["status"] == ExperimentStatus.PARTIAL
+    assert update_call["status"] == ExperimentStatus.COMPLETE
     assert update_call["run_count"] == 4
     assert update_call["failed_count"] == 0
     assert update_call["grid_equivalent_count"] == 6
@@ -561,6 +561,57 @@ def test_finalise_bayesian_experiment_persists_summary(
     assert bayesian_summary["attempted_trials"] == 4
     assert bayesian_summary["discarded_trials"] == 0
     mock_log_summary.assert_called_once()
+
+
+@patch("server.core.orchestrator._log_bayesian_summary")
+@patch("server.core.orchestrator.get_collection")
+def test_finalise_bayesian_experiment_promotes_no_failure_partial_to_complete(
+    mock_get_collection: MagicMock,
+    mock_log_summary: MagicMock,
+) -> None:
+    """
+    Scenario: _finalise_bayesian_experiment treats a partial Bayesian run with no
+    failures as complete
+
+    Given attempted Bayesian trials are fewer than planned and none failed
+    When finalization runs
+    Then status is complete and the summary preserves the discarded/not-started split
+    in summary metadata.
+    """
+    config = _slice_config(parallelism=1)
+    config.execution.search_strategy = "bayesian"
+    config.execution.bayesian.n_trials = 5
+    config.chunking.params.chunk_sizes = [128, 256, 512]
+    config.chunking.params.overlaps = [0, 50]
+
+    collection = _mock_collection()
+    mock_get_collection.return_value = collection
+
+    final_status, failed_count = _finalise_bayesian_experiment(
+        experiment_id="exp-bayesian-promoted",
+        config=config,
+        planned_trials=5,
+        cancelled=False,
+        paused=False,
+        run_ids=["run-1", "run-2", "run-3"],
+        attempted_trials=3,
+        discarded_trials=2,
+        best_trial=None,
+        infrastructure_error=None,
+    )
+
+    assert final_status == ExperimentStatus.COMPLETE
+    assert failed_count == 0
+
+    update_call = collection.update_one.call_args.args[1]["$set"]
+    assert update_call["status"] == ExperimentStatus.COMPLETE
+    assert update_call["run_count"] == 5
+    assert update_call["failed_count"] == 0
+    assert update_call["grid_equivalent_count"] == 6
+    assert update_call["bayesian_summary"]["attempted_trials"] == 3
+    assert update_call["bayesian_summary"]["discarded_trials"] == 2
+    assert update_call["bayesian_summary"]["planned_trials"] == 5
+    mock_log_summary.assert_not_called()
 
 
 @patch("server.core.orchestrator.get_collection")

--- a/tests/test_slice16_parallel_sweep.py
+++ b/tests/test_slice16_parallel_sweep.py
@@ -534,6 +534,8 @@ def test_finalise_bayesian_experiment_persists_summary(
         cancelled=False,
         paused=False,
         run_ids=["run-1", "run-2", "run-3", "run-4"],
+        attempted_trials=4,
+        discarded_trials=0,
         best_trial=best_trial,
         infrastructure_error=None,
     )
@@ -556,6 +558,8 @@ def test_finalise_bayesian_experiment_persists_summary(
     assert bayesian_summary["best_overlap"] == 50
     assert bayesian_summary["grid_equivalent_count"] == 6
     assert bayesian_summary["planned_trials"] == 4
+    assert bayesian_summary["attempted_trials"] == 4
+    assert bayesian_summary["discarded_trials"] == 0
     mock_log_summary.assert_called_once()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -384,6 +384,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorlog"
+version = "6.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/bf/cb30a51af3aa8ce63735f77e23dcd4fc0720fe0339bcb04f77345659c277/colorlog-6.11.0.tar.gz", hash = "sha256:9d90fb53fa906c8970c18fbe46506bae1fb5f86b513b8f867db37e4ace9be7ae", size = 17734, upload-time = "2026-07-17T12:16:46.59Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/a1/6b71004ab0fea510230be9ce05a4059029ac847c009fcc80b1b73d6fa5ab/colorlog-6.11.0-py3-none-any.whl", hash = "sha256:f1e27d75aa2cb138f3f640c0e305b65b680ccbef6ecc034eba7e03494ffcd2a1", size = 12016, upload-time = "2026-07-17T12:16:45.3Z" },
+]
+
+[[package]]
 name = "coverage"
 version = "7.13.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1316,6 +1325,24 @@ wheels = [
 ]
 
 [[package]]
+name = "optuna"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "alembic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
+    { name = "colorlog", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
+    { name = "numpy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
+    { name = "packaging", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
+    { name = "sqlalchemy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
+    { name = "tqdm", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/aa/05f5e3f662cc96a4c478fc3446b8ed6359825a2b504ecb614a9ac84e4a4d/optuna-4.9.0.tar.gz", hash = "sha256:b322e5cbdf1655fb84c37646c4a7a1f391de1b47806bbe222e015825d0a82b87", size = 485834, upload-time = "2026-06-01T06:23:30.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/f3/e5fcd5d9b15771ed6dc10e3a7eeddc672e418f4f4c4653d216cc1d857e2d/optuna-4.9.0-py3-none-any.whl", hash = "sha256:f52f3be6148654850c92a5860d398fd88ec6b2c84ab68d9c3d07dcff02e7afee", size = 425553, upload-time = "2026-06-01T06:23:28.804Z" },
+]
+
+[[package]]
 name = "orjson"
 version = "3.11.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1762,6 +1789,7 @@ dependencies = [
     { name = "langchain-text-splitters", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
     { name = "nltk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
     { name = "numpy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
+    { name = "optuna", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
     { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
     { name = "pydantic-settings", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
     { name = "pymongo", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
@@ -1804,6 +1832,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
     { name = "nltk", specifier = ">=3.8.1" },
     { name = "numpy", specifier = ">=1.26,<3" },
+    { name = "optuna", specifier = ">=3.0" },
     { name = "pip", marker = "extra == 'dev'", specifier = ">=26.1.2" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.6.0" },


### PR DESCRIPTION
## Slice 41A - Bayesian Search: Simple Functional

### Summary
- Add opt-in Bayesian search for chunk-size and overlap tuning while preserving grid behavior.
- Surface Bayesian attempted, discarded, not-started, and completion-reason details consistently in API-backed list and detail views.
- Normalize Bayesian summaries for running and partial experiments so dashboard and frontend typing receive a stable response shape.
- Retain image revision provenance for server and frontend builds.
- Improve `QUICKSTART.md` prerequisites by user goal: visitor/judge setup is visible first, while experimenter, researcher, developer, and operator paths remain collapsed until needed.
- Document `.env.example` to `.env` setup and make path-specific environment values explicit: Atlas Cloud requires `MONGODB_URI`, Atlas Local needs no edited values, and Voyage/SIE settings are opt-in.
- Clarify service startup commands and provide distinct sequential, parallel, and Bayesian sweep examples.
- Collapse alternate startup paths under `Other paths` and link users from sweep output to the project screenshots.

### Verification
- Commit-time repository gates passed, including backend lint/formatting, mypy, frontend lint/typecheck/build, security checks, markdown lint, and fast unit tests.
- Pre-push gates passed, including the full test suite, coverage, and secrets checks.
- Existing PR verification evidence: backend 170 tests passed with 86.42% coverage; frontend 10 tests passed.

### Scope
- Branch: `feat/slice-41a-bayesian-search-simple-functional`
- Slice: 41A

### Working-tree note
- `.env.example` backend-default correction is committed in the branch; no uncommitted changes remain.