### PR TITLE
chore(release): cut releases via branch and PR, not direct main push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Release via branch + PR** — `./scripts/release/release.sh` creates `release/vX.Y.Z`, commits the bump there, and opens a PR to `main` (never pushes the bump directly). Tag + GitHub release after merge. Aligns with GitHub ruleset **Require a pull request before merging** on `main` (**IMPLEMENTED**; **VERIFIED** via Active Protect-main-branch ruleset).
+
 ## [0.12.0] - 2026-07-28
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,7 @@ cd frontend && npm run lint && npm run test && npm run typecheck && npm run buil
 [ ] Decisions logged in PROGRESS.md Decision Log
 [ ] Committed with a short, specific message
 [ ] Consider release: ./scripts/release/release.sh minor (slices/features) or patch (fixes/polish)
+    Creates release/vX.Y.Z + PR — never push the bump to main; tag after merge
     See PROGRESS.md § Release Cadence for guidance
 ```
 
@@ -293,17 +294,17 @@ See [docs/contributor-guide/release-process.md](docs/contributor-guide/release-p
 
 **Quick reference**:
 ```bash
-# Create a new release (minor version bump for new slices/features)
+# From clean main — creates release/vX.Y.Z, opens PR (does not push main)
 ./scripts/release/release.sh minor
 
-# Create a patch release (bug fixes, polish)
+# Patch release (bug fixes, polish)
 ./scripts/release/release.sh patch
 
-# Check current version
+# After the PR merges: tag + GitHub release on main (see release-process.md §4)
 rag-params-finder version
 ```
 
-The project follows [Semantic Versioning](https://semver.org/). Release automation via `scripts/release/release.sh` handles version updates, CHANGELOG.md updates, git tagging, and optional GitHub release creation.
+The project follows [Semantic Versioning](https://semver.org/). `scripts/release/release.sh` bumps versions on a `release/vX.Y.Z` branch and opens a PR to `main`; tag and GitHub release happen **after** merge. Never push a version bump directly to `main`.
 
 ## Further Reading
 

--- a/README.md
+++ b/README.md
@@ -174,11 +174,11 @@ This project follows [Semantic Versioning](https://semver.org/):
 - **MINOR** (0.x.0) — New features, completed slices (backward compatible)
 - **PATCH** (0.0.x) — Bug fixes, polish, enhancements
 
-**Current version:** v0.11.0 ([CHANGELOG.md](CHANGELOG.md))
+**Current version:** v0.12.0 ([CHANGELOG.md](CHANGELOG.md))
 
-**Release history:** [15 releases on GitHub](https://github.com/neomatrix369/rag-params-finder/releases) documenting development from v0.0.1 (initial skeleton) through v0.11.0 (weighted averaging)
+**Release history:** [GitHub Releases](https://github.com/neomatrix369/rag-params-finder/releases) from v0.0.1 through v0.12.0 (dual-backend Postgres, module theme separation, coverage floors, and more)
 
-**For contributors:** See [Release Process](docs/contributor-guide/release-process.md) for how to create new releases
+**For contributors:** See [Release Process](docs/contributor-guide/release-process.md) — cut `release/vX.Y.Z` + PR; never push a version bump directly to `main`.
 
 ---
 

--- a/docs/contributor-guide/development.md
+++ b/docs/contributor-guide/development.md
@@ -387,6 +387,7 @@ Record every non-obvious choice in `docs/plan/slices/PROGRESS.md` → Decision L
 [ ] Decisions logged in PROGRESS.md Decision Log
 [ ] Committed with a short, specific message
 [ ] Consider release: ./scripts/release/release.sh minor (slices/features) or patch (fixes/polish)
+    Creates release/vX.Y.Z + PR — never push the bump to main; tag after merge
     See docs/plan/slices/PROGRESS.md § Release Cadence for guidance
 ```
 

--- a/docs/contributor-guide/release-process.md
+++ b/docs/contributor-guide/release-process.md
@@ -39,6 +39,8 @@ Create a new release when:
 
 ## Creating a Release
 
