### PR TITLE
chore(ci): upgrade upload-artifact to v7 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ jobs:
           mutmut run --paths-to-mutate server/ cli/ || true
           mutmut results || true
           mutmut junitxml > mutation-results-python.xml || true
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         if: always()
         with:
           name: mutation-python-${{ github.run_number }}
@@ -84,7 +84,7 @@ jobs:
         with:
           format: cyclonedx-json
           output-file: sbom.json
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         if: always()
         with:
           name: sbom-${{ github.run_number }}
@@ -141,7 +141,7 @@ jobs:
             --report-sarif=meterian-reports/report.sarif
             --report-sbom=meterian-reports/sbom.cdx.json,meterian-reports/sbom.csv
       - name: Upload Meterian reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: meterian-${{ github.run_number }}
@@ -194,7 +194,7 @@ jobs:
           chalk docker build -f docker/server.Dockerfile -t chalk-attested-server:${{ github.sha }} .
       - name: Upload Chalk report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: chalk-report-${{ github.run_number }}
           path: ~/.local/chalk/chalk.log

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ jobs:
           mutmut run --paths-to-mutate server/ cli/ || true
           mutmut results || true
           mutmut junitxml > mutation-results-python.xml || true
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: mutation-python-${{ github.run_number }}
@@ -52,7 +52,7 @@ jobs:
       - run: npm ci
       - name: Run Stryker mutation tests
         run: npx stryker run || true
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: mutation-node-${{ github.run_number }}
@@ -84,7 +84,7 @@ jobs:
         with:
           format: cyclonedx-json
           output-file: sbom.json
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: sbom-${{ github.run_number }}
@@ -141,7 +141,7 @@ jobs:
             --report-sarif=meterian-reports/report.sarif
             --report-sbom=meterian-reports/sbom.cdx.json,meterian-reports/sbom.csv
       - name: Upload Meterian reports
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: meterian-${{ github.run_number }}
@@ -194,7 +194,7 @@ jobs:
           chalk docker build -f docker/server.Dockerfile -t chalk-attested-server:${{ github.sha }} .
       - name: Upload Chalk report
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: chalk-report-${{ github.run_number }}
           path: ~/.local/chalk/chalk.log


### PR DESCRIPTION
## Summary

Bumps `actions/upload-artifact` from `@v4`/`@v5` to `@v7` across `nightly.yml`. Both v4 and v5 target Node.js 20; v7 is the current Node.js 24-native release.

## Root cause

GitHub Actions deprecated Node.js 20 (September 2025). v4 and v5 of `upload-artifact` both use Node.js 20 runtime and produce deprecation warnings on current runners.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/nightly.yml` | `upload-artifact@v4/v5` → `@v7` (5 occurrences) |

## Known remaining warning

`actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809` is a **transitive dependency** inside `anchore/sbom-action@v0.24.0` (already the latest release). That warning cannot be resolved here — it requires anchore upstream to update their action's internal dependency.

## Verification

- `actionlint` passes ✅
- `@v7` is a drop-in replacement — same inputs/outputs as v4/v5