### PR TITLE
docs: link SIE ecosystem hub on neomatrix369.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ model × chunking method × retrieval method — stores the retrieval scores and
 shows you exactly which configuration performs best.
 **Before you write a single line of your RAG application.**
 
-**Jump to:** [Quickstart](QUICKSTART.md) | [Who is this for?](#who-is-this-for) | [Screenshots](#-screenshots) | [Key Features](#-key-features) | [Documentation](docs/README.md) | [Contributing](#-contributing)
+**Jump to:** [Quickstart](QUICKSTART.md) | [Who is this for?](#who-is-this-for) | [Screenshots](#-screenshots) | [Key Features](#-key-features) | [Documentation](docs/README.md) | [SIE ecosystem demos](https://neomatrix369.github.io/pages/projects.html#sie) | [Contributing](#-contributing)
 
 ## Why this matters
 


### PR DESCRIPTION
## Summary
- Add link to the SIE ecosystem section on neomatrix369.github.io/projects (Tripwire dashboard, rag-params-finder context).

## Test plan
- [x] README renders correctly on GitHub


Made with [Cursor](https://cursor.com)