+**Hard rule**: never push a version bump directly to `main`. Always cut a `release/vX.Y.Z` branch, open a PR, merge, then tag + GitHub release on `main`. The repo’s Active **Protect-main-branch** ruleset requires a pull request before merging (and blocks force-pushes / deletions).
+
 ### 1. Complete the work
 
 - Finish slice implementation
@@ -46,13 +48,16 @@ Create a new release when:
 - All quality gates pass: `./scripts/ci/quality-gates.sh` (full CI mirror; `git push` runs essential pre-commit hooks when installed)
 - Update `docs/plan/slices/PROGRESS.md` to mark slice complete
 - Commit work with clear messages
+- Start from a clean, up-to-date `main`: `git checkout main && git pull origin main`
 
 ### 2. Update CHANGELOG.md
 
-Add new section under `## [Unreleased]`:
+On the release branch (the script creates it), promote `## [Unreleased]` to a dated version section:
 
 ```markdown
-## [0.12.0] - YYYY-MM-DD
+## [Unreleased]
+
+## [0.13.0] - YYYY-MM-DD
 
 ### Added
 - Feature description (what it does, why it matters)
@@ -64,7 +69,7 @@ Add new section under `## [Unreleased]`:
 - What bugs were fixed
 ```
 
-Move appropriate items from `## [Unreleased]` to the new version.
+Also refresh **Current version** under Release Cadence in `docs/plan/slices/PROGRESS.md`.
 
 ### 3. Run the release script
 
@@ -80,20 +85,30 @@ Move appropriate items from `## [Unreleased]` to the new version.
 ```
 
 The script will:
-1. Calculate next version
-2. Update `pyproject.toml`, `frontend/package.json`
-3. Prompt you to verify CHANGELOG.md
-4. Create commit: "chore: Bump version to X.Y.Z"
-5. Create annotated git tag with CHANGELOG excerpt
-6. Ask permission to push
-7. Optionally create GitHub release (if `gh` CLI installed)
+1. Require clean `main`
+2. Create branch `release/vX.Y.Z` (never bumps on `main`)
+3. Calculate next version and update `pyproject.toml`, `frontend/package.json`
+4. Prompt you to verify CHANGELOG.md (+ PROGRESS cadence)
+5. Create commit: `chore: Bump version to X.Y.Z` on the release branch
+6. Ask permission to push the **branch** and open a PR to `main` (does **not** push `main`)
 
-### 4. Verify the release
+### 4. After the PR merges
+
+On updated `main`:
+
+```bash
+git checkout main && git pull origin main
+git tag -a "vX.Y.Z" -m "Release X.Y.Z"
+git push origin "vX.Y.Z"
+gh release create "vX.Y.Z" --title "vX.Y.Z" --notes "$(awk '/^## \[X.Y.Z\]/{p=1} p{if(/^## \[/ && !/^## \[X.Y.Z\]/){exit} print}' CHANGELOG.md)"
+```
+
+### 5. Verify the release
 
 Check:
 - GitHub releases: `https://github.com/neomatrix369/rag-params-finder/releases`
 - Git tags: `git tag -l`
-- CLI version: `rag-params-finder version` (should show new version)
+- CLI version: `.venv/bin/rag-params-finder version` (should show new version)
 
 ---
 
@@ -113,12 +128,7 @@ For urgent fixes to a released version:
    ./scripts/release/release.sh patch
    ```
 
-4. Merge back to main:
-   ```bash
-   git checkout main
-   git merge hotfix/0.11.1
-   git push origin main
-   ```
+4. Open a PR from the hotfix branch into `main` (do not push the bump straight to `main`). After merge, tag + GitHub release as in §4 above.
 
 ---
 
@@ -223,32 +233,34 @@ This auto-generates release notes from commits between tags.
 
 ## Scripts Reference
 
-### `scripts/bump_version.py`
+### `scripts/release/bump_version.py`
 
 Semantic version bumper (used by `release.sh`):
 
 ```bash
-./scripts/bump_version.py 0.11.0 minor  # → 0.12.0
-./scripts/bump_version.py 0.11.0 patch  # → 0.11.1
-./scripts/bump_version.py 0.11.0 major  # → 1.0.0
+./scripts/release/bump_version.py 0.12.0 minor  # → 0.13.0
+./scripts/release/bump_version.py 0.12.0 patch  # → 0.12.1
+./scripts/release/bump_version.py 0.12.0 major  # → 1.0.0
 ```
 
 ### `scripts/release/release.sh`
 
-Full release workflow:
+Full release workflow (branch + PR; never pushes the bump to `main`):
 
 ```bash
-./scripts/release/release.sh minor  # Bump minor version
-./scripts/release/release.sh patch  # Bump patch version
-./scripts/release/release.sh major  # Bump major version (rare)
+./scripts/release/release.sh minor  # Create release/vX.Y.Z + PR
+./scripts/release/release.sh patch  # Same for patch
+./scripts/release/release.sh major  # Same for major (rare)
 ```
 
-### `scripts/create_github_releases.sh`
+After the PR merges, tag and create the GitHub release on `main` (see §4 above).
+
+### `scripts/release/create_github_releases.sh`
 
 Batch create GitHub releases for all tags (used for retrospective releases):
 
 ```bash
-./scripts/create_github_releases.sh
+./scripts/release/create_github_releases.sh
 ```
 
 Requires `gh` CLI authenticated (`gh auth login`).

--- a/docs/plan/slices/PROGRESS.md
+++ b/docs/plan/slices/PROGRESS.md
@@ -699,6 +699,7 @@ Implement the 4 stubbed chunkers (fixed, token, sentence, semantic), add sparse/
 
 | Date | Slice | Decision | Why |
 |------|-------|----------|-----|
+| 2026-07-28 | release | Future releases: `release/vX.Y.Z` branch + PR to main; never push version bump directly to main; tag + `gh release` only after merge | Direct-to-main push on v0.12.0; prefer reviewable release PR |
 | 2026-07-28 | 40 | Theme folders COMPLETE — gate evidence PASSED; nw-review APPROVED | Leave IN PROGRESS after Should landing |
 | 2026-07-28 | 40 | Theme folders `01`–`07` + README via `git mv` (#162) — Should landed | Leave flat catalog / nest PROGRESS |
 | 2026-07-28 | 45 | Scripts theme folders (`ci`/`docker`/`release`/`security`) + flat shims — DECISIONS #159 | Leave scripts flat / delete shims immediately |
@@ -967,17 +968,18 @@ Integrate SIE (Superlinked Inference Engine) as a third embedding provider, add 
 - ✅ **After polish sprints** — Dashboard UX improvements, scoped logging, etc.
 - ❌ **Not for every commit** — Bundle related changes; release when value is deliverable
 
-**Release workflow**:
+**Release workflow** (branch + PR — **never** push a version bump directly to `main`):
 ```bash
-# After marking slice complete in this file:
+# After marking slice complete; start from clean main:
 ./scripts/release/release.sh minor    # For slice completion or new feature
 ./scripts/release/release.sh patch     # For bug fixes or polish
 
 # The script will:
-# 1. Bump version in pyproject.toml, frontend/package.json
-# 2. Prompt for CHANGELOG.md update
-# 3. Create annotated git tag with changelog excerpt
-# 4. Optionally push and create GitHub release
+# 1. Create release/vX.Y.Z from main
+# 2. Bump version in pyproject.toml, frontend/package.json
+# 3. Prompt for CHANGELOG.md update
+# 4. Commit on the release branch; push branch + open PR to main
+# After PR merge: tag vX.Y.Z on main + gh release create
 ```
 
 **See**: [docs/contributor-guide/release-process.md](../../contributor-guide/release-process.md) for complete workflow.
@@ -992,6 +994,7 @@ Tracks skill runs across slices and sessions. Appended automatically by `/verify
 
 | Date | Branch | Skill | Slice | Outcome | Notes |
 |---|---|---|---|---|---|
+| 2026-07-28 | main (WIP) | /sync-docs | release branch+PR | APPLIED | Feature-delta: CLAUDE/README/development + release-process Scripts ref + CHANGELOG Unreleased Changed; Protect-main-branch PR-required noted. release.sh + PROGRESS already updated. User-guide N/A. Evidence **IMPLEMENTED** (script/docs); ruleset PR-required **VERIFIED** (Active Protect-main-branch). |
 | 2026-07-28 | main | /sync-docs | 44 Residual §4 / #163 | APPLIED | Feature-delta for documented Nightly Stryker timeout: `development.md` honest residual note; CHANGELOG Unreleased Changed (**DECIDED**, not IMPLEMENTED); `slice-44.json` mutation + lifecycle residual; HANDOFF Where We Are. Trackers (PROGRESS/TRAIL/DECISIONS/SLICE-44) already had §4. No user-guide. CLAUDE.md Nightly claims absent — no change. |
 | 2026-07-27 | chore/project-hygiene | /sync-docs | Meterian `.meterian` exclusions | APPLIED | Feature-delta sync: `.meterian` already present; corrected stale `.trivyignore` langsmith blocker (sie-sdk websockets&lt;15; SUPERSEDES “core pre-release”); TRAIL deferred rows for ST4/transformers, langsmith, aim; `development.md` SCA suppressions triad; `pip-audit.sh` + `security-scan.sh` (`-w /workspace`) parity comments; CHANGELOG Security + TRAIL link. No user-guide. Evidence **IMPLEMENTED**; **VERIFIED** pending Meterian nightly. |
 | 2026-07-27 | chore/project-hygiene | (manual) | Meterian `.meterian` exclusions | APPLIED | Root `.meterian` + `nightly.yml` comment + `development.md` pointer + PROGRESS/CHANGELOG. Waives aim CVE-2025-51464/5321, langchain CVE-2024-7774, transformers CVE-2026-4372/5241/1839, langsmith 0.8.0 (GHSA-f4xh). **IMPLEMENTED**; **VERIFIED** pending Meterian nightly. |

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -1,13 +1,30 @@
 #!/bin/bash
 set -e
+set -o pipefail
 
-# Usage: ./scripts/release.sh [major|minor|patch]
-# Example: ./scripts/release.sh minor  # 0.11.0 → 0.12.0
+# Usage: ./scripts/release/release.sh [major|minor|patch]
+# Example: ./scripts/release/release.sh minor  # 0.12.0 → 0.13.0
+#
+# Releases go through a branch + PR — never push the version bump directly to main.
 
 RELEASE_TYPE=${1:-patch}
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$ROOT"
+
+# 0. Preflight — must start from a clean main (or ask)
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "ERROR: Start on main before releasing (current: $CURRENT_BRANCH)."
+  echo "  git checkout main && git pull origin main"
+  exit 1
+fi
+
+if [[ -n "$(git status --short)" ]]; then
+  echo "ERROR: Working tree is dirty. Commit or stash before releasing."
+  git status --short
+  exit 1
+fi
 
 # 1. Get current version from pyproject.toml
 CURRENT_VERSION=$(grep -E '^version = ' pyproject.toml | cut -d'"' -f2)
@@ -16,88 +33,125 @@ echo "Current version: $CURRENT_VERSION"
 # 2. Calculate next version
 NEW_VERSION=$("$SCRIPT_DIR/bump_version.py" "$CURRENT_VERSION" "$RELEASE_TYPE")
 echo "Next version: $NEW_VERSION"
+RELEASE_BRANCH="release/v${NEW_VERSION}"
 
-# 3. Update version in files
+if git show-ref --verify --quiet "refs/heads/${RELEASE_BRANCH}" \
+  || git show-ref --verify --quiet "refs/remotes/origin/${RELEASE_BRANCH}"; then
+  echo "ERROR: Branch ${RELEASE_BRANCH} already exists. Aborting."
+  exit 1
+fi
+
+if git tag -l "v${NEW_VERSION}" | grep -q .; then
+  echo "ERROR: Tag v${NEW_VERSION} already exists. Aborting."
+  exit 1
+fi
+
+# 3. Create release branch (never bump on main)
+echo "Creating branch ${RELEASE_BRANCH}..."
+git checkout -b "$RELEASE_BRANCH"
+
+# 4. Update version in files
 echo "Updating version in files..."
 sed -i.bak "s/version = \"$CURRENT_VERSION\"/version = \"$NEW_VERSION\"/" pyproject.toml
 sed -i.bak "s/\"version\": \"$CURRENT_VERSION\"/\"version\": \"$NEW_VERSION\"/" frontend/package.json
 
 # Check if cli/main.py has VERSION constant
 if grep -q "VERSION = " cli/main.py 2>/dev/null; then
-    sed -i.bak "s/VERSION = \"$CURRENT_VERSION\"/VERSION = \"$NEW_VERSION\"/" cli/main.py
+  sed -i.bak "s/VERSION = \"$CURRENT_VERSION\"/VERSION = \"$NEW_VERSION\"/" cli/main.py
 fi
 
 # Remove backup files
 rm -f pyproject.toml.bak frontend/package.json.bak cli/main.py.bak 2>/dev/null || true
 
-# 4. Prompt to update CHANGELOG.md
+# 5. Prompt to update CHANGELOG.md
 echo ""
 echo "================================================"
 echo "NEXT STEP: Update CHANGELOG.md"
 echo "================================================"
 echo ""
-echo "Add the following section under ## [Unreleased]:"
+echo "Promote ## [Unreleased] body to:"
 echo ""
 echo "## [$NEW_VERSION] - $(date +%Y-%m-%d)"
 echo ""
-echo "### Added"
-echo "- "
+echo "Leave a fresh empty ## [Unreleased] section above it."
 echo ""
-echo "### Changed"
-echo "- "
+echo "Also update docs/plan/slices/PROGRESS.md Release Cadence"
+echo "  Current version → v$NEW_VERSION"
 echo ""
-echo "### Fixed"
-echo "- "
-echo ""
-echo "Press ENTER when you've updated CHANGELOG.md..."
+echo "Press ENTER when you've updated CHANGELOG.md (and PROGRESS if desired)..."
 read -r
 
-# 5. Extract changelog for this version (between this version and next section)
-CHANGELOG_EXCERPT=$(awk "/^## \[$NEW_VERSION\]/,/^## \[/" CHANGELOG.md | head -n -1)
+# 6. Extract changelog for this version (macOS-safe; no head -n -1)
+CHANGELOG_EXCERPT=$(awk "/^## \\[$NEW_VERSION\\]/{p=1} p{if(/^## \\[/ && !/^## \\[$NEW_VERSION\\]/){exit} print}" CHANGELOG.md)
 
-if [ -z "$CHANGELOG_EXCERPT" ]; then
-    echo "ERROR: Could not find [$NEW_VERSION] section in CHANGELOG.md"
-    exit 1
+if [[ -z "$CHANGELOG_EXCERPT" ]]; then
+  echo "ERROR: Could not find [$NEW_VERSION] section in CHANGELOG.md"
+  echo "Restoring files and returning to main..."
+  git checkout -- pyproject.toml frontend/package.json cli/main.py CHANGELOG.md 2>/dev/null || true
+  git checkout main
+  git branch -D "$RELEASE_BRANCH"
+  exit 1
 fi
 
-# 6. Commit version bump
-git add pyproject.toml frontend/package.json CHANGELOG.md cli/main.py 2>/dev/null || true
+# 7. Commit version bump on the release branch
+git add pyproject.toml frontend/package.json CHANGELOG.md cli/main.py docs/plan/slices/PROGRESS.md 2>/dev/null || true
+git status --short
 git commit -m "chore: Bump version to $NEW_VERSION"
 
-# 7. Create annotated tag
-git tag -a "v$NEW_VERSION" -m "Release $NEW_VERSION
-
-$CHANGELOG_EXCERPT"
-
 echo ""
-echo "✅ Created tag v$NEW_VERSION"
+echo "✅ Committed on ${RELEASE_BRANCH}"
+echo "   Tag + GitHub release happen AFTER the PR merges to main."
 
-# 8. Ask before pushing
+# 8. Ask before pushing the branch (never main)
 echo ""
-echo "Ready to push commit and tag to origin?"
-echo "  git push origin main"
-echo "  git push origin v$NEW_VERSION"
-read -p "Push now? (y/N): " -n 1 -r
+echo "Ready to push release branch and open a PR?"
+echo "  git push -u origin ${RELEASE_BRANCH}"
+echo "  gh pr create → main"
+read -p "Push branch + open PR? (y/N): " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
-    git push origin main
-    git push origin "v$NEW_VERSION"
-    echo "✅ Pushed to GitHub"
+  git push -u origin "$RELEASE_BRANCH"
+  echo "✅ Pushed ${RELEASE_BRANCH}"
 
-    # 9. Create GitHub release (if gh CLI installed)
-    if command -v gh &> /dev/null; then
-        read -p "Create GitHub release? (y/N): " -n 1 -r
-        echo
-        if [[ $REPLY =~ ^[Yy]$ ]]; then
-            gh release create "v$NEW_VERSION" \
-                --title "v$NEW_VERSION" \
-                --notes "$CHANGELOG_EXCERPT"
-            echo "✅ GitHub release created"
-        fi
-    else
-        echo "💡 Install gh CLI to auto-create GitHub releases: brew install gh"
-    fi
+  if command -v gh &>/dev/null; then
+    PR_URL=$(gh pr create \
+      --base main \
+      --head "$RELEASE_BRANCH" \
+      --title "chore(release): bump to v${NEW_VERSION}" \
+      --body "$(cat <<EOF
+## Summary
+- Bump version **${CURRENT_VERSION} → ${NEW_VERSION}** (\`${RELEASE_TYPE}\`)
+- Promote CHANGELOG \`[Unreleased]\` → \`[${NEW_VERSION}]\`
+
+## After merge
+\`\`\`bash
+git checkout main && git pull origin main
+git tag -a "v${NEW_VERSION}" -m "Release ${NEW_VERSION}"
+git push origin "v${NEW_VERSION}"
+gh release create "v${NEW_VERSION}" --title "v${NEW_VERSION}" --notes-file - <<'NOTES'
+${CHANGELOG_EXCERPT}
+NOTES
+\`\`\`
+
+## Test plan
+- [ ] CI green on this PR
+- [ ] CHANGELOG has \`[${NEW_VERSION}]\` section
+- [ ] \`pyproject.toml\` / \`frontend/package.json\` show ${NEW_VERSION}
+EOF
+)")
+    echo "✅ PR opened: ${PR_URL}"
+  else
+    echo "💡 Install gh CLI to open the PR automatically: brew install gh"
+    echo "   Or open: https://github.com/neomatrix369/rag-params-finder/compare/main...${RELEASE_BRANCH}"
+  fi
 else
-    echo "Skipped push. Run manually:"
-    echo "  git push origin main && git push origin v$NEW_VERSION"
+  echo "Skipped push. When ready:"
+  echo "  git push -u origin ${RELEASE_BRANCH}"
+  echo "  gh pr create --base main --head ${RELEASE_BRANCH}"
 fi
+
+echo ""
+echo "================================================"
+echo "Do NOT push this bump to main directly."
+echo "Merge the PR, then tag + gh release on main."
+echo "================================================"

--- a/uv.lock
+++ b/uv.lock
@@ -1836,7 +1836,7 @@ wheels = [
 
 [[package]]
 name = "rag-params-finder"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "aim", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'linux'" },


### PR DESCRIPTION
## Summary
- chore(release): cut releases via branch and PR, not direct main push

Aligns `release.sh` and docs with Protect-main-branch: version bumps go on `release/vX.Y.Z` + PR; tag + GitHub release only after merge. Syncs CLAUDE/README to v0.12.0.

## Test plan
- [x] CI green on this PR
- [x] `./scripts/release/release.sh` docs match branch + PR flow (no direct push to main)
- [x] README current version shows v0.12.0

## Test Results

### Backend (pytest unit tier)
- **338 passed** in ~24s
- Scoped coverage **97.74%** (fail-under 95%)

### Frontend (vitest `test:ci`)
- **261 passed** / 24 files
- Coverage stmts/br/fn/lines **98.4% / 93.11% / 100% / 99.69%**

Made with [Cursor](https://cursor.com